### PR TITLE
Add Ottoneu fantasy football rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,50 @@ git push -u origin my-branch-name
 gh pr create --fill
 ```
 
+## Ottoneu Fantasy Football Rules
+
+League 309 is a **12-team Superflex Half PPR** league.
+
+### Scoring (Half PPR)
+
+| Stat | Points |
+|------|--------|
+| Passing yards | 0.04/yd (1 pt per 25 yds) |
+| Passing TD | 4 |
+| Interception | -2 |
+| Rushing yards | 0.1/yd (1 pt per 10 yds) |
+| Rushing TD | 6 |
+| Receptions | 0.5 |
+| Receiving yards | 0.1/yd (1 pt per 10 yds) |
+| Receiving TD | 6 |
+| FG 0-39 yds | 3 |
+| FG 40-49 yds | 4 |
+| FG 50+ yds | 5 |
+| Extra point | 1 |
+
+### Roster (Superflex format)
+
+20 roster spots per team. Starting lineup: 1 QB, 2 RB, 2 WR, 1 TE, 1 K, 1 Superflex (QB/RB/WR/TE). In superflex, it is almost always optimal to start a QB in the superflex slot, making QBs significantly more valuable than in standard formats.
+
+IR/PUP/NFI players don't count against roster limits but do count against salary cap.
+
+### Salary Cap & Player Acquisition
+
+- **$400 cap** per team
+- **Auctions:** 24-hour blind Vickrey-style (winner pays second-highest bid + $1). Minimum bid is the player's current cap penalty or $1.
+- **Waivers:** Cut players can be claimed within 24 hours at their full previous salary.
+- **Cutting:** Incurs a cap penalty of half the player's salary (rounded up). Player cannot be reacquired by the same team for 30 days.
+
+### Salary Increases & Arbitration
+
+- **End of season:** +$4 for players who played at least 1 NFL game, +$1 for all others.
+- **Arbitration (Feb 15 - Mar 31):** Each team has a $60 allocation budget distributed across other teams. Each team must give every other team $1-$8, and no single player can receive more than $4 from one team (max $44 league-wide per player).
+
+### Season Structure
+
+- Season ends after NFL week 16.
+- Trade deadline: day before Thanksgiving. Trades can include cap space loans (expire end of regular season). Trades require 48-hour league approval; 7 of 12 managers must vote against to veto.
+
 ## Tech Stack
 
 - **Frontend:** Next.js 16, React 19, TypeScript, Tailwind CSS 4, Recharts


### PR DESCRIPTION
## Summary
- Adds comprehensive Ottoneu fantasy football rules to CLAUDE.md for context in future analysis
- Covers scoring (half PPR), superflex roster format, $400 salary cap mechanics, auction/waiver rules, salary increases, arbitration, and season structure
- Specific to league 309 (12-team Superflex Half PPR)

## Test plan
- [ ] Verify rules accuracy against [Ottoneu official rules](https://ottoneu.fangraphs.com/football/help/rules)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)