### PR TITLE
Add college player support with rookie PPG projections

### DIFF
--- a/web/app/surplus-adjustments/AdjustmentsTable.tsx
+++ b/web/app/surplus-adjustments/AdjustmentsTable.tsx
@@ -67,6 +67,7 @@ export default function AdjustmentsTable({
   const [filterPos, setFilterPos] = useState("ALL");
   const [filterTeam, setFilterTeam] = useState("ALL");
   const [filterModified, setFilterModified] = useState(false);
+  const [filterCollege, setFilterCollege] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saved" | "error">("idle");
   const [sortKey, setSortKey] = useState<SortKey>("surplus");
@@ -114,7 +115,8 @@ export default function AdjustmentsTable({
       .filter((p) => {
         if (!filterModified) return true;
         return (adjustments[p.player_id]?.adjustment ?? 0) !== 0;
-      });
+      })
+      .filter((p) => !filterCollege || p.is_college === true);
 
     // Sort
     return filtered.sort((a, b) => {
@@ -190,7 +192,7 @@ export default function AdjustmentsTable({
       const diff = (va as number) - (vb as number);
       return sortDir === "asc" ? diff : -diff;
     });
-  }, [players, filterPos, filterTeam, filterModified, adjustments, sortKey, sortDir, getProj]);
+  }, [players, filterPos, filterTeam, filterModified, filterCollege, adjustments, sortKey, sortDir, getProj]);
 
   const updateAdjustment = (playerId: string, value: number) => {
     setAdjustments((prev) => ({
@@ -242,6 +244,11 @@ export default function AdjustmentsTable({
   const totalModified = useMemo(
     () => players.filter((p) => (adjustments[p.player_id]?.adjustment ?? 0) !== 0).length,
     [players, adjustments]
+  );
+
+  const totalCollege = useMemo(
+    () => players.filter((p) => p.is_college === true).length,
+    [players]
   );
 
   const sortIndicator = (key: SortKey) => {
@@ -298,6 +305,17 @@ export default function AdjustmentsTable({
             className="rounded"
           />
           Modified only ({totalModified})
+        </label>
+
+        {/* College filter */}
+        <label className="flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={filterCollege}
+            onChange={(e) => setFilterCollege(e.target.checked)}
+            className="rounded"
+          />
+          College only ({totalCollege})
         </label>
 
         {/* Save button */}


### PR DESCRIPTION
## Overview
Adds comprehensive support for college football prospects in the projection system, enabling analysis of pre-draft players alongside NFL rosters.

## Changes

### Database & Schema
- Add `is_college` boolean column to `players` table with migration
- Backfill existing college players based on nfl_team not matching any NFL abbreviation

### Backend (Python)
- **New projection method**: `CollegeProspectPPG` uses average rookie PPG by position
- **Roster scraping**: Enhanced `scrape_roster.py` to support college player scraping with separate form-based search flow
- **Stats handling**: New `build_stats_data()` function prevents overwriting existing stats when snap count data is missing (fixes #81)
- **VORP analysis**: Updated to include college players (0 games) alongside qualified NFL players
- **Configuration**: Added `COLLEGE_POSITIONS`, `NFL_TEAM_CODES` constants
- **Projection generation**: New `compute_avg_rookie_ppg()` and `generate_college_projections()` functions
- **Job enqueueing**: Added college roster scrape jobs with lower priority (depends on NFL stats)
- **Tests**: Comprehensive test coverage for projection methods and stats-building logic

### Frontend (TypeScript/React)
- Display "College" badge in projections table for college prospect projections
- Add college player filter checkbox to surplus adjustments page
- Update VORP calculation to include college players with 0 games
- Updated type definitions and data fetching to include `is_college` field
- Added NFL team code constants for validation

### Documentation
- Updated projections methodology page to explain college prospect projection method

## Fixes
- **#81**: `scrape_roster` now preserves existing DB stats when snap count data is unavailable (returns minimal payload)