### PR TITLE
Add projection accuracy backtest page

### DIFF
--- a/web/app/projection-accuracy/AccuracyScatterChart.tsx
+++ b/web/app/projection-accuracy/AccuracyScatterChart.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import {
+  ResponsiveContainer,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ReferenceLine,
+} from "recharts";
+import { BacktestPlayer, Position, POSITION_COLORS } from "@/lib/types";
+
+interface TooltipPayload {
+  active?: boolean;
+  payload?: Array<{ payload: BacktestPlayer }>;
+}
+
+function CustomTooltip({ active, payload }: TooltipPayload) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0].payload;
+  const signed = d.error >= 0 ? `+${d.error.toFixed(2)}` : d.error.toFixed(2);
+  return (
+    <div className="bg-white/95 dark:bg-slate-900/95 border border-slate-200 dark:border-slate-700 p-3 rounded shadow-lg text-sm">
+      <p className="font-bold text-slate-900 dark:text-slate-100">{d.name}</p>
+      <p className="text-slate-500 dark:text-slate-400">
+        {d.position} · {d.nfl_team}
+      </p>
+      <div className="mt-2 space-y-1">
+        <p>
+          Proj PPG:{" "}
+          <span className="font-mono font-medium">
+            {d.projected_ppg.toFixed(2)}
+          </span>
+        </p>
+        <p>
+          Actual PPG:{" "}
+          <span className="font-mono font-medium">
+            {d.actual_ppg.toFixed(2)}
+          </span>
+        </p>
+        <p>
+          Error:{" "}
+          <span
+            className={`font-mono font-medium ${
+              d.error >= 0
+                ? "text-green-600 dark:text-green-400"
+                : "text-red-600 dark:text-red-400"
+            }`}
+          >
+            {signed}
+          </span>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+interface Props {
+  players: BacktestPlayer[];
+  selectedPositions: Position[];
+}
+
+export default function AccuracyScatterChart({
+  players,
+  selectedPositions,
+}: Props) {
+  const filtered = players.filter((p) =>
+    selectedPositions.includes(p.position as Position)
+  );
+
+  const allPpg = filtered.flatMap((p) => [p.projected_ppg, p.actual_ppg]);
+  const rawMin = allPpg.length > 0 ? Math.min(...allPpg) : 0;
+  const rawMax = allPpg.length > 0 ? Math.max(...allPpg) : 20;
+  const padding = (rawMax - rawMin) * 0.05;
+  const minVal = Math.max(0, rawMin - padding);
+  const maxVal = rawMax + padding;
+
+  return (
+    <div className="w-full h-[500px] bg-slate-50 dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-4">
+      <ResponsiveContainer width="100%" height="100%">
+        <ScatterChart margin={{ top: 20, right: 20, bottom: 40, left: 40 }}>
+          <XAxis
+            type="number"
+            dataKey="projected_ppg"
+            name="Projected PPG"
+            domain={[minVal, maxVal]}
+            label={{
+              value: "Projected PPG",
+              position: "bottom",
+              offset: 10,
+              fill: "#94a3b8",
+              fontSize: 12,
+            }}
+            tick={{ fontSize: 11 }}
+          />
+          <YAxis
+            type="number"
+            dataKey="actual_ppg"
+            name="Actual PPG"
+            domain={[minVal, maxVal]}
+            label={{
+              value: "Actual PPG",
+              angle: -90,
+              position: "insideLeft",
+              offset: -10,
+              fill: "#94a3b8",
+              fontSize: 12,
+            }}
+            tick={{ fontSize: 11 }}
+          />
+          <ReferenceLine
+            segment={[
+              { x: minVal, y: minVal },
+              { x: maxVal, y: maxVal },
+            ]}
+            stroke="#94a3b8"
+            strokeDasharray="4 4"
+            strokeWidth={1.5}
+          />
+          <Tooltip content={<CustomTooltip />} cursor={{ strokeDasharray: "3 3" }} />
+          <Legend verticalAlign="top" />
+          {(["QB", "RB", "WR", "TE", "K"] as Position[])
+            .filter((pos) => selectedPositions.includes(pos))
+            .map((pos) => (
+              <Scatter
+                key={pos}
+                name={pos}
+                data={filtered.filter((p) => p.position === pos)}
+                fill={POSITION_COLORS[pos]}
+                opacity={0.8}
+              />
+            ))}
+        </ScatterChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/web/app/projection-accuracy/ProjectionAccuracyClient.tsx
+++ b/web/app/projection-accuracy/ProjectionAccuracyClient.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { BacktestPlayer, Position, POSITIONS } from "@/lib/types";
+import { PositionMetrics } from "./metrics";
+import AccuracyScatterChart from "./AccuracyScatterChart";
+import DataTable, { Column } from "@/components/DataTable";
+import PositionFilter from "@/components/PositionFilter";
+import SummaryCard from "@/components/SummaryCard";
+
+const PLAYER_COLUMNS: Column[] = [
+  { key: "name", label: "Player" },
+  { key: "position", label: "Pos" },
+  { key: "nfl_team", label: "Team" },
+  { key: "team_name", label: "Owner" },
+  { key: "price", label: "Salary", format: "currency" },
+  { key: "seasons_used", label: "Seasons" },
+  { key: "games_played", label: "GP", format: "number" },
+  { key: "projected_ppg", label: "Proj PPG", format: "decimal" },
+  { key: "actual_ppg", label: "Actual PPG", format: "decimal" },
+  { key: "error", label: "Error", format: "decimal" },
+  { key: "abs_error", label: "|Error|", format: "decimal" },
+];
+
+const METRICS_COLUMNS: Column[] = [
+  { key: "position", label: "Position" },
+  { key: "count", label: "Players", format: "number" },
+  { key: "mae", label: "MAE", format: "decimal" },
+  { key: "bias", label: "Bias", format: "decimal" },
+  { key: "r2", label: "R²", format: "decimal" },
+  { key: "rmse", label: "RMSE", format: "decimal" },
+];
+
+interface Props {
+  players: BacktestPlayer[];
+  allMetrics: PositionMetrics[];
+  targetSeason: number;
+  availableSeasons: number[];
+}
+
+export default function ProjectionAccuracyClient({
+  players,
+  allMetrics,
+  targetSeason,
+  availableSeasons,
+}: Props) {
+  const router = useRouter();
+  const [selectedPositions, setSelectedPositions] = useState<Position[]>([
+    ...POSITIONS,
+  ]);
+  const [minGames, setMinGames] = useState(4);
+
+  const togglePosition = (pos: Position) => {
+    setSelectedPositions((prev) =>
+      prev.includes(pos) ? prev.filter((p) => p !== pos) : [...prev, pos]
+    );
+  };
+
+  const toggleAll = () => {
+    setSelectedPositions(
+      selectedPositions.length === POSITIONS.length ? [] : [...POSITIONS]
+    );
+  };
+
+  const filteredPlayers = players.filter(
+    (p) =>
+      selectedPositions.includes(p.position as Position) &&
+      p.games_played >= minGames
+  );
+
+  const overallMetrics = allMetrics[0];
+
+  return (
+    <div className="space-y-8">
+      {/* Season tabs */}
+      <div className="flex gap-2">
+        {availableSeasons.map((season) => (
+          <button
+            key={season}
+            onClick={() =>
+              router.push(`/projection-accuracy?season=${season}`)
+            }
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors border ${
+              season === targetSeason
+                ? "bg-blue-600 text-white border-transparent"
+                : "bg-transparent text-slate-600 dark:text-slate-400 border-slate-300 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800"
+            }`}
+          >
+            {season}
+          </button>
+        ))}
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-5 gap-4">
+        <SummaryCard
+          label="Players Backtested"
+          value={String(overallMetrics.count)}
+        />
+        <SummaryCard
+          label="MAE (Mean Abs Error)"
+          value={overallMetrics.mae.toFixed(2)}
+        />
+        <SummaryCard
+          label="Bias (Mean Error)"
+          value={
+            (overallMetrics.bias >= 0 ? "+" : "") +
+            overallMetrics.bias.toFixed(2)
+          }
+          variant={
+            Math.abs(overallMetrics.bias) < 0.2
+              ? "default"
+              : overallMetrics.bias > 0
+              ? "positive"
+              : "negative"
+          }
+        />
+        <SummaryCard
+          label="R² (Correlation)"
+          value={overallMetrics.r2.toFixed(2)}
+          variant={
+            overallMetrics.r2 >= 0.5
+              ? "positive"
+              : overallMetrics.r2 >= 0.25
+              ? "default"
+              : "negative"
+          }
+        />
+        <SummaryCard
+          label="RMSE"
+          value={overallMetrics.rmse.toFixed(2)}
+        />
+      </div>
+
+      {/* Per-position breakdown */}
+      <section>
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-white mb-3">
+          Metrics by Position
+        </h2>
+        <DataTable columns={METRICS_COLUMNS} data={allMetrics} />
+      </section>
+
+      {/* Scatter chart */}
+      <section>
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-white mb-3">
+          Projected vs Actual PPG
+        </h2>
+        <p className="text-sm text-slate-500 dark:text-slate-400 mb-4">
+          Points on the dashed diagonal = perfect prediction. Above the line =
+          outperformed projection. Below = underperformed.
+        </p>
+        <AccuracyScatterChart
+          players={players}
+          selectedPositions={selectedPositions}
+        />
+      </section>
+
+      {/* Filters + error table */}
+      <section>
+        <div className="flex flex-wrap items-center gap-4 mb-4">
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
+            Per-Player Errors
+          </h2>
+          <PositionFilter
+            positions={POSITIONS}
+            selectedPositions={selectedPositions}
+            onToggle={togglePosition}
+            showAll
+            onToggleAll={toggleAll}
+          />
+          <div className="flex items-center gap-2 bg-slate-100 dark:bg-slate-800 px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-700">
+            <span className="text-sm font-medium text-slate-600 dark:text-slate-300">
+              Min Games: {minGames}
+            </span>
+            <input
+              type="range"
+              min="0"
+              max="17"
+              value={minGames}
+              onChange={(e) => setMinGames(Number(e.target.value))}
+              className="w-24 accent-blue-600"
+            />
+          </div>
+        </div>
+        <DataTable
+          columns={PLAYER_COLUMNS}
+          data={filteredPlayers}
+          highlightRules={[
+            {
+              key: "error",
+              op: "gte",
+              value: 3,
+              className: "bg-green-50 dark:bg-green-950",
+            },
+            {
+              key: "error",
+              op: "lte",
+              value: -3,
+              className: "bg-red-50 dark:bg-red-950",
+            },
+          ]}
+        />
+      </section>
+    </div>
+  );
+}

--- a/web/app/projection-accuracy/metrics.ts
+++ b/web/app/projection-accuracy/metrics.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure metric calculation functions for projection accuracy backtesting.
+ * No side effects, no imports from app code.
+ */
+
+import type { BacktestPlayer } from "@/lib/types";
+
+export interface PositionMetrics {
+  position: string;
+  count: number;
+  mae: number;
+  bias: number;
+  r2: number;
+  rmse: number;
+  [key: string]: string | number | null | undefined;
+}
+
+export function calculateMetrics(
+  players: BacktestPlayer[],
+  position = "ALL"
+): PositionMetrics {
+  const n = players.length;
+  if (n === 0) {
+    return { position, count: 0, mae: 0, bias: 0, r2: 0, rmse: 0 };
+  }
+
+  const mae = players.reduce((sum, p) => sum + p.abs_error, 0) / n;
+  const bias = players.reduce((sum, p) => sum + p.error, 0) / n;
+
+  const mean_actual = players.reduce((sum, p) => sum + p.actual_ppg, 0) / n;
+  const ss_tot = players.reduce(
+    (sum, p) => sum + Math.pow(p.actual_ppg - mean_actual, 2),
+    0
+  );
+  const ss_res = players.reduce(
+    (sum, p) => sum + Math.pow(p.actual_ppg - p.projected_ppg, 2),
+    0
+  );
+  const r2 = ss_tot === 0 ? 0 : Math.max(0, 1 - ss_res / ss_tot);
+  const rmse = Math.sqrt(ss_res / n);
+
+  return { position, count: n, mae, bias, r2, rmse };
+}
+
+/**
+ * Returns metrics for all positions combined (index 0) followed by one entry
+ * per position in the provided list.
+ */
+export function calculateMetricsByPosition(
+  players: BacktestPlayer[],
+  positions: readonly string[]
+): PositionMetrics[] {
+  const all = calculateMetrics(players, "ALL");
+  const perPosition = positions.map((pos) =>
+    calculateMetrics(
+      players.filter((p) => p.position === pos),
+      pos
+    )
+  );
+  return [all, ...perPosition];
+}

--- a/web/app/projection-accuracy/page.tsx
+++ b/web/app/projection-accuracy/page.tsx
@@ -1,0 +1,87 @@
+import { fetchBacktestData } from "@/lib/analysis";
+import { calculateMetricsByPosition } from "./metrics";
+import { POSITIONS } from "@/lib/types";
+import ProjectionAccuracyClient from "./ProjectionAccuracyClient";
+
+export const revalidate = 3600;
+
+const AVAILABLE_SEASONS = [2024, 2025];
+
+interface Props {
+  searchParams: Promise<{ season?: string }>;
+}
+
+export default async function ProjectionAccuracyPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const rawSeason = Number(params.season);
+  const targetSeason = AVAILABLE_SEASONS.includes(rawSeason)
+    ? rawSeason
+    : 2025;
+
+  const players = await fetchBacktestData(targetSeason);
+  const allMetrics = calculateMetricsByPosition(players, POSITIONS);
+
+  return (
+    <main className="min-h-screen bg-white dark:bg-black p-8">
+      <div className="max-w-7xl mx-auto space-y-8">
+        <header>
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+            Projection Accuracy — {targetSeason}
+          </h1>
+          <p className="text-slate-500 dark:text-slate-400 mt-2">
+            Backtesting the WeightedAveragePPG model: projections built from
+            prior seasons compared to actual {targetSeason} results.
+          </p>
+        </header>
+
+        {/* Methodology */}
+        <section className="bg-slate-50 dark:bg-slate-900 rounded-lg p-5 border border-slate-200 dark:border-slate-800 space-y-3 text-sm text-slate-700 dark:text-slate-300">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+            Methodology
+          </h2>
+          <p>
+            For each target season, prior seasons are used as inputs to the{" "}
+            <strong>WeightedAveragePPG</strong> model (recency weights 0.50 /
+            0.30 / 0.20, games-scaled). The resulting projection is compared to
+            the player&apos;s actual PPG in the target season.
+          </p>
+          <ul className="list-disc list-inside space-y-1">
+            <li>
+              <strong>Error</strong> = Actual PPG − Projected PPG (positive =
+              outperformed)
+            </li>
+            <li>
+              <strong>MAE</strong> — mean absolute error (lower is better)
+            </li>
+            <li>
+              <strong>Bias</strong> — mean signed error (positive = model
+              under-projects)
+            </li>
+            <li>
+              <strong>R²</strong> — proportion of variance explained (higher is
+              better, capped at 0)
+            </li>
+            <li>
+              <strong>RMSE</strong> — root mean squared error (penalises large
+              misses)
+            </li>
+          </ul>
+        </section>
+
+        {players.length === 0 ? (
+          <p className="text-slate-500 dark:text-slate-400">
+            No backtest data available for {targetSeason}. Historical data prior
+            to this season may not be loaded yet.
+          </p>
+        ) : (
+          <ProjectionAccuracyClient
+            players={players}
+            allMetrics={allMetrics}
+            targetSeason={targetSeason}
+            availableSeasons={AVAILABLE_SEASONS}
+          />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/web/components/Navigation.tsx
+++ b/web/components/Navigation.tsx
@@ -20,6 +20,7 @@ const SOFA_LEAGUE_LINK = {
 const PRIVATE_LINKS = [
   { href: "/projected-salary", label: "Projected Salary" },
   { href: "/projections", label: "Projections" },
+  { href: "/projection-accuracy", label: "Proj. Accuracy" },
   { href: "/vorp", label: "VORP" },
   { href: "/surplus-value", label: "Surplus Value" },
   { href: "/arbitration", label: "Arbitration" },

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -108,6 +108,24 @@ export interface PlayerCardData {
   transactions: Transaction[];
 }
 
+// === Backtest Types ===
+
+export interface BacktestPlayer {
+  player_id: string;
+  name: string;
+  position: string;
+  nfl_team: string;
+  team_name: string | null;
+  price: number;
+  projected_ppg: number;
+  actual_ppg: number;
+  error: number;         // actual - projected (signed)
+  abs_error: number;
+  seasons_used: string;  // pre-serialized: "2022, 2023, 2024"
+  games_played: number;
+  [key: string]: string | number | null | undefined;
+}
+
 // === Position Constants ===
 
 export type Position = 'QB' | 'RB' | 'WR' | 'TE' | 'K';

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -8,6 +8,7 @@ const PROTECTED_ROUTES = [
   "/arbitration",
   "/arbitration-simulation",
   "/projections",
+  "/projection-accuracy",
 ];
 
 export function middleware(request: NextRequest) {


### PR DESCRIPTION
## Summary
- New `/projection-accuracy` route backtests the `WeightedAveragePPG` model by projecting from prior seasons and comparing to actual PPG in a target season
- Season toggled via `?season=` URL param (2024 or 2025); defaults to 2025
- Protected route, linked from navigation after "Projections"

## New files
- `web/app/projection-accuracy/metrics.ts` — pure functions: `calculateMetrics`, `calculateMetricsByPosition` (MAE, bias, R², RMSE)
- `web/app/projection-accuracy/AccuracyScatterChart.tsx` — Recharts scatter with y=x reference line, one series per position
- `web/app/projection-accuracy/ProjectionAccuracyClient.tsx` — client wrapper with season tabs, summary cards, per-position table, chart, position filter, min-games slider, and per-player error table
- `web/app/projection-accuracy/page.tsx` — server component, awaits `searchParams`, calls `fetchBacktestData`

## Modified files
- `web/lib/analysis.ts` — adds `fetchBacktestData(targetSeason)` using `WeightedAveragePPG` on historical seasons
- `web/lib/types.ts` — adds `BacktestPlayer` interface
- `web/components/Navigation.tsx` — adds "Proj. Accuracy" link to `PRIVATE_LINKS`
- `web/middleware.ts` — adds `/projection-accuracy` to `PROTECTED_ROUTES`

## Test plan
- [ ] Visit `/projection-accuracy` (requires auth) — default season = 2025
- [ ] Toggle to 2024 → URL updates, metrics and chart change
- [ ] Position filter hides/shows chart dots and table rows
- [ ] Min-games slider at 0 shows all players; at 17 shows only full-season starters
- [ ] Green rows = error ≥ 3 (outperformed), red rows = error ≤ −3 (underperformed)
- [ ] `npm run build` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)