### PR TITLE
fix: remove nfl_data_py from backfill action (pandas conflict on py3.12)

### DIFF
--- a/.github/workflows/backfill-nfl-stats.yml
+++ b/.github/workflows/backfill-nfl-stats.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install supabase python-dotenv nfl_data_py pandas numpy pyarrow
+          pip install supabase python-dotenv pandas numpy pyarrow
 
       - name: Create .env
         run: |


### PR DESCRIPTION
## Problem

The `Backfill NFL Stats` action was failing because `nfl_data_py` pins `pandas==1.5.3`, which cannot be built on Python 3.12 (`pkg_resources` missing).

## Fix

Drop `nfl_data_py` from the `pip install` step in `backfill-nfl-stats.yml`. The backfill script (`scripts/backfill_nfl_stats.py`) reads nflverse-data parquet files directly via `pandas.read_parquet` and never imports `nfl_data_py`, so it was an unnecessary dependency.