### PR TITLE
Add protected player projections page

### DIFF
--- a/web/app/projections/ProjectionsClient.tsx
+++ b/web/app/projections/ProjectionsClient.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import DataTable, { Column } from "@/components/DataTable";
+import { POSITIONS } from "@/lib/analysis";
+import PositionFilter from "@/components/PositionFilter";
+import { Position } from "@/lib/types";
+
+interface ProjectionRow {
+  name: string;
+  position: string;
+  nfl_team: string;
+  team_name: string;
+  price: number;
+  observed_ppg: number;
+  projected_ppg: number;
+  ppg_delta: number;
+  [key: string]: string | number | null | undefined;
+}
+
+const TABLE_COLUMNS: Column[] = [
+  { key: "name", label: "Player" },
+  { key: "position", label: "Pos" },
+  { key: "nfl_team", label: "Team" },
+  { key: "team_name", label: "Owner" },
+  { key: "price", label: "Salary", format: "currency" },
+  { key: "observed_ppg", label: "Obs PPG", format: "decimal" },
+  { key: "projected_ppg", label: "Proj PPG", format: "decimal" },
+  { key: "ppg_delta", label: "Delta", format: "decimal" },
+];
+
+interface Props {
+  initialData: ProjectionRow[];
+}
+
+export default function ProjectionsClient({ initialData }: Props) {
+  const [selectedPositions, setSelectedPositions] = useState<Position[]>([
+    ...POSITIONS,
+  ]);
+
+  const togglePosition = (pos: Position) => {
+    setSelectedPositions((prev) =>
+      prev.includes(pos) ? prev.filter((p) => p !== pos) : [...prev, pos]
+    );
+  };
+
+  const toggleAll = () => {
+    setSelectedPositions(
+      selectedPositions.length === POSITIONS.length ? [] : [...POSITIONS]
+    );
+  };
+
+  const filteredData = initialData.filter((p) =>
+    selectedPositions.includes(p.position as Position)
+  );
+
+  return (
+    <section>
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
+          All Players
+        </h2>
+        <PositionFilter
+          positions={POSITIONS}
+          selectedPositions={selectedPositions}
+          onToggle={togglePosition}
+          showAll
+          onToggleAll={toggleAll}
+        />
+      </div>
+      <DataTable
+        columns={TABLE_COLUMNS}
+        data={filteredData}
+        highlightRules={[
+          { key: "ppg_delta", op: "gte", value: 1.5, className: "bg-green-50 dark:bg-green-950" },
+          { key: "ppg_delta", op: "lte", value: -1.5, className: "bg-red-50 dark:bg-red-950" },
+        ]}
+      />
+    </section>
+  );
+}

--- a/web/app/projections/page.tsx
+++ b/web/app/projections/page.tsx
@@ -1,0 +1,81 @@
+import { fetchAndMergeProjectedData, SEASON } from "@/lib/analysis";
+import ProjectionsClient from "./ProjectionsClient";
+
+export const revalidate = 3600;
+
+export default async function ProjectionsPage() {
+  const players = await fetchAndMergeProjectedData();
+
+  if (players.length === 0) {
+    return (
+      <main className="min-h-screen bg-white dark:bg-black p-8">
+        <div className="max-w-7xl mx-auto">
+          <h1 className="text-3xl font-bold text-slate-900 dark:text-white">
+            No projection data available.
+          </h1>
+        </div>
+      </main>
+    );
+  }
+
+  const rows = players
+    .map((p) => ({
+      name: p.name,
+      position: p.position,
+      nfl_team: p.nfl_team,
+      team_name: p.team_name ?? "FA",
+      price: p.price,
+      observed_ppg: p.observed_ppg,
+      projected_ppg: p.ppg,
+      ppg_delta: p.ppg - p.observed_ppg,
+    }))
+    .sort((a, b) => b.projected_ppg - a.projected_ppg);
+
+  return (
+    <main className="min-h-screen bg-white dark:bg-black p-8">
+      <div className="max-w-7xl mx-auto space-y-8">
+        <header>
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+            Player Projections ({SEASON})
+          </h1>
+          <p className="text-slate-500 dark:text-slate-400 mt-2">
+            Weighted-average PPG projections built from 2022–2024 historical
+            seasons. Delta shows how a player is trending vs. their projection.
+          </p>
+        </header>
+
+        {/* Methodology */}
+        <section className="bg-slate-50 dark:bg-slate-900 rounded-lg p-5 border border-slate-200 dark:border-slate-800 space-y-3 text-sm text-slate-700 dark:text-slate-300">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+            Methodology
+          </h2>
+          <p>
+            Each player&apos;s projected PPG is a weighted average of their per-game
+            output across the three most recent seasons, with recency weights{" "}
+            <strong>0.50 / 0.30 / 0.20</strong> (most recent to oldest). Seasons
+            with fewer than 4 games played are discounted proportionally (
+            <code className="bg-slate-200 dark:bg-slate-800 px-1.5 py-0.5 rounded text-xs">
+              weight × games / 4
+            </code>
+            ) to reduce noise from small samples. Players with no qualifying
+            historical seasons are excluded.
+          </p>
+          <ul className="list-disc list-inside space-y-1">
+            <li>
+              <strong>Obs PPG</strong> — this season&apos;s actual points-per-game
+            </li>
+            <li>
+              <strong>Proj PPG</strong> — weighted historical average
+            </li>
+            <li>
+              <strong>Delta</strong> — Obs PPG minus Proj PPG (positive = outperforming
+              projection, negative = underperforming)
+            </li>
+          </ul>
+        </section>
+
+        <ProjectionsClient initialData={rows} />
+      </div>
+    </main>
+  );
+}

--- a/web/components/Navigation.tsx
+++ b/web/components/Navigation.tsx
@@ -19,6 +19,7 @@ const SOFA_LEAGUE_LINK = {
 
 const PRIVATE_LINKS = [
   { href: "/projected-salary", label: "Projected Salary" },
+  { href: "/projections", label: "Projections" },
   { href: "/vorp", label: "VORP" },
   { href: "/surplus-value", label: "Surplus Value" },
   { href: "/arbitration", label: "Arbitration" },

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -7,6 +7,7 @@ const PROTECTED_ROUTES = [
   "/surplus-value",
   "/arbitration",
   "/arbitration-simulation",
+  "/projections",
 ];
 
 export function middleware(request: NextRequest) {


### PR DESCRIPTION
## Summary

- Adds `/projections` as a new protected route (requires auth cookie)
- Server page calls the existing `fetchAndMergeProjectedData()` to get weighted-average PPG projections across 2022–2024 seasons
- Client component provides position filtering and a sortable `DataTable` with green/red highlights for rows where Delta ≥ 1.5 or ≤ −1.5 PPG
- Includes methodology callout explaining recency weights (0.50/0.30/0.20) and games-played discount
- "Projections" link added to nav between Projected Salary and VORP

## Test plan

- [ ] Visit `/projections` without auth → redirected to `/login`
- [ ] Login → revisit `/projections` → table loads sorted by Proj PPG desc
- [ ] Toggle position filter buttons → rows filter correctly
- [ ] Click column headers → table sorts
- [ ] Rows with Delta ≥ 1.5 highlighted green; ≤ −1.5 highlighted red
- [ ] `npm run build` → no TypeScript errors ✓ (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)