### PR TITLE
Update TE replacement level from 15 to 20 for VORP analysis

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -25,7 +25,7 @@ MIN_GAMES = 4
 
 # Replacement level: approximate number of fantasy-relevant players per position
 # in a 12-team superflex league (accounts for 2 QBs starting per team)
-REPLACEMENT_LEVEL = {'QB': 24, 'RB': 30, 'WR': 30, 'TE': 15, 'K': 13}
+REPLACEMENT_LEVEL = {'QB': 24, 'RB': 30, 'WR': 30, 'TE': 20, 'K': 13}
 
 # NOTE: Database salaries already reflect the end-of-season $4/$1 bump.
 # No additional salary projection is needed.

--- a/web/lib/arb-logic.ts
+++ b/web/lib/arb-logic.ts
@@ -13,7 +13,7 @@ export const REPLACEMENT_LEVEL: Record<string, number> = {
     QB: 24,
     RB: 30,
     WR: 30,
-    TE: 15,
+    TE: 20,
     K: 13,
 };
 


### PR DESCRIPTION
## Summary
- Increase TE replacement level from 15 to 20 in both Python and TypeScript configs

## Rationale
In this 12-team league with 20-player rosters, most teams carry 2 tight ends since rosters are deep. The previous replacement level of 15 (1.25 TEs per team) underestimated the actual depth.

With 20 rostered TEs across the league, the replacement baseline better reflects what's actually available on waivers vs. what teams consider startable.

This change affects:
- VORP calculations (lower replacement PPG = higher VORP for elite TEs)
- Surplus value analysis (impacts dollar values)
- Arbitration target identification
- Web app `/vorp` and `/surplus-value` pages

## Files Changed
- `scripts/config.py` - Python analysis scripts
- `web/lib/arb-logic.ts` - TypeScript web app

## Test plan
- [x] Verify both files updated
- [ ] Run `python scripts/run_all_analyses.py` to see new TE VORP values
- [ ] Check web app `/vorp` page shows updated TE replacement benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)