### PR TITLE
Add on-demand Claude code review GitHub Action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,58 @@
+name: Claude Code Review
+
+on:
+  # Trigger by commenting /claude-review on a PR
+  issue_comment:
+    types: [created]
+  # Also allow manual trigger from the Actions tab
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request number to review'
+        required: true
+        type: number
+
+jobs:
+  claude-review:
+    # For comment trigger: only run on PR comments (not issue comments) with the /claude-review command
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '/claude-review'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Get PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ github.event.inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Review mode: post comments on the PR
+          direct_prompt: |
+            Please review the changes in PR #${{ steps.pr.outputs.number }}.
+            Focus on:
+            - Correctness and potential bugs
+            - Code quality and maintainability
+            - Security concerns
+            - Performance issues
+            - Consistency with existing patterns in the codebase
+            Post your review as comments on the pull request.


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow for Claude-powered code review that is **only triggered on demand** — never automatically on every PR.

## How to trigger

**Option 1 (recommended):** Comment `/claude-review` on any PR

**Option 2:** Go to Actions → "Claude Code Review" → "Run workflow" and enter a PR number

## Setup

Requires `CLAUDE_CODE_OAUTH_TOKEN` secret in repository settings (already exists in the environment).