### PR TITLE
fix: cast all dedup stat columns back to int after pandas groupby sum

### DIFF
--- a/scripts/backfill_nfl_stats.py
+++ b/scripts/backfill_nfl_stats.py
@@ -472,7 +472,9 @@ def backfill_seasons(
         dedup_df["total_points"] = dedup_df.apply(
             lambda r: round(calc_half_ppr_points(r.to_dict()), 2), axis=1
         )
-        dedup_df["games_played"] = dedup_df["games_played"].apply(_safe_int)
+        # pandas sum() promotes int columns with NaN to float64 — cast back to int|None
+        for col in present_sum:
+            dedup_df[col] = dedup_df[col].apply(_safe_int)
         dedup_df["ppg"] = dedup_df.apply(
             lambda r: round(r["total_points"] / r["games_played"], 2)
             if r.get("games_played") else 0.0,


### PR DESCRIPTION
## Problem

```
APIError: invalid input syntax for type integer: "0.0"
```

After the dedup `groupby().sum()`, pandas promotes all integer columns that contain any `NaN` to `float64`. When these are serialized and sent to Postgres integer columns, they fail.

## Fix

Apply `_safe_int()` to **all** integer stat columns after dedup, not just `games_played`.