### PR TITLE
Fix name matching for players with initials (DJ Moore bug)

### DIFF
--- a/scripts/name_utils.py
+++ b/scripts/name_utils.py
@@ -9,6 +9,7 @@ def normalize_player_name(name: str) -> str:
     Normalize player name for matching across data sources.
 
     Removes:
+    - Periods (normalizes initials: "D.J." and "DJ" both become "Dj")
     - Suffixes: Jr, Jr., Sr, Sr., II, III, IV, V
     - Extra whitespace
     - Case differences (convert to title case)
@@ -20,19 +21,24 @@ def normalize_player_name(name: str) -> str:
         Normalized name suitable for matching
 
     Examples:
+        >>> normalize_player_name("D.J. Moore")
+        'Dj Moore'
+        >>> normalize_player_name("DJ Moore")
+        'Dj Moore'
         >>> normalize_player_name("Oronde Gadsden II")
         'Oronde Gadsden'
         >>> normalize_player_name("Marvin Harrison Jr.")
         'Marvin Harrison'
-        >>> normalize_player_name("Patrick Jones II")
-        'Patrick Jones'
-        >>> normalize_player_name("Velus Jones Jr.")
-        'Velus Jones'
         >>> normalize_player_name("Josh Allen")
         'Josh Allen'
     """
     # Strip whitespace
     name = name.strip()
+
+    # Strip periods so initials normalize consistently across sources
+    # e.g. "D.J. Moore" (nfl_data_py) and "DJ Moore" (Ottoneu) both become "DJ Moore"
+    # Suffix regex handles "Jr" without period too (period is optional in pattern)
+    name = name.replace('.', '')
 
     # Remove suffix patterns (case-insensitive, at end of string only)
     # Matches: Jr, Jr., Sr, Sr., II, III, IV, V


### PR DESCRIPTION
## Summary
- Players like "DJ Moore" (Ottoneu format) weren't matching "D.J. Moore" (nfl_data_py format) during stats sync
- This caused `games_played` to be non-zero but `total_points = 0`, breaking `ppg`/`pps` calculations
- Root cause: Python's `.title()` turns "DJ" → "Dj" but leaves "D.J." unchanged, so the two never matched

## Fix
Added `name.replace('.', '')` as the first normalization step in `normalize_player_name()` (`scripts/name_utils.py`). Both formats now converge before title-casing:
- `"D.J. Moore"` → strip periods → `"DJ Moore"` → title case → `"Dj Moore"`
- `"DJ Moore"` → (no periods) → `"DJ Moore"` → title case → `"Dj Moore"` ✓

Suffix removal is unaffected — the regex already handles `Jr` without a period.

## Test plan
- [ ] Run assertions: `normalize_player_name("D.J. Moore") == normalize_player_name("DJ Moore")`
- [ ] Re-run scraper (`python scripts/enqueue.py batch && python scripts/worker.py`) and verify DJ Moore shows correct points on the projections/projected-salary page

🤖 Generated with [Claude Code](https://claude.com/claude-code)