### PR TITLE
feat: add age column and sortable headers to adjustments table

### DIFF
--- a/web/app/surplus-adjustments/AdjustmentsTable.tsx
+++ b/web/app/surplus-adjustments/AdjustmentsTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { SurplusPlayer, MY_TEAM } from "@/lib/arb-logic";
 
 interface AdjustmentEntry {
@@ -14,6 +14,30 @@ interface AdjustmentsTableProps {
 }
 
 const POSITIONS = ["ALL", "QB", "RB", "WR", "TE"];
+
+type SortKey =
+  | "name"
+  | "position"
+  | "age"
+  | "team_name"
+  | "price"
+  | "dollar_value"
+  | "surplus"
+  | "adjustment"
+  | "adj_value"
+  | "adj_surplus";
+
+type SortDir = "asc" | "desc";
+
+function calculateAge(birthDate: string | null | undefined): number | null {
+  if (!birthDate) return null;
+  const today = new Date();
+  const dob = new Date(birthDate + "T00:00:00");
+  let age = today.getFullYear() - dob.getFullYear();
+  const m = today.getMonth() - dob.getMonth();
+  if (m < 0 || (m === 0 && today.getDate() < dob.getDate())) age--;
+  return age;
+}
 
 export default function AdjustmentsTable({
   players,
@@ -35,6 +59,20 @@ export default function AdjustmentsTable({
   const [filterModified, setFilterModified] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saved" | "error">("idle");
+  const [sortKey, setSortKey] = useState<SortKey>("surplus");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const toggleSort = useCallback(
+    (key: SortKey) => {
+      if (sortKey === key) {
+        setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+      } else {
+        setSortKey(key);
+        setSortDir(key === "name" || key === "position" || key === "team_name" ? "asc" : "desc");
+      }
+    },
+    [sortKey]
+  );
 
   const hasChanges = useMemo(() => {
     for (const p of players) {
@@ -55,14 +93,75 @@ export default function AdjustmentsTable({
   }, [players]);
 
   const filteredPlayers = useMemo(() => {
-    return players
+    const filtered = players
       .filter((p) => filterPos === "ALL" || p.position === filterPos)
       .filter((p) => filterTeam === "ALL" || p.team_name === filterTeam)
       .filter((p) => {
         if (!filterModified) return true;
         return (adjustments[p.player_id]?.adjustment ?? 0) !== 0;
       });
-  }, [players, filterPos, filterTeam, filterModified, adjustments]);
+
+    // Sort
+    return filtered.sort((a, b) => {
+      const adj_a = adjustments[a.player_id] ?? { adjustment: 0, notes: "" };
+      const adj_b = adjustments[b.player_id] ?? { adjustment: 0, notes: "" };
+      let va: number | string;
+      let vb: number | string;
+
+      switch (sortKey) {
+        case "name":
+          va = a.name;
+          vb = b.name;
+          break;
+        case "position":
+          va = a.position;
+          vb = b.position;
+          break;
+        case "age":
+          va = calculateAge(a.birth_date) ?? 999;
+          vb = calculateAge(b.birth_date) ?? 999;
+          break;
+        case "team_name":
+          va = a.team_name ?? "ZZZ";
+          vb = b.team_name ?? "ZZZ";
+          break;
+        case "price":
+          va = a.price;
+          vb = b.price;
+          break;
+        case "dollar_value":
+          va = a.dollar_value;
+          vb = b.dollar_value;
+          break;
+        case "surplus":
+          va = a.surplus;
+          vb = b.surplus;
+          break;
+        case "adjustment":
+          va = adj_a.adjustment;
+          vb = adj_b.adjustment;
+          break;
+        case "adj_value":
+          va = Math.max(1, a.dollar_value + adj_a.adjustment);
+          vb = Math.max(1, b.dollar_value + adj_b.adjustment);
+          break;
+        case "adj_surplus":
+          va = Math.max(1, a.dollar_value + adj_a.adjustment) - a.price;
+          vb = Math.max(1, b.dollar_value + adj_b.adjustment) - b.price;
+          break;
+        default:
+          va = 0;
+          vb = 0;
+      }
+
+      if (typeof va === "string" && typeof vb === "string") {
+        const cmp = va.localeCompare(vb);
+        return sortDir === "asc" ? cmp : -cmp;
+      }
+      const diff = (va as number) - (vb as number);
+      return sortDir === "asc" ? diff : -diff;
+    });
+  }, [players, filterPos, filterTeam, filterModified, adjustments, sortKey, sortDir]);
 
   const updateAdjustment = (playerId: string, value: number) => {
     setAdjustments((prev) => ({
@@ -116,6 +215,14 @@ export default function AdjustmentsTable({
     [players, adjustments]
   );
 
+  const sortIndicator = (key: SortKey) => {
+    if (sortKey !== key) return <span className="text-slate-300 dark:text-slate-600 ml-0.5">↕</span>;
+    return <span className="text-blue-500 ml-0.5">{sortDir === "asc" ? "↑" : "↓"}</span>;
+  };
+
+  const thClass =
+    "px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap cursor-pointer select-none hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors";
+
   return (
     <div className="space-y-4">
       {/* Controls bar */}
@@ -126,11 +233,10 @@ export default function AdjustmentsTable({
             <button
               key={pos}
               onClick={() => setFilterPos(pos)}
-              className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
-                filterPos === pos
+              className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${filterPos === pos
                   ? "bg-blue-600 text-white"
                   : "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700"
-              }`}
+                }`}
             >
               {pos}
             </button>
@@ -185,15 +291,36 @@ export default function AdjustmentsTable({
         <table className="min-w-full text-sm">
           <thead>
             <tr className="bg-slate-100 dark:bg-slate-800">
-              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Player</th>
-              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Pos</th>
-              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Owner</th>
-              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Salary</th>
-              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">VORP Value</th>
-              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Raw Surplus</th>
-              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Adjustment ($)</th>
-              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Adj. Value</th>
-              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Adj. Surplus</th>
+              <th className={thClass} onClick={() => toggleSort("name")}>
+                Player{sortIndicator("name")}
+              </th>
+              <th className={thClass} onClick={() => toggleSort("position")}>
+                Pos{sortIndicator("position")}
+              </th>
+              <th className={thClass} onClick={() => toggleSort("age")}>
+                Age{sortIndicator("age")}
+              </th>
+              <th className={thClass} onClick={() => toggleSort("team_name")}>
+                Owner{sortIndicator("team_name")}
+              </th>
+              <th className={thClass} onClick={() => toggleSort("price")}>
+                Salary{sortIndicator("price")}
+              </th>
+              <th className={thClass} onClick={() => toggleSort("dollar_value")}>
+                VORP Value{sortIndicator("dollar_value")}
+              </th>
+              <th className={thClass} onClick={() => toggleSort("surplus")}>
+                Raw Surplus{sortIndicator("surplus")}
+              </th>
+              <th className={thClass} onClick={() => toggleSort("adjustment")}>
+                Adjustment ($){sortIndicator("adjustment")}
+              </th>
+              <th className={thClass} onClick={() => toggleSort("adj_value")}>
+                Adj. Value{sortIndicator("adj_value")}
+              </th>
+              <th className={thClass} onClick={() => toggleSort("adj_surplus")}>
+                Adj. Surplus{sortIndicator("adj_surplus")}
+              </th>
               <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">Notes</th>
             </tr>
           </thead>
@@ -206,14 +333,15 @@ export default function AdjustmentsTable({
               const isUnsaved =
                 adj.adjustment !== origAdj.adjustment || adj.notes !== origAdj.notes;
               const isSavedNonZero = !isUnsaved && adj.adjustment !== 0;
+              const age = calculateAge(player.birth_date);
 
               const rowClass = isUnsaved
                 ? "bg-yellow-50 dark:bg-yellow-950/20"
                 : isSavedNonZero
-                ? "bg-blue-50 dark:bg-blue-950/20"
-                : i % 2 === 0
-                ? "bg-white dark:bg-slate-950"
-                : "bg-slate-50 dark:bg-slate-900";
+                  ? "bg-blue-50 dark:bg-blue-950/20"
+                  : i % 2 === 0
+                    ? "bg-white dark:bg-slate-950"
+                    : "bg-slate-50 dark:bg-slate-900";
 
               return (
                 <tr
@@ -229,6 +357,9 @@ export default function AdjustmentsTable({
                   <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap">
                     {player.position}
                   </td>
+                  <td className="px-3 py-2 text-slate-600 dark:text-slate-400 whitespace-nowrap text-xs">
+                    {age ?? "—"}
+                  </td>
                   <td className="px-3 py-2 text-slate-500 dark:text-slate-400 whitespace-nowrap text-xs">
                     {player.team_name ?? "FA"}
                   </td>
@@ -239,11 +370,10 @@ export default function AdjustmentsTable({
                     ${player.dollar_value}
                   </td>
                   <td
-                    className={`px-3 py-2 whitespace-nowrap font-medium ${
-                      player.surplus >= 0
+                    className={`px-3 py-2 whitespace-nowrap font-medium ${player.surplus >= 0
                         ? "text-green-700 dark:text-green-400"
                         : "text-red-700 dark:text-red-400"
-                    }`}
+                      }`}
                   >
                     {player.surplus >= 0 ? "+" : ""}
                     {player.surplus}
@@ -266,11 +396,10 @@ export default function AdjustmentsTable({
                     ${adjValue}
                   </td>
                   <td
-                    className={`px-3 py-2 whitespace-nowrap font-medium ${
-                      adjSurplus >= 0
+                    className={`px-3 py-2 whitespace-nowrap font-medium ${adjSurplus >= 0
                         ? "text-green-700 dark:text-green-400"
                         : "text-red-700 dark:text-red-400"
-                    }`}
+                      }`}
                   >
                     {adjSurplus >= 0 ? "+" : ""}
                     {adjSurplus}

--- a/web/lib/analysis.ts
+++ b/web/lib/analysis.ts
@@ -52,6 +52,7 @@ export async function fetchAndMergeData(): Promise<Player[]> {
       nfl_team: player.nfl_team,
       price: pPrice ? Number(pPrice.price) || 0 : 0,
       team_name: pPrice?.team_name || null,
+      birth_date: player.birth_date ?? null,
       total_points: Number(pStats.total_points) || 0,
       games_played: Number(pStats.games_played) || 0,
       snaps: Number(pStats.snaps) || 0,

--- a/web/lib/arb-logic.ts
+++ b/web/lib/arb-logic.ts
@@ -25,6 +25,7 @@ export interface Player {
     nfl_team: string;
     price: number;
     team_name: string | null;
+    birth_date: string | null;
     total_points: number;
     games_played: number;
     snaps: number;


### PR DESCRIPTION
## Summary

Adds player age and column sorting to the Surplus Adjustments table.

### Changes

- **Age column**: Shows each player's age (calculated from `birth_date` in the DB) between Position and Owner columns. Displays "—" for players missing birth date data.
- **Sortable columns**: All data columns are now clickable to sort. Click once for default direction (descending for numeric, ascending for text), click again to toggle. Active sort column shows ↑/↓ indicator; inactive columns show ↕.
- **Data plumbing**: Added `birth_date` to the `Player` interface and `fetchAndMergeData()` so it flows through the VORP/surplus pipeline.

### Files Changed

| File | Change |
|------|--------|
| `web/lib/arb-logic.ts` | Added `birth_date` field to `Player` interface |
| `web/lib/analysis.ts` | Include `birth_date` in `fetchAndMergeData()` merge |
| `web/app/surplus-adjustments/AdjustmentsTable.tsx` | Age column + sortable headers |
