### PR TITLE
fix: transaction date column not populating

### DIFF
--- a/scripts/tasks/scrape_player_card.py
+++ b/scripts/tasks/scrape_player_card.py
@@ -80,7 +80,7 @@ async def run(params: dict, context, supabase) -> TaskResult:
                 if date_idx is not None and len(cols) > date_idx:
                     date_text = (await cols[date_idx].inner_text()).strip()
                     if date_text:
-                        for fmt in ("%m/%d/%Y", "%Y-%m-%d", "%b %d, %Y"):
+                        for fmt in ("%b %d, %Y %I:%M %p", "%m/%d/%Y", "%Y-%m-%d", "%b %d, %Y"):
                             try:
                                 t_date = datetime.strptime(date_text, fmt).date().isoformat()
                                 break


### PR DESCRIPTION
## Problem
The `transaction_date` column in the `transactions` table was always `null` for all 248 rows.

## Root Cause
The Ottoneu football transaction table returns dates with a time component (e.g. `Aug 24, 2025 7:40 PM`), but the date parser only tried date-only formats:
- `%m/%d/%Y`
- `%Y-%m-%d`
- `%b %d, %Y`

None of these matched, so `transaction_date` was never set.

## Fix
Added `%b %d, %Y %I:%M %p` as the first format to try, which correctly handles the time component.

## Additional
Backfilled all 248 existing transaction rows directly in the database by extracting dates from the `raw_description` field.