### PR TITLE
Add player age to database and player detail page

### DIFF
--- a/migrations/006_add_birth_date.sql
+++ b/migrations/006_add_birth_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE players ADD COLUMN IF NOT EXISTS birth_date date;

--- a/scripts/backfill_birth_dates.py
+++ b/scripts/backfill_birth_dates.py
@@ -1,0 +1,45 @@
+"""Backfill birth_date for all players using nfl_data_py roster data."""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(__file__))
+
+import nfl_data_py as nfl
+from config import get_supabase_client
+from name_utils import normalize_player_name
+
+
+def run():
+    supabase = get_supabase_client()
+
+    # Pull rosters for multiple seasons to maximize coverage
+    print("Fetching roster data from nfl_data_py...")
+    rosters = nfl.import_seasonal_rosters([2022, 2023, 2024, 2025])
+
+    # Keep only rows with a birth_date
+    rosters = rosters[rosters["birth_date"].notna()][["player_name", "birth_date"]].drop_duplicates("player_name")
+
+    # Build name -> birth_date lookup (normalized names)
+    dob_lookup = {
+        normalize_player_name(str(row.player_name)): str(row.birth_date)
+        for _, row in rosters.iterrows()
+    }
+    print(f"Loaded {len(dob_lookup)} players with birth dates from nfl_data_py")
+
+    # Fetch all players from DB
+    result = supabase.table("players").select("id, name").execute()
+    players = result.data or []
+    print(f"Found {len(players)} players in database")
+
+    matched = 0
+    for p in players:
+        norm = normalize_player_name(p["name"])
+        dob = dob_lookup.get(norm)
+        if dob:
+            supabase.table("players").update({"birth_date": dob}).eq("id", p["id"]).execute()
+            matched += 1
+
+    print(f"Updated {matched}/{len(players)} players with birth_date.")
+
+
+if __name__ == "__main__":
+    run()

--- a/web/app/players/[id]/page.tsx
+++ b/web/app/players/[id]/page.tsx
@@ -32,6 +32,17 @@ export default async function PlayerCardPage({
     const posColor =
         POSITION_COLORS[player.position as Position] ?? "#6B7280";
 
+    const age = player.birth_date
+        ? (() => {
+              const today = new Date();
+              const dob = new Date(player.birth_date + "T00:00:00");
+              let a = today.getFullYear() - dob.getFullYear();
+              const m = today.getMonth() - dob.getMonth();
+              if (m < 0 || (m === 0 && today.getDate() < dob.getDate())) a--;
+              return a;
+          })()
+        : null;
+
     return (
         <main className="min-h-screen bg-white dark:bg-black p-8">
             <div className="max-w-4xl mx-auto space-y-8">
@@ -60,7 +71,7 @@ export default async function PlayerCardPage({
                                     </span>
                                 </div>
                                 <p className="text-slate-500 dark:text-slate-400 mt-1">
-                                    {player.nfl_team} · Ottoneu ID: {player.ottoneu_id}
+                                    {player.nfl_team}{age != null ? ` · Age ${age}` : ""} · Ottoneu ID: {player.ottoneu_id}
                                 </p>
                             </div>
 

--- a/web/lib/players.ts
+++ b/web/lib/players.ts
@@ -87,7 +87,7 @@ export async function fetchPlayerCard(
     // Get the player
     const { data: player } = await supabase
         .from("players")
-        .select("id, ottoneu_id, name, position, nfl_team")
+        .select("id, ottoneu_id, name, position, nfl_team, birth_date")
         .eq("ottoneu_id", ottoneuId)
         .single();
 
@@ -149,6 +149,7 @@ export async function fetchPlayerCard(
         name: player.name,
         position: player.position,
         nfl_team: player.nfl_team,
+        birth_date: player.birth_date ?? null,
         price: currentPrice,
         team_name: currentTeam,
         seasonStats,

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -94,6 +94,7 @@ export interface PlayerCardData {
   name: string;
   position: string;
   nfl_team: string;
+  birth_date: string | null;
   price: number | null;
   team_name: string | null;
   seasonStats: SeasonStats[];


### PR DESCRIPTION
## Summary

- Adds `birth_date date` column to the `players` table (migration 006)
- New `scripts/backfill_birth_dates.py` populates birth dates from `nfl_data_py.import_seasonal_rosters()` across 2022–2025 seasons — matched **336/340** players
- Player detail page header now shows **Age N** between team and Ottoneu ID
- TypeScript types and data fetching updated accordingly

## Test plan

- [x] Migration applied via Supabase MCP
- [x] Backfill script ran successfully (336/340 matched)
- [x] `npm run build` passes with no TypeScript errors
- [x] Visit a player detail page and confirm age appears in the header subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)