### PR TITLE
Auto-trigger Claude code review for Jules bot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,6 +1,9 @@
 name: Claude Code Review
 
 on:
+  # Automatically review PRs opened by Jules (Google Labs Jules GitHub app)
+  pull_request:
+    types: [opened]
   # Trigger by commenting /claude-review on a PR
   issue_comment:
     types: [created]
@@ -14,9 +17,13 @@ on:
 
 jobs:
   claude-review:
+    # For pull_request trigger: only run when Jules opens a PR
     # For comment trigger: only run on PR comments (not issue comments) with the /claude-review command
     if: |
       (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'pull_request' &&
+       github.event.action == 'opened' &&
+       github.event.pull_request.user.login == 'google-labs-jules[bot]') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
        contains(github.event.comment.body, '/claude-review'))
@@ -32,6 +39,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "number=${{ github.event.inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
             echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary

Enable automatic Claude code review for pull requests opened by the Google Labs Jules GitHub app, in addition to the existing manual trigger via `/claude-review` comments.

## Changes

- Added `pull_request` trigger with `types: [opened]` to the workflow
- Updated job condition to automatically run reviews when Jules bot opens a PR
- Added logic to extract PR number from `pull_request` event context

## Test Plan

N/A - This is a GitHub Actions workflow configuration change. The workflow will be tested automatically when Jules bot opens a PR.

https://claude.ai/code/session_01PLi64uDbUhA7pz6k2neEws