### PR TITLE
Remove year parameter from scrape player data workflow

### DIFF
--- a/.github/workflows/scrape-players.yml
+++ b/.github/workflows/scrape-players.yml
@@ -1,14 +1,8 @@
 name: Scrape Player Data
 
 on:
-  # Manual trigger with optional season override
+  # Manual trigger
   workflow_dispatch:
-    inputs:
-      season:
-        description: "Season year to scrape"
-        required: false
-        default: "2025"
-        type: string
 
   # Daily at 6:00 AM UTC (10 PM PT previous day)
   schedule:


### PR DESCRIPTION
The `season` year input is no longer needed by the scraper — the script now derives the season automatically. This removes the unused `season` input from the `workflow_dispatch` manual trigger.

Resolves #51