### PR TITLE
Add manual surplus value adjustments with Raw/Adjusted arb mode toggle

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -53,7 +53,22 @@ create table transactions (
   unique(player_id, league_id, transaction_type, transaction_date, salary)
 );
 
+-- Stores manual surplus value adjustments per player per league
+-- Used to override VORP-calculated dollar value with scouting judgment
+create table surplus_adjustments (
+  id uuid default gen_random_uuid() primary key,
+  player_id uuid references players(id) not null,
+  league_id integer not null,
+  adjustment numeric not null default 0,
+  notes text,
+  created_at timestamp with time zone default now() not null,
+  updated_at timestamp with time zone default now() not null,
+  unique(player_id, league_id)
+);
+
 -- Create indexes for performance
+create index idx_surplus_adjustments_league on surplus_adjustments(league_id);
+create index idx_surplus_adjustments_player on surplus_adjustments(player_id);
 create index idx_players_ottoneu_id on players(ottoneu_id);
 create index idx_player_stats_player_id on player_stats(player_id);
 create index idx_league_prices_league_id on league_prices(league_id);

--- a/web/app/api/surplus-adjustments/route.ts
+++ b/web/app/api/surplus-adjustments/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { LEAGUE_ID } from "@/lib/arb-logic";
+
+export async function GET() {
+  const { data, error } = await supabase
+    .from("surplus_adjustments")
+    .select("player_id, adjustment, notes")
+    .eq("league_id", LEAGUE_ID);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data ?? []);
+}
+
+interface AdjustmentRow {
+  player_id: string;
+  adjustment: number;
+  notes?: string;
+}
+
+export async function POST(req: NextRequest) {
+  const body: AdjustmentRow[] = await req.json();
+
+  const rows = body.map((item) => ({
+    player_id: item.player_id,
+    league_id: LEAGUE_ID,
+    adjustment: item.adjustment,
+    notes: item.notes ?? null,
+    updated_at: new Date().toISOString(),
+  }));
+
+  const { error } = await supabase
+    .from("surplus_adjustments")
+    .upsert(rows, { onConflict: "player_id,league_id" });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ success: true });
+}

