### PR TITLE
🧪 Add tests for PositionFilter component

### DIFF
--- a/web/__tests__/components/PositionFilter.test.tsx
+++ b/web/__tests__/components/PositionFilter.test.tsx
@@ -56,9 +56,9 @@ describe("PositionFilter", () => {
         const wrButton = screen.getByText("WR");
         const rbButton = screen.getByText("RB");
 
-        expect(qbButton).toHaveStyle(`background-color: ${POSITION_COLORS["QB"]}`);
-        expect(wrButton).toHaveStyle(`background-color: ${POSITION_COLORS["WR"]}`);
-        expect(rbButton).not.toHaveStyle("background-color");
+        expect(qbButton).toHaveStyle({ backgroundColor: POSITION_COLORS["QB"] });
+        expect(wrButton).toHaveStyle({ backgroundColor: POSITION_COLORS["WR"] });
+        expect(rbButton).not.toHaveStyle({ backgroundColor: POSITION_COLORS["RB"] });
     });
 
     it("does not render the All button when showAll is false", () => {


### PR DESCRIPTION
Added a new test suite for the `PositionFilter` component in `web/__tests__/components/PositionFilter.test.tsx`. The tests cover all key functionalities including:
- Rendering of position buttons based on props.
- Interaction with buttons (triggering `onToggle`).
- Dynamic styling for selected positions using their designated colors.
- "All" button visibility and highlighting logic.

Due to environmental limitations (missing `node_modules` and network restrictions), tests could not be run locally but have been verified through careful manual code review and logic analysis.

---
*PR created automatically by Jules for task [8690878201965537368](https://jules.google.com/task/8690878201965537368) started by @alex-monroe*