### PR TITLE
Allow google-labs-jules bot in code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_bots: "google-labs-jules[bot]"
           # Review mode: post comments on the PR
           direct_prompt: |
             Please review the changes in PR #${{ steps.pr.outputs.number }}.


### PR DESCRIPTION
## Summary

Configure the Claude code review workflow to allow the `google-labs-jules[bot]` to trigger code reviews on pull requests.

## Changes

- Added `google-labs-jules[bot]` to the `allowed_bots` configuration in the Claude code review GitHub Action workflow

## Test Plan

N/A - This is a configuration change to the GitHub Actions workflow. The workflow will automatically use this setting on the next PR triggered by the allowed bot.

https://claude.ai/code/session_01RMkY3QazEvEdgoKw4r46zp