--- a/web/app/arbitration-simulation/SimulationControls.tsx
+++ b/web/app/arbitration-simulation/SimulationControls.tsx
@@ -15,6 +15,8 @@ import SimulationTeams from "./SimulationTeams";
 
 interface SimulationControlsProps {
   initialPlayers: Player[];
+  /** Serialized adjustments from the server (Record is JSON-safe, Map is not) */
+  initialAdjustments?: Record<string, number>;
 }
 
 const MY_ROSTER_COLUMNS: Column[] = [
@@ -63,7 +65,7 @@ const CUT_CANDIDATE_RULES: HighlightRule[] = [
   { key: "surplus_after_arb", op: "lt", value: -10, className: "bg-red-50 dark:bg-red-950/30" },
 ];
 
-export default function SimulationControls({ initialPlayers }: SimulationControlsProps) {
+export default function SimulationControls({ initialPlayers, initialAdjustments }: SimulationControlsProps) {
   const [numSimulations, setNumSimulations] = useState(NUM_SIMULATIONS);
   const [valueVariation, setValueVariation] = useState(VALUE_VARIATION);
   const [simResults, setSimResults] = useState<SimulationResult[]>([]);
@@ -72,10 +74,13 @@ export default function SimulationControls({ initialPlayers }: SimulationControl
   // Run simulation when parameters change
   useEffect(() => {
     setIsRunning(true);
-    const results = runArbitrationSimulation(initialPlayers, numSimulations, valueVariation);
+    const adjMap = initialAdjustments
+      ? new Map(Object.entries(initialAdjustments))
+      : undefined;
+    const results = runArbitrationSimulation(initialPlayers, numSimulations, valueVariation, adjMap);
     setSimResults(results);
     setIsRunning(false);
-  }, [initialPlayers, numSimulations, valueVariation]);
+  }, [initialPlayers, initialAdjustments, numSimulations, valueVariation]);
 
   const myRoster = simResults
     .filter((p) => p.team_name === MY_TEAM)

--- a/web/app/arbitration-simulation/page.tsx
+++ b/web/app/arbitration-simulation/page.tsx
@@ -1,25 +1,65 @@
-import { fetchAndMergeData, SEASON } from "@/lib/analysis";
+import { fetchAndMergeData, SEASON, LEAGUE_ID } from "@/lib/analysis";
+import { supabase } from "@/lib/supabase";
 import SimulationControls from "./SimulationControls";
+import ModeToggle from "@/components/ModeToggle";
 
-export const revalidate = 3600;
+interface Props {
+  searchParams: Promise<{ mode?: string }>;
+}
 
-export default async function ArbitrationSimulationPage() {
-  const allPlayers = await fetchAndMergeData();
+export default async function ArbitrationSimulationPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const isAdjusted = params.mode === "adjusted";
+
+  const [allPlayers, adjRes] = await Promise.all([
+    fetchAndMergeData(),
+    supabase
+      .from("surplus_adjustments")
+      .select("player_id, adjustment")
+      .eq("league_id", LEAGUE_ID)
+      .neq("adjustment", 0),
+  ]);
+
+  const hasAdjustments = (adjRes.data?.length ?? 0) > 0;
+
+  let initialAdjustments: Record<string, number> | undefined;
+  if (isAdjusted && adjRes.data && adjRes.data.length > 0) {
+    initialAdjustments = Object.fromEntries(
+      adjRes.data.map((r) => [String(r.player_id), Number(r.adjustment)])
+    );
+  }
 
   return (
     <main className="min-h-screen bg-white dark:bg-black p-8">
       <div className="max-w-7xl mx-auto space-y-8">
         <header>
-          <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
-            Arbitration Simulation ({SEASON})
-          </h1>
-          <p className="text-slate-500 dark:text-slate-400 mt-2">
-            Monte Carlo simulation of how all 12 teams will allocate their arbitration budgets.
-            Adjust parameters below to explore different scenarios.
-          </p>
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+                Arbitration Simulation ({SEASON})
+              </h1>
+              <p className="text-slate-500 dark:text-slate-400 mt-2">
+                Monte Carlo simulation of how all 12 teams will allocate their arbitration budgets.
+                Adjust parameters below to explore different scenarios.
+              </p>
+            </div>
+            <ModeToggle
+              currentMode={isAdjusted ? "adjusted" : "raw"}
+              basePath="/arbitration-simulation"
+              hasAdjustments={hasAdjustments}
+            />
+          </div>
+          {isAdjusted && hasAdjustments && (
+            <div className="mt-3 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg px-4 py-2 text-sm text-blue-800 dark:text-blue-300">
+              Showing results with your manual surplus adjustments applied.
+            </div>
+          )}
         </header>
 
-        <SimulationControls initialPlayers={allPlayers} />
+        <SimulationControls
+          initialPlayers={allPlayers}
+          initialAdjustments={initialAdjustments}
+        />
       </div>
     </main>
   );

--- a/web/app/surplus-adjustments/AdjustmentsTable.tsx
+++ b/web/app/surplus-adjustments/AdjustmentsTable.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { SurplusPlayer, MY_TEAM } from "@/lib/arb-logic";
+
+interface AdjustmentEntry {
+  adjustment: number;
+  notes: string;
+}
+
+interface AdjustmentsTableProps {
+  players: SurplusPlayer[];
+  existingAdjustments: Record<string, AdjustmentEntry>;
+}
+
+const POSITIONS = ["ALL", "QB", "RB", "WR", "TE"];
+
+export default function AdjustmentsTable({
+  players,
+  existingAdjustments,
+}: AdjustmentsTableProps) {
+  const [adjustments, setAdjustments] = useState<Record<string, AdjustmentEntry>>(() => {
+    const init: Record<string, AdjustmentEntry> = {};
+    for (const p of players) {
+      init[p.player_id] = existingAdjustments[p.player_id] ?? {
+        adjustment: 0,
+        notes: "",
+      };
+    }
+    return init;
+  });
+
+  const [filterPos, setFilterPos] = useState("ALL");
+  const [filterTeam, setFilterTeam] = useState("ALL");
+  const [filterModified, setFilterModified] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saved" | "error">("idle");
+
+  const hasChanges = useMemo(() => {
+    for (const p of players) {
+      const cur = adjustments[p.player_id] ?? { adjustment: 0, notes: "" };
+      const orig = existingAdjustments[p.player_id] ?? { adjustment: 0, notes: "" };
+      if (cur.adjustment !== orig.adjustment || cur.notes !== orig.notes) return true;
+    }
+    return false;
+  }, [adjustments, players, existingAdjustments]);
+
+  const allTeams = useMemo(() => {
+    const teams = new Set<string>();
+    for (const p of players) {
+      if (p.team_name && p.team_name !== "FA" && p.team_name !== "")
+        teams.add(p.team_name);
+    }
+    return Array.from(teams).sort();
+  }, [players]);
+
+  const filteredPlayers = useMemo(() => {
+    return players
+      .filter((p) => filterPos === "ALL" || p.position === filterPos)
+      .filter((p) => filterTeam === "ALL" || p.team_name === filterTeam)
+      .filter((p) => {
+        if (!filterModified) return true;
+        return (adjustments[p.player_id]?.adjustment ?? 0) !== 0;
+      });
+  }, [players, filterPos, filterTeam, filterModified, adjustments]);
+
+  const updateAdjustment = (playerId: string, value: number) => {
+    setAdjustments((prev) => ({
+      ...prev,
+      [playerId]: { ...(prev[playerId] ?? { adjustment: 0, notes: "" }), adjustment: value },
+    }));
+    setSaveStatus("idle");
+  };
+
+  const updateNotes = (playerId: string, notes: string) => {
+    setAdjustments((prev) => ({
+      ...prev,
+      [playerId]: { ...(prev[playerId] ?? { adjustment: 0, notes: "" }), notes },
+    }));
+    setSaveStatus("idle");
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveStatus("idle");
+    try {
+      // Send all non-zero adjustments, plus any that were previously non-zero (to update them to 0)
+      const rows = Object.entries(adjustments)
+        .filter(([player_id, v]) => {
+          const orig = existingAdjustments[player_id];
+          return v.adjustment !== 0 || v.notes !== "" || (orig && (orig.adjustment !== 0 || orig.notes !== ""));
+        })
+        .map(([player_id, v]) => ({
+          player_id,
+          adjustment: v.adjustment,
+          notes: v.notes,
+        }));
+
+      const res = await fetch("/api/surplus-adjustments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(rows),
+      });
+
+      if (!res.ok) throw new Error("Save failed");
+      setSaveStatus("saved");
+    } catch {
+      setSaveStatus("error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const totalModified = useMemo(
+    () => players.filter((p) => (adjustments[p.player_id]?.adjustment ?? 0) !== 0).length,
+    [players, adjustments]
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* Controls bar */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Position filter */}
+        <div className="flex gap-1">
+          {POSITIONS.map((pos) => (
+            <button
+              key={pos}
+              onClick={() => setFilterPos(pos)}
+              className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
+                filterPos === pos
+                  ? "bg-blue-600 text-white"
+                  : "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700"
+              }`}
+            >
+              {pos}
+            </button>
+          ))}
+        </div>
+
+        {/* Team filter */}
+        <select
+          value={filterTeam}
+          onChange={(e) => setFilterTeam(e.target.value)}
+          className="px-2 py-1.5 text-xs rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300"
+        >
+          <option value="ALL">All Teams</option>
+          {allTeams.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+
+        {/* Modified filter */}
+        <label className="flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={filterModified}
+            onChange={(e) => setFilterModified(e.target.checked)}
+            className="rounded"
+          />
+          Modified only ({totalModified})
+        </label>
+
+        {/* Save button */}
+        <div className="ml-auto flex items-center gap-3">
+          {saveStatus === "saved" && (
+            <span className="text-xs text-green-600 dark:text-green-400">Saved!</span>
+          )}
+          {saveStatus === "error" && (
+            <span className="text-xs text-red-600 dark:text-red-400">Save failed</span>
+          )}
+          <button
+            onClick={handleSave}
+            disabled={saving || !hasChanges}
+            className="px-4 py-1.5 rounded bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {saving ? "Saving..." : "Save Changes"}
+          </button>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-800">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="bg-slate-100 dark:bg-slate-800">
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Player</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Pos</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Owner</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Salary</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">VORP Value</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Raw Surplus</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Adjustment ($)</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Adj. Value</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Adj. Surplus</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredPlayers.map((player, i) => {
+              const adj = adjustments[player.player_id] ?? { adjustment: 0, notes: "" };
+              const adjValue = Math.max(1, player.dollar_value + adj.adjustment);
+              const adjSurplus = adjValue - player.price;
+              const origAdj = existingAdjustments[player.player_id] ?? { adjustment: 0, notes: "" };
+              const isUnsaved =
+                adj.adjustment !== origAdj.adjustment || adj.notes !== origAdj.notes;
+              const isSavedNonZero = !isUnsaved && adj.adjustment !== 0;
+
+              const rowClass = isUnsaved
+                ? "bg-yellow-50 dark:bg-yellow-950/20"
+                : isSavedNonZero
+                ? "bg-blue-50 dark:bg-blue-950/20"
+                : i % 2 === 0
+                ? "bg-white dark:bg-slate-950"
+                : "bg-slate-50 dark:bg-slate-900";
+
+              return (
+                <tr
+                  key={player.player_id}
+                  className={`border-t border-slate-100 dark:border-slate-800 ${rowClass}`}
+                >
+                  <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap font-medium">
+                    {player.name}
+                    {player.team_name === MY_TEAM && (
+                      <span className="ml-1 text-xs text-blue-600 dark:text-blue-400">★</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap">
+                    {player.position}
+                  </td>
+                  <td className="px-3 py-2 text-slate-500 dark:text-slate-400 whitespace-nowrap text-xs">
+                    {player.team_name ?? "FA"}
+                  </td>
+                  <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap">
+                    ${player.price}
+                  </td>
+                  <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap">
+                    ${player.dollar_value}
+                  </td>
+                  <td
+                    className={`px-3 py-2 whitespace-nowrap font-medium ${
+                      player.surplus >= 0
+                        ? "text-green-700 dark:text-green-400"
+                        : "text-red-700 dark:text-red-400"
+                    }`}
+                  >
+                    {player.surplus >= 0 ? "+" : ""}
+                    {player.surplus}
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    <input
+                      type="number"
+                      value={adj.adjustment}
+                      onChange={(e) =>
+                        updateAdjustment(
+                          player.player_id,
+                          parseInt(e.target.value) || 0
+                        )
+                      }
+                      className="w-20 px-2 py-1 text-sm border border-slate-300 dark:border-slate-600 rounded bg-white dark:bg-slate-800 text-slate-900 dark:text-white focus:ring-1 focus:ring-blue-500 text-right"
+                      step="1"
+                    />
+                  </td>
+                  <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap">
+                    ${adjValue}
+                  </td>
+                  <td
+                    className={`px-3 py-2 whitespace-nowrap font-medium ${
+                      adjSurplus >= 0
+                        ? "text-green-700 dark:text-green-400"
+                        : "text-red-700 dark:text-red-400"
+                    }`}
+                  >
+                    {adjSurplus >= 0 ? "+" : ""}
+                    {adjSurplus}
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    <input
+                      type="text"
+                      value={adj.notes}
+                      onChange={(e) => updateNotes(player.player_id, e.target.value)}
+                      placeholder="e.g. injury recovery"
+                      className="w-44 px-2 py-1 text-xs border border-slate-300 dark:border-slate-600 rounded bg-white dark:bg-slate-800 text-slate-900 dark:text-white focus:ring-1 focus:ring-blue-500"
+                    />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-xs text-slate-500 dark:text-slate-400">
+        {filteredPlayers.length} players shown.{" "}
+        <span className="inline-block w-2 h-2 rounded-sm bg-yellow-200 dark:bg-yellow-900 border border-yellow-400 mr-0.5" />
+        {" "}unsaved changes.{" "}
+        <span className="inline-block w-2 h-2 rounded-sm bg-blue-100 dark:bg-blue-950 border border-blue-300 mr-0.5" />
+        {" "}saved non-zero adjustment.{" "}
+        ★ = your team.
+      </p>
+    </div>
+  );
+}

--- a/web/app/surplus-adjustments/page.tsx
+++ b/web/app/surplus-adjustments/page.tsx
@@ -1,0 +1,73 @@
+import { fetchAndMergeData, calculateSurplus, SEASON, LEAGUE_ID } from "@/lib/analysis";
+import { supabase } from "@/lib/supabase";
+import AdjustmentsTable from "./AdjustmentsTable";
+import Link from "next/link";
+
+export const revalidate = 0;
+
+export default async function SurplusAdjustmentsPage() {
+  const [allPlayers, adjRes] = await Promise.all([
+    fetchAndMergeData(),
+    supabase
+      .from("surplus_adjustments")
+      .select("player_id, adjustment, notes")
+      .eq("league_id", LEAGUE_ID),
+  ]);
+
+  const surplusPlayers = calculateSurplus(allPlayers).filter(
+    (p) => p.position !== "K"
+  );
+
+  const existingAdjustments: Record<string, { adjustment: number; notes: string }> = {};
+  for (const row of adjRes.data ?? []) {
+    existingAdjustments[String(row.player_id)] = {
+      adjustment: Number(row.adjustment) || 0,
+      notes: row.notes ?? "",
+    };
+  }
+
+  const savedCount = Object.values(existingAdjustments).filter(
+    (a) => a.adjustment !== 0
+  ).length;
+
+  return (
+    <main className="min-h-screen bg-white dark:bg-black p-8">
+      <div className="max-w-7xl mx-auto space-y-6">
+        <header>
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+            Surplus Value Adjustments ({SEASON})
+          </h1>
+          <p className="text-slate-500 dark:text-slate-400 mt-2">
+            Override each player&apos;s VORP-calculated dollar value with your own scouting
+            judgment. Enter a positive number to increase value (e.g. injury recovery,
+            scheme upgrade) or negative to decrease it. Adjustments persist in the
+            database and can be applied on the{" "}
+            <Link href="/arbitration?mode=adjusted" className="text-blue-600 dark:text-blue-400 underline">
+              Arbitration
+            </Link>
+            ,{" "}
+            <Link href="/projected-arbitration?mode=adjusted" className="text-blue-600 dark:text-blue-400 underline">
+              Projected Arbitration
+            </Link>
+            , and{" "}
+            <Link href="/arbitration-simulation?mode=adjusted" className="text-blue-600 dark:text-blue-400 underline">
+              Arb Simulation
+            </Link>{" "}
+            pages by toggling to &ldquo;Adjusted&rdquo; mode.
+          </p>
+        </header>
+
+        {savedCount > 0 && (
+          <div className="bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg px-5 py-3 text-sm text-blue-800 dark:text-blue-300">
+            {savedCount} player{savedCount !== 1 ? "s" : ""} currently have non-zero adjustments saved.
+          </div>
+        )}
+
+        <AdjustmentsTable
+          players={surplusPlayers}
+          existingAdjustments={existingAdjustments}
+        />
+      </div>
+    </main>
+  );
+}

--- a/web/components/ModeToggle.tsx
+++ b/web/components/ModeToggle.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from "next/link";
+
+interface ModeToggleProps {
+  currentMode: "raw" | "adjusted";
+  basePath: string;
+  hasAdjustments: boolean;
+  /** Any extra search params to preserve in the URL (e.g. year=2026) */
+  extraParams?: Record<string, string>;
+}
+
+export default function ModeToggle({
+  currentMode,
+  basePath,
+  hasAdjustments,
+  extraParams = {},
+}: ModeToggleProps) {
+  const buildUrl = (mode: "raw" | "adjusted") => {
+    const params = new URLSearchParams(extraParams);
+    if (mode === "adjusted") params.set("mode", "adjusted");
+    const qs = params.toString();
+    return qs ? `${basePath}?${qs}` : basePath;
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-slate-600 dark:text-slate-400">Surplus:</span>
+      <div className="flex rounded-md overflow-hidden border border-slate-200 dark:border-slate-700 text-sm font-medium">
+        <Link
+          href={buildUrl("raw")}
+          className={`px-3 py-1.5 transition-colors whitespace-nowrap ${
+            currentMode === "raw"
+              ? "bg-blue-600 text-white"
+              : "bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800"
+          }`}
+        >
+          Raw
+        </Link>
+        <Link
+          href={buildUrl("adjusted")}
+          className={`px-3 py-1.5 transition-colors whitespace-nowrap flex items-center gap-1.5 ${
+            currentMode === "adjusted"
+              ? "bg-blue-600 text-white"
+              : "bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800"
+          }`}
+        >
+          Adjusted
+          {hasAdjustments && currentMode === "raw" && (
+            <span className="w-2 h-2 rounded-full bg-blue-500 inline-block" />
+          )}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/web/components/Navigation.tsx
+++ b/web/components/Navigation.tsx
@@ -23,6 +23,7 @@ const PRIVATE_LINKS = [
   { href: "/projection-accuracy", label: "Proj. Accuracy" },
   { href: "/vorp", label: "VORP" },
   { href: "/surplus-value", label: "Surplus Value" },
+  { href: "/surplus-adjustments", label: "Adjustments" },
   { href: "/arbitration", label: "Arbitration" },
   { href: "/projected-arbitration", label: "Proj. Arbitration" },
   { href: "/arbitration-simulation", label: "Arb Simulation" },


### PR DESCRIPTION
Closes #68

## Summary

- **New `/surplus-adjustments` page** — editable table showing all rostered players with their VORP value, raw surplus, an adjustment input (dollar delta to add/subtract), and adjusted surplus. Filter by position, team, or modified-only. Yellow rows = unsaved changes, blue rows = saved non-zero adjustment. Save button batches all changes to the DB.
- **`surplus_adjustments` table** — new Supabase table (migration applied) with `player_id`, `league_id`, `adjustment`, and `notes` columns. Unique on `(player_id, league_id)`.
- **API route** — `GET /api/surplus-adjustments` returns saved adjustments; `POST` upserts a batch.
- **Raw/Adjusted mode toggle** — added to `/arbitration`, `/projected-arbitration`, and `/arbitration-simulation`. Mode stored in URL (`?mode=adjusted`) so it persists on refresh. A blue dot on the toggle indicates saved adjustments exist. A blue info banner confirms when adjusted mode is active.
- **Core analysis updated** — `calculateSurplus()`, `analyzeArbitration()`, and `runArbitrationSimulation()` all accept an optional `adjustments: Map<string, number>` that shifts each player's `dollar_value` (and therefore `surplus`) by the stored delta. All existing call sites are unaffected (parameter is optional).

## Test plan

- [ ] Visit `/surplus-adjustments`, enter adjustments for a few players, save, reload — values persist
- [ ] On `/arbitration`, toggle to Adjusted — targets reorder to reflect adjusted surplus; blue banner appears
- [ ] On `/arbitration-simulation`, toggle to Adjusted — simulation re-runs with adjusted values
- [ ] On `/projected-arbitration`, toggle to Adjusted — works alongside year selector
- [ ] Zero-adjustment players are not written to DB (filtered out on save)
- [ ] Build passes cleanly (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)