### PR TITLE
Add SOFA League link and lock icons to navigation

### DIFF
--- a/web/components/Navigation.tsx
+++ b/web/components/Navigation.tsx
@@ -11,7 +11,7 @@ const PUBLIC_LINKS = [
 ];
 
 const SOFA_LEAGUE_LINK = {
-  href: "https://ottoneu.fangraphs.com/football/309",
+  href: "https://ottoneu.fangraphs.com/football/309/",
   label: "SOFA League",
   isExternal: true,
 };


### PR DESCRIPTION
## Summary
- Add external link to Ottoneu League 309 (SOFA) in navigation bar
- Add lock icons (🔒) to all protected route tabs
- Position SOFA League link between public and protected links

## Changes
- Import `Lock` and `ExternalLink` icons from lucide-react
- Add `SOFA_LEAGUE_LINK` constant with external URL
- Render SOFA League as external link with icon (opens in new tab)
- Render lock icons before all protected route labels
- Use `inline-flex items-center gap-1` for proper icon alignment

## Visual Improvements
- Lock icons help users identify which pages require authentication
- External link icon indicates SOFA League opens in new tab
- Icons inherit colors for dark mode support
- Lock icons use 60% opacity for subtle appearance

## Test Plan
- [x] TypeScript compilation passes
- [x] Production build succeeds
- [x] ESLint passes for Navigation.tsx
- [x] Dev server runs without errors
- [ ] Manually test SOFA League link opens in new tab
- [ ] Verify lock icons appear on protected tabs when authenticated
- [ ] Verify icons align properly with text
- [ ] Test dark mode appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)