### PR TITLE
fix: use SUPABASE_SERVICE_ROLE_KEY in backfill action to bypass RLS

### DIFF
--- a/.github/workflows/backfill-nfl-stats.yml
+++ b/.github/workflows/backfill-nfl-stats.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Create .env
         run: |
           echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" > .env
-          echo "SUPABASE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" >> .env
+          echo "SUPABASE_KEY=${{ secrets.SUPABASE_SECRET_KEY }}" >> .env
 
       - name: Run NFL stats backfill
         run: |


### PR DESCRIPTION
## Problem

Backfill was failing with RLS error when trying to insert new `players` rows:
```
postgrest.exceptions.APIError: new row violates row-level security policy for table "players"
```

The `SUPABASE_KEY` (anon key) is blocked by RLS from inserting into `players`. The service role key bypasses RLS entirely.

## Fix

Use `SUPABASE_SERVICE_ROLE_KEY` secret in place of `SUPABASE_KEY` when creating the `.env` in the backfill action.

## Required Setup

Before running the action, add this secret in **GitHub → Settings → Secrets and variables → Actions**:

| Name | Value |
|------|-------|
| `SUPABASE_SERVICE_ROLE_KEY` | Found in Supabase Dashboard → Project Settings → API → `service_role` key |