### PR TITLE
Add arbitration planner with plan creation, comparison, and persistence

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -13,6 +13,7 @@ Next.js App Router with five pages. All pages are server components that fetch l
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/arbitration` | Arbitration targets with per-opponent breakdown |
+| `/arbitration-planner` | Interactive planner to allocate $60 arbitration budget across opponents, save/compare plans |
 
 ## Reusable Components
 
@@ -35,7 +36,7 @@ Shared type definitions in `web/lib/types.ts`:
 
 ## Analysis Logic
 
-Analysis math is ported to `web/lib/analysis.ts` (TS equivalent of `scripts/analysis_utils.py`). Arbitration simulation logic lives in `web/lib/arb-logic.ts`.
+Analysis math is ported to `web/lib/analysis.ts` (TS equivalent of `scripts/analysis_utils.py`). Arbitration logic is split across `web/lib/vorp.ts`, `web/lib/surplus.ts`, `web/lib/arbitration.ts`, and `web/lib/simulation.ts`, re-exported from `web/lib/arb-logic.ts`.
 
 ## Configuration
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -1,6 +1,6 @@
 # Database Schema
 
-Six tables, all with UUID primary keys.
+Nine tables, all with UUID primary keys.
 
 ## Tables
 
@@ -13,6 +13,8 @@ Six tables, all with UUID primary keys.
 | `transactions` | Event log of all roster moves (adds, cuts, trades, auctions) | — |
 | `surplus_adjustments` | Manual value overrides per player per league | — |
 | `player_projections` | Calculated projection outputs from Python backend | — |
+| `arbitration_plans` | Saved arbitration allocation plans per league | `(league_id, name)` |
+| `arbitration_plan_allocations` | Per-player dollar allocations within a plan (FK → `arbitration_plans`, `players`) | `(plan_id, player_id)` |
 
 ## Schema Files
 
@@ -25,3 +27,5 @@ Six tables, all with UUID primary keys.
 - `player_stats.player_id` → `players.id`
 - `nfl_stats.player_id` → `players.id`
 - `league_prices.player_id` → `players.id`
+- `arbitration_plan_allocations.plan_id` → `arbitration_plans.id` (CASCADE DELETE)
+- `arbitration_plan_allocations.player_id` → `players.id`

--- a/migrations/012_create_arbitration_plans.sql
+++ b/migrations/012_create_arbitration_plans.sql
@@ -1,0 +1,27 @@
+-- Migration 012: Create arbitration plan tables for saving/comparing
+-- manual arbitration allocation strategies.
+
+-- Stores plan metadata (name, timestamps)
+CREATE TABLE arbitration_plans (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  league_id integer NOT NULL,
+  name text NOT NULL,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  updated_at timestamp with time zone DEFAULT now() NOT NULL,
+  UNIQUE(league_id, name)
+);
+
+-- Stores per-player dollar allocations within a plan
+CREATE TABLE arbitration_plan_allocations (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  plan_id uuid REFERENCES arbitration_plans(id) ON DELETE CASCADE NOT NULL,
+  player_id uuid REFERENCES players(id) NOT NULL,
+  amount integer NOT NULL CHECK (amount >= 1 AND amount <= 4),
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  UNIQUE(plan_id, player_id)
+);
+
+-- Indexes for common query patterns
+CREATE INDEX idx_arb_plans_league ON arbitration_plans(league_id);
+CREATE INDEX idx_arb_plan_allocs_plan ON arbitration_plan_allocations(plan_id);
+CREATE INDEX idx_arb_plan_allocs_player ON arbitration_plan_allocations(player_id);

--- a/schema.sql
+++ b/schema.sql
@@ -111,6 +111,46 @@ create table nfl_stats (
   unique(player_id, season)
 );
 
+-- Stores saved arbitration plans for manual allocation strategies
+create table arbitration_plans (
+  id uuid default gen_random_uuid() primary key,
+  league_id integer not null,
+  name text not null,
+  created_at timestamp with time zone default now() not null,
+  updated_at timestamp with time zone default now() not null,
+  unique(league_id, name)
+);
+
+-- Stores per-player dollar allocations within an arbitration plan
+create table arbitration_plan_allocations (
+  id uuid default gen_random_uuid() primary key,
+  plan_id uuid references arbitration_plans(id) on delete cascade not null,
+  player_id uuid references players(id) not null,
+  amount integer not null check (amount >= 1 and amount <= 4),
+  created_at timestamp with time zone default now() not null,
+  unique(plan_id, player_id)
+);
+
+-- Stores saved arbitration plans for comparing allocation strategies
+create table arbitration_plans (
+  id uuid default gen_random_uuid() primary key,
+  league_id integer not null,
+  name text not null,
+  created_at timestamp with time zone default now() not null,
+  updated_at timestamp with time zone default now() not null,
+  unique(league_id, name)
+);
+
+-- Stores per-player dollar allocations within an arbitration plan
+create table arbitration_plan_allocations (
+  id uuid default gen_random_uuid() primary key,
+  plan_id uuid references arbitration_plans(id) on delete cascade not null,
+  player_id uuid references players(id) not null,
+  amount integer not null check (amount >= 1 and amount <= 4),
+  created_at timestamp with time zone default now() not null,
+  unique(plan_id, player_id)
+);
+
 -- Create indexes for performance
 create index idx_surplus_adjustments_league on surplus_adjustments(league_id);
 create index idx_surplus_adjustments_player on surplus_adjustments(player_id);
@@ -123,3 +163,6 @@ create index idx_player_projections_season on player_projections(season);
 create index idx_player_projections_player_id on player_projections(player_id);
 create index idx_nfl_stats_season on nfl_stats(season);
 create index idx_nfl_stats_player_id on nfl_stats(player_id);
+create index idx_arb_plans_league on arbitration_plans(league_id);
+create index idx_arb_plan_allocs_plan on arbitration_plan_allocations(plan_id);
+create index idx_arb_plan_allocs_player on arbitration_plan_allocations(player_id);

--- a/web/app/api/arbitration-plans/[id]/route.ts
+++ b/web/app/api/arbitration-plans/[id]/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+// PUT /api/arbitration-plans/[id] — update plan allocations
+export async function PUT(req: NextRequest, { params }: Params) {
+  const { id } = await params;
+  const { allocations, name } = await req.json();
+
+  // Optionally update the plan name
+  if (name !== undefined) {
+    const { error: nameError } = await supabase
+      .from("arbitration_plans")
+      .update({ name, updated_at: new Date().toISOString() })
+      .eq("id", id);
+
+    if (nameError) {
+      if (nameError.code === "23505") {
+        return NextResponse.json(
+          { error: "A plan with that name already exists" },
+          { status: 409 }
+        );
+      }
+      return NextResponse.json(
+        { error: nameError.message },
+        { status: 500 }
+      );
+    }
+  }
+
+  // Update allocations if provided
+  if (allocations !== undefined) {
+    // Delete existing allocations
+    const { error: deleteError } = await supabase
+      .from("arbitration_plan_allocations")
+      .delete()
+      .eq("plan_id", id);
+
+    if (deleteError)
+      return NextResponse.json(
+        { error: deleteError.message },
+        { status: 500 }
+      );
+
+    // Insert new allocations (only non-zero ones)
+    const rows = Object.entries(allocations as Record<string, number>)
+      .filter(([, amount]) => amount > 0)
+      .map(([player_id, amount]) => ({
+        plan_id: id,
+        player_id,
+        amount,
+      }));
+
+    if (rows.length > 0) {
+      const { error: insertError } = await supabase
+        .from("arbitration_plan_allocations")
+        .insert(rows);
+
+      if (insertError)
+        return NextResponse.json(
+          { error: insertError.message },
+          { status: 500 }
+        );
+    }
+
+    // Update the plan's updated_at timestamp
+    await supabase
+      .from("arbitration_plans")
+      .update({ updated_at: new Date().toISOString() })
+      .eq("id", id);
+  }
+
+  return NextResponse.json({ success: true });
+}
+
+// DELETE /api/arbitration-plans/[id] — delete a plan
+export async function DELETE(_req: NextRequest, { params }: Params) {
+  const { id } = await params;
+
+  const { error } = await supabase
+    .from("arbitration_plans")
+    .delete()
+    .eq("id", id);
+
+  if (error)
+    return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ success: true });
+}

--- a/web/app/api/arbitration-plans/route.ts
+++ b/web/app/api/arbitration-plans/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { LEAGUE_ID } from "@/lib/arb-logic";
+
+// GET /api/arbitration-plans — list all plans with their allocations
+export async function GET() {
+  const { data: plans, error: plansError } = await supabase
+    .from("arbitration_plans")
+    .select("*")
+    .eq("league_id", LEAGUE_ID)
+    .order("updated_at", { ascending: false });
+
+  if (plansError)
+    return NextResponse.json({ error: plansError.message }, { status: 500 });
+
+  if (!plans || plans.length === 0) return NextResponse.json([]);
+
+  // Fetch all allocations for these plans
+  const planIds = plans.map((p) => p.id);
+  const { data: allocations, error: allocError } = await supabase
+    .from("arbitration_plan_allocations")
+    .select("plan_id, player_id, amount")
+    .in("plan_id", planIds);
+
+  if (allocError)
+    return NextResponse.json({ error: allocError.message }, { status: 500 });
+
+  // Group allocations by plan_id
+  const allocsByPlan = new Map<string, Record<string, number>>();
+  for (const a of allocations ?? []) {
+    if (!allocsByPlan.has(a.plan_id)) allocsByPlan.set(a.plan_id, {});
+    allocsByPlan.get(a.plan_id)![a.player_id] = a.amount;
+  }
+
+  const result = plans.map((p) => ({
+    ...p,
+    allocations: allocsByPlan.get(p.id) ?? {},
+  }));
+
+  return NextResponse.json(result);
+}
+
+// POST /api/arbitration-plans — create a new plan
+export async function POST(req: NextRequest) {
+  const { name } = await req.json();
+
+  if (!name || typeof name !== "string" || name.trim().length === 0) {
+    return NextResponse.json({ error: "Name is required" }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from("arbitration_plans")
+    .insert({ league_id: LEAGUE_ID, name: name.trim() })
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      return NextResponse.json(
+        { error: "A plan with that name already exists" },
+        { status: 409 }
+      );
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ...data, allocations: {} });
+}

--- a/web/app/arbitration-planner/PlanComparison.tsx
+++ b/web/app/arbitration-planner/PlanComparison.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { useMemo } from "react";
+import SummaryCard from "@/components/SummaryCard";
+import {
+  ARB_BUDGET_PER_TEAM,
+  ARB_MIN_PER_TEAM,
+  ARB_MAX_PER_TEAM,
+} from "@/lib/config";
+import type { ArbitrationPlan, PlannerPlayer, PlannerTeam } from "@/lib/types";
+
+interface Props {
+  plans: ArbitrationPlan[];
+  teams: PlannerTeam[];
+  comparePlanIds: string[];
+  onComparePlanIdsChange: (ids: string[]) => void;
+}
+
+export default function PlanComparison({
+  plans,
+  teams,
+  comparePlanIds,
+  onComparePlanIdsChange,
+}: Props) {
+  const selectedPlans = plans.filter((p) => comparePlanIds.includes(p.id));
+
+  // Build player lookup from all teams
+  const playerLookup = useMemo(() => {
+    const map = new Map<string, PlannerPlayer>();
+    for (const team of teams) {
+      for (const p of team.players) {
+        map.set(p.player_id, p);
+      }
+    }
+    return map;
+  }, [teams]);
+
+  // Gather all player_ids that appear in any selected plan
+  const allAllocatedPlayers = useMemo(() => {
+    const playerIds = new Set<string>();
+    for (const plan of selectedPlans) {
+      for (const pid of Object.keys(plan.allocations)) {
+        playerIds.add(pid);
+      }
+    }
+    return playerIds;
+  }, [selectedPlans]);
+
+  // Group allocated players by team
+  const teamGroups = useMemo(() => {
+    const groups = new Map<string, string[]>();
+    for (const pid of allAllocatedPlayers) {
+      const player = playerLookup.get(pid);
+      if (!player) continue;
+      const team = player.team_name;
+      if (!groups.has(team)) groups.set(team, []);
+      groups.get(team)!.push(pid);
+    }
+    // Sort teams alphabetically, sort players within each team by name
+    return [...groups.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([team, pids]) => ({
+        team,
+        playerIds: pids.sort((a, b) => {
+          const pa = playerLookup.get(a);
+          const pb = playerLookup.get(b);
+          return (pa?.name ?? "").localeCompare(pb?.name ?? "");
+        }),
+      }));
+  }, [allAllocatedPlayers, playerLookup]);
+
+  // Per-plan team totals
+  const planTeamTotals = useMemo(() => {
+    const result = new Map<string, Map<string, number>>();
+    for (const plan of selectedPlans) {
+      const teamTotals = new Map<string, number>();
+      for (const [pid, amount] of Object.entries(plan.allocations)) {
+        const player = playerLookup.get(pid);
+        if (!player) continue;
+        teamTotals.set(
+          player.team_name,
+          (teamTotals.get(player.team_name) ?? 0) + amount
+        );
+      }
+      result.set(plan.id, teamTotals);
+    }
+    return result;
+  }, [selectedPlans, playerLookup]);
+
+  const togglePlan = (planId: string) => {
+    if (comparePlanIds.includes(planId)) {
+      onComparePlanIdsChange(comparePlanIds.filter((id) => id !== planId));
+    } else {
+      onComparePlanIdsChange([...comparePlanIds, planId]);
+    }
+  };
+
+  if (plans.length < 2) {
+    return (
+      <div className="text-center py-12 text-slate-500 dark:text-slate-400">
+        Create at least 2 plans to compare them.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Plan selector */}
+      <div>
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+          Select Plans to Compare
+        </h2>
+        <div className="flex flex-wrap gap-3">
+          {plans.map((plan) => (
+            <label
+              key={plan.id}
+              className={`flex items-center gap-2 px-4 py-2 rounded-lg border cursor-pointer transition-colors ${
+                comparePlanIds.includes(plan.id)
+                  ? "border-blue-500 bg-blue-50 dark:bg-blue-950/30"
+                  : "border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-900"
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={comparePlanIds.includes(plan.id)}
+                onChange={() => togglePlan(plan.id)}
+                className="rounded"
+              />
+              <span className="text-sm font-medium text-slate-900 dark:text-white">
+                {plan.name}
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {selectedPlans.length < 2 ? (
+        <div className="text-center py-8 text-slate-500 dark:text-slate-400">
+          Select at least 2 plans to see the comparison.
+        </div>
+      ) : (
+        <>
+          {/* Summary cards */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            {selectedPlans.map((plan) => {
+              const total = Object.values(plan.allocations).reduce(
+                (sum, v) => sum + v,
+                0
+              );
+              const playerCount = Object.keys(plan.allocations).length;
+              return (
+                <SummaryCard
+                  key={plan.id}
+                  label={plan.name}
+                  value={`$${total} / ${playerCount} players`}
+                  variant={
+                    total === ARB_BUDGET_PER_TEAM
+                      ? "positive"
+                      : total > ARB_BUDGET_PER_TEAM
+                        ? "negative"
+                        : "default"
+                  }
+                />
+              );
+            })}
+          </div>
+
+          {/* Per-team totals comparison */}
+          <section>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+              Per-Team Allocation
+            </h2>
+            <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-800">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="bg-slate-100 dark:bg-slate-800">
+                    <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300">
+                      Team
+                    </th>
+                    {selectedPlans.map((plan) => (
+                      <th
+                        key={plan.id}
+                        className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300"
+                      >
+                        {plan.name}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {teams.map((team, i) => (
+                    <tr
+                      key={team.team_name}
+                      className={`border-t border-slate-100 dark:border-slate-800 ${
+                        i % 2 === 0
+                          ? "bg-white dark:bg-slate-950"
+                          : "bg-slate-50 dark:bg-slate-900"
+                      }`}
+                    >
+                      <td className="px-3 py-2 text-slate-800 dark:text-slate-200 font-medium whitespace-nowrap">
+                        {team.team_name}
+                      </td>
+                      {selectedPlans.map((plan) => {
+                        const total =
+                          planTeamTotals.get(plan.id)?.get(team.team_name) ?? 0;
+                        const isValid =
+                          total === 0 ||
+                          (total >= ARB_MIN_PER_TEAM &&
+                            total <= ARB_MAX_PER_TEAM);
+                        return (
+                          <td
+                            key={plan.id}
+                            className={`px-3 py-2 whitespace-nowrap ${
+                              !isValid && total > 0
+                                ? "text-red-700 dark:text-red-400 font-bold"
+                                : total > 0
+                                  ? "text-slate-800 dark:text-slate-200"
+                                  : "text-slate-400 dark:text-slate-600"
+                            }`}
+                          >
+                            ${total}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                  {/* Total row */}
+                  <tr className="border-t-2 border-slate-300 dark:border-slate-600 bg-slate-100 dark:bg-slate-800 font-bold">
+                    <td className="px-3 py-2 text-slate-900 dark:text-white">
+                      Total
+                    </td>
+                    {selectedPlans.map((plan) => {
+                      const total = Object.values(plan.allocations).reduce(
+                        (sum, v) => sum + v,
+                        0
+                      );
+                      return (
+                        <td
+                          key={plan.id}
+                          className={`px-3 py-2 ${
+                            total === ARB_BUDGET_PER_TEAM
+                              ? "text-green-700 dark:text-green-400"
+                              : total > ARB_BUDGET_PER_TEAM
+                                ? "text-red-700 dark:text-red-400"
+                                : "text-slate-900 dark:text-white"
+                          }`}
+                        >
+                          ${total}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          {/* Detailed player comparison */}
+          <section>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+              Player-by-Player Comparison
+            </h2>
+            <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-800">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="bg-slate-100 dark:bg-slate-800">
+                    <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300">
+                      Player
+                    </th>
+                    <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300">
+                      Pos
+                    </th>
+                    <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300">
+                      Salary
+                    </th>
+                    <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300">
+                      Surplus
+                    </th>
+                    {selectedPlans.map((plan) => (
+                      <th
+                        key={plan.id}
+                        className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300"
+                      >
+                        {plan.name}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {teamGroups.map((group) => (
+                    <>
+                      {/* Team header row */}
+                      <tr
+                        key={`header-${group.team}`}
+                        className="bg-slate-200 dark:bg-slate-700"
+                      >
+                        <td
+                          colSpan={4 + selectedPlans.length}
+                          className="px-3 py-2 font-semibold text-slate-900 dark:text-white"
+                        >
+                          {group.team}
+                        </td>
+                      </tr>
+                      {group.playerIds.map((pid, i) => {
+                        const player = playerLookup.get(pid);
+                        if (!player) return null;
+                        const allSame =
+                          selectedPlans.every(
+                            (p) =>
+                              (p.allocations[pid] ?? 0) ===
+                              (selectedPlans[0].allocations[pid] ?? 0)
+                          );
+                        return (
+                          <tr
+                            key={pid}
+                            className={`border-t border-slate-100 dark:border-slate-800 ${
+                              !allSame
+                                ? "bg-yellow-50 dark:bg-yellow-950/20"
+                                : i % 2 === 0
+                                  ? "bg-white dark:bg-slate-950"
+                                  : "bg-slate-50 dark:bg-slate-900"
+                            }`}
+                          >
+                            <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap font-medium">
+                              {player.name}
+                            </td>
+                            <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap">
+                              {player.position}
+                            </td>
+                            <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap">
+                              ${player.price}
+                            </td>
+                            <td
+                              className={`px-3 py-2 whitespace-nowrap ${
+                                player.surplus >= 0
+                                  ? "text-green-700 dark:text-green-400"
+                                  : "text-red-700 dark:text-red-400"
+                              }`}
+                            >
+                              ${player.surplus}
+                            </td>
+                            {selectedPlans.map((plan) => {
+                              const amount = plan.allocations[pid] ?? 0;
+                              return (
+                                <td
+                                  key={plan.id}
+                                  className={`px-3 py-2 whitespace-nowrap font-medium ${
+                                    amount > 0
+                                      ? "text-blue-700 dark:text-blue-300"
+                                      : "text-slate-400 dark:text-slate-600"
+                                  }`}
+                                >
+                                  {amount > 0 ? `$${amount}` : "—"}
+                                </td>
+                              );
+                            })}
+                          </tr>
+                        );
+                      })}
+                    </>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/app/arbitration-planner/PlannerClient.tsx
+++ b/web/app/arbitration-planner/PlannerClient.tsx
@@ -1,0 +1,556 @@
+"use client";
+
+import { useState, useEffect, useMemo, useCallback } from "react";
+import SummaryCard from "@/components/SummaryCard";
+import {
+  ARB_BUDGET_PER_TEAM,
+  ARB_MIN_PER_TEAM,
+  ARB_MAX_PER_TEAM,
+  ARB_MAX_PER_PLAYER_PER_TEAM,
+  NUM_TEAMS,
+} from "@/lib/config";
+import type { ArbitrationPlan, PlannerPlayer, PlannerTeam } from "@/lib/types";
+import PlanComparison from "./PlanComparison";
+
+interface Props {
+  teams: PlannerTeam[];
+}
+
+type Tab = "plan" | "compare";
+
+export default function PlannerClient({ teams }: Props) {
+  const [plans, setPlans] = useState<ArbitrationPlan[]>([]);
+  const [activePlanId, setActivePlanId] = useState<string | null>(null);
+  const [allocations, setAllocations] = useState<Record<string, number>>({});
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [newPlanName, setNewPlanName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState<Tab>("plan");
+  const [comparePlanIds, setComparePlanIds] = useState<string[]>([]);
+
+  const numOpponents = NUM_TEAMS - 1;
+
+  // Load saved plans on mount
+  useEffect(() => {
+    fetch("/api/arbitration-plans")
+      .then((r) => r.json())
+      .then((data: ArbitrationPlan[]) => {
+        setPlans(data);
+        if (data.length > 0) {
+          setActivePlanId(data[0].id);
+          setAllocations(data[0].allocations);
+        }
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  // Build per-team allocation totals
+  const teamTotals = useMemo(() => {
+    const totals = new Map<string, number>();
+    for (const team of teams) {
+      let teamTotal = 0;
+      for (const p of team.players) {
+        teamTotal += allocations[p.player_id] ?? 0;
+      }
+      totals.set(team.team_name, teamTotal);
+    }
+    return totals;
+  }, [allocations, teams]);
+
+  const totalSpent = useMemo(
+    () => Object.values(allocations).reduce((sum, v) => sum + v, 0),
+    [allocations]
+  );
+  const remaining = ARB_BUDGET_PER_TEAM - totalSpent;
+
+  // Validation: check per-team constraints
+  const teamErrors = useMemo(() => {
+    const errors = new Map<string, string>();
+    for (const [team, total] of teamTotals.entries()) {
+      if (total > ARB_MAX_PER_TEAM)
+        errors.set(team, `Over max ($${total}/$${ARB_MAX_PER_TEAM})`);
+    }
+    return errors;
+  }, [teamTotals]);
+
+  // Count teams below minimum (only when budget is fully allocated)
+  const teamsUnderMin = useMemo(() => {
+    if (totalSpent < ARB_BUDGET_PER_TEAM) return [];
+    return teams
+      .filter((t) => (teamTotals.get(t.team_name) ?? 0) < ARB_MIN_PER_TEAM)
+      .map((t) => t.team_name);
+  }, [teamTotals, totalSpent, teams]);
+
+  const setPlayerAllocation = useCallback(
+    (playerId: string, amount: number) => {
+      setAllocations((prev) => {
+        const next = { ...prev };
+        if (amount === 0) delete next[playerId];
+        else next[playerId] = amount;
+        return next;
+      });
+    },
+    []
+  );
+
+  const toggle = (team: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(team)) next.delete(team);
+      else next.add(team);
+      return next;
+    });
+  };
+
+  // Plan management
+  const createPlan = async () => {
+    if (!newPlanName.trim()) return;
+    const res = await fetch("/api/arbitration-plans", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: newPlanName.trim() }),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      alert(err.error || "Failed to create plan");
+      return;
+    }
+    const plan: ArbitrationPlan = await res.json();
+    setPlans((prev) => [plan, ...prev]);
+    setActivePlanId(plan.id);
+    setAllocations({});
+    setNewPlanName("");
+  };
+
+  const selectPlan = (planId: string) => {
+    const plan = plans.find((p) => p.id === planId);
+    if (plan) {
+      setActivePlanId(planId);
+      setAllocations({ ...plan.allocations });
+    }
+  };
+
+  const savePlan = async () => {
+    if (!activePlanId) return;
+    setSaving(true);
+    const res = await fetch(`/api/arbitration-plans/${activePlanId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ allocations }),
+    });
+    if (res.ok) {
+      setPlans((prev) =>
+        prev.map((p) =>
+          p.id === activePlanId
+            ? { ...p, allocations: { ...allocations }, updated_at: new Date().toISOString() }
+            : p
+        )
+      );
+    }
+    setSaving(false);
+  };
+
+  const deletePlan = async (planId: string) => {
+    if (!confirm("Delete this plan?")) return;
+    const res = await fetch(`/api/arbitration-plans/${planId}`, {
+      method: "DELETE",
+    });
+    if (res.ok) {
+      setPlans((prev) => prev.filter((p) => p.id !== planId));
+      if (activePlanId === planId) {
+        setActivePlanId(null);
+        setAllocations({});
+      }
+      setComparePlanIds((prev) => prev.filter((id) => id !== planId));
+    }
+  };
+
+  const activePlan = plans.find((p) => p.id === activePlanId);
+  const hasUnsavedChanges =
+    activePlan &&
+    JSON.stringify(allocations) !== JSON.stringify(activePlan.allocations);
+
+  if (loading) {
+    return (
+      <div className="text-slate-500 dark:text-slate-400 py-12 text-center">
+        Loading plans...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <header>
+        <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+          Arbitration Planner
+        </h1>
+        <p className="text-slate-500 dark:text-slate-400 mt-2">
+          Allocate your ${ARB_BUDGET_PER_TEAM} arbitration budget across
+          opponent rosters. ${ARB_MIN_PER_TEAM}-${ARB_MAX_PER_TEAM} per team,
+          up to ${ARB_MAX_PER_PLAYER_PER_TEAM} per player.
+        </p>
+      </header>
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b border-slate-200 dark:border-slate-800">
+        <button
+          onClick={() => setTab("plan")}
+          className={`px-4 py-2 text-sm font-medium rounded-t-md transition-colors ${
+            tab === "plan"
+              ? "bg-blue-600 text-white"
+              : "text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"
+          }`}
+        >
+          Plan
+        </button>
+        <button
+          onClick={() => setTab("compare")}
+          className={`px-4 py-2 text-sm font-medium rounded-t-md transition-colors ${
+            tab === "compare"
+              ? "bg-blue-600 text-white"
+              : "text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"
+          }`}
+        >
+          Compare Plans
+        </button>
+      </div>
+
+      {tab === "plan" && (
+        <>
+          {/* Plan selector */}
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="flex-1 min-w-[200px]">
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+                Active Plan
+              </label>
+              <select
+                value={activePlanId ?? ""}
+                onChange={(e) => selectPlan(e.target.value)}
+                className="w-full rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white"
+              >
+                <option value="" disabled>
+                  {plans.length === 0
+                    ? "No plans yet — create one below"
+                    : "Select a plan"}
+                </option>
+                {plans.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex items-end gap-2">
+              <div>
+                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+                  New Plan
+                </label>
+                <input
+                  type="text"
+                  value={newPlanName}
+                  onChange={(e) => setNewPlanName(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && createPlan()}
+                  placeholder="Plan name..."
+                  className="rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white"
+                />
+              </div>
+              <button
+                onClick={createPlan}
+                disabled={!newPlanName.trim()}
+                className="px-4 py-2 text-sm font-medium rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Create
+              </button>
+            </div>
+
+            {activePlanId && (
+              <div className="flex gap-2">
+                <button
+                  onClick={savePlan}
+                  disabled={saving || !hasUnsavedChanges}
+                  className="px-4 py-2 text-sm font-medium rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {saving ? "Saving..." : "Save"}
+                </button>
+                <button
+                  onClick={() => deletePlan(activePlanId)}
+                  className="px-4 py-2 text-sm font-medium rounded-md bg-red-600 text-white hover:bg-red-700"
+                >
+                  Delete
+                </button>
+              </div>
+            )}
+          </div>
+
+          {hasUnsavedChanges && (
+            <div className="bg-yellow-50 dark:bg-yellow-950/30 border border-yellow-200 dark:border-yellow-800 rounded-lg px-4 py-2 text-sm text-yellow-800 dark:text-yellow-300">
+              You have unsaved changes.
+            </div>
+          )}
+
+          {/* Budget summary */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <SummaryCard
+              label="Budget"
+              value={`$${totalSpent} / $${ARB_BUDGET_PER_TEAM}`}
+            />
+            <SummaryCard
+              label="Remaining"
+              value={remaining}
+              variant={remaining < 0 ? "negative" : remaining === 0 ? "positive" : "default"}
+            />
+            <SummaryCard
+              label="Players Targeted"
+              value={`${Object.keys(allocations).length}`}
+            />
+            <SummaryCard
+              label="Teams with Allocations"
+              value={`${[...teamTotals.values()].filter((v) => v > 0).length} / ${numOpponents}`}
+            />
+          </div>
+
+          {/* Budget errors */}
+          {remaining < 0 && (
+            <div className="bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-lg px-4 py-2 text-sm text-red-800 dark:text-red-300">
+              Over budget by ${Math.abs(remaining)}.
+            </div>
+          )}
+          {teamErrors.size > 0 && (
+            <div className="bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-lg px-4 py-2 text-sm text-red-800 dark:text-red-300">
+              Team limit exceeded:{" "}
+              {[...teamErrors.entries()]
+                .map(([team, msg]) => `${team}: ${msg}`)
+                .join(", ")}
+            </div>
+          )}
+          {teamsUnderMin.length > 0 && (
+            <div className="bg-yellow-50 dark:bg-yellow-950/30 border border-yellow-200 dark:border-yellow-800 rounded-lg px-4 py-2 text-sm text-yellow-800 dark:text-yellow-300">
+              Teams below ${ARB_MIN_PER_TEAM} minimum:{" "}
+              {teamsUnderMin.join(", ")}
+            </div>
+          )}
+
+          {/* Team sections */}
+          {!activePlanId ? (
+            <div className="text-center py-12 text-slate-500 dark:text-slate-400">
+              Create or select a plan to start allocating.
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {teams.map((team) => {
+                const teamTotal = teamTotals.get(team.team_name) ?? 0;
+                const isOpen = expanded.has(team.team_name);
+                const error = teamErrors.get(team.team_name);
+                const isValid =
+                  teamTotal === 0 ||
+                  (teamTotal >= ARB_MIN_PER_TEAM &&
+                    teamTotal <= ARB_MAX_PER_TEAM);
+
+                return (
+                  <div
+                    key={team.team_name}
+                    className="border border-slate-200 dark:border-slate-800 rounded-lg overflow-hidden"
+                  >
+                    <button
+                      onClick={() => toggle(team.team_name)}
+                      className="w-full flex items-center justify-between px-4 py-3 bg-slate-50 dark:bg-slate-900 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors text-left"
+                    >
+                      <span className="font-medium text-slate-900 dark:text-white">
+                        {team.team_name}{" "}
+                        <span className="text-sm font-normal text-slate-500 dark:text-slate-400">
+                          ({team.players.length} players, ${team.total_salary}{" "}
+                          cap)
+                        </span>
+                      </span>
+                      <span className="flex items-center gap-3">
+                        <span
+                          className={`text-sm font-medium ${
+                            error
+                              ? "text-red-600 dark:text-red-400"
+                              : teamTotal > 0
+                                ? "text-green-600 dark:text-green-400"
+                                : "text-slate-500 dark:text-slate-400"
+                          }`}
+                        >
+                          ${teamTotal} / ${ARB_MAX_PER_TEAM}
+                          {!isValid && teamTotal > 0 && " ⚠"}
+                        </span>
+                        <span className="text-slate-400">
+                          {isOpen ? "▲" : "▼"}
+                        </span>
+                      </span>
+                    </button>
+                    {isOpen && (
+                      <TeamRosterTable
+                        players={team.players}
+                        allocations={allocations}
+                        onAllocate={setPlayerAllocation}
+                      />
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </>
+      )}
+
+      {tab === "compare" && (
+        <PlanComparison
+          plans={plans}
+          teams={teams}
+          comparePlanIds={comparePlanIds}
+          onComparePlanIdsChange={setComparePlanIds}
+        />
+      )}
+    </div>
+  );
+}
+
+// --- Team Roster Table ---
+
+function TeamRosterTable({
+  players,
+  allocations,
+  onAllocate,
+}: {
+  players: PlannerPlayer[];
+  allocations: Record<string, number>;
+  onAllocate: (playerId: string, amount: number) => void;
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="bg-slate-100 dark:bg-slate-800">
+            <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300">
+              Player
+            </th>
+            <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300">
+              Pos
+            </th>
+            <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300">
+              NFL Team
+            </th>
+            <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300">
+              Salary
+            </th>
+            <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300">
+              Value
+            </th>
+            <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300">
+              Surplus
+            </th>
+            <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300">
+              Adj. Surplus
+            </th>
+            <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300">
+              Arb $
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {players.map((p, i) => {
+            const amount = allocations[p.player_id] ?? 0;
+            return (
+              <tr
+                key={p.player_id}
+                className={`border-t border-slate-100 dark:border-slate-800 ${
+                  amount > 0
+                    ? "bg-blue-50 dark:bg-blue-950/30"
+                    : i % 2 === 0
+                      ? "bg-white dark:bg-slate-950"
+                      : "bg-slate-50 dark:bg-slate-900"
+                }`}
+              >
+                <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap font-medium">
+                  {p.name}
+                </td>
+                <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap">
+                  {p.position}
+                </td>
+                <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap">
+                  {p.nfl_team}
+                </td>
+                <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap">
+                  ${p.price}
+                </td>
+                <td className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap">
+                  ${p.dollar_value}
+                </td>
+                <td
+                  className={`px-3 py-2 whitespace-nowrap ${
+                    p.surplus >= 0
+                      ? "text-green-700 dark:text-green-400"
+                      : "text-red-700 dark:text-red-400"
+                  }`}
+                >
+                  ${p.surplus}
+                </td>
+                <td
+                  className={`px-3 py-2 whitespace-nowrap ${
+                    p.adjusted_surplus >= 0
+                      ? "text-green-700 dark:text-green-400"
+                      : "text-red-700 dark:text-red-400"
+                  }`}
+                >
+                  ${p.adjusted_surplus}
+                </td>
+                <td className="px-3 py-2 whitespace-nowrap">
+                  <AllocationStepper
+                    value={amount}
+                    onChange={(v) => onAllocate(p.player_id, v)}
+                  />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// --- Stepper input for $0-$4 ---
+
+function AllocationStepper({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        onClick={() => onChange(Math.max(0, value - 1))}
+        disabled={value === 0}
+        className="w-6 h-6 flex items-center justify-center rounded bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-600 disabled:opacity-30 disabled:cursor-not-allowed text-xs font-bold"
+      >
+        −
+      </button>
+      <span
+        className={`w-6 text-center text-sm font-medium ${
+          value > 0
+            ? "text-blue-700 dark:text-blue-300"
+            : "text-slate-400 dark:text-slate-600"
+        }`}
+      >
+        {value}
+      </span>
+      <button
+        onClick={() =>
+          onChange(Math.min(ARB_MAX_PER_PLAYER_PER_TEAM, value + 1))
+        }
+        disabled={value >= ARB_MAX_PER_PLAYER_PER_TEAM}
+        className="w-6 h-6 flex items-center justify-center rounded bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-600 disabled:opacity-30 disabled:cursor-not-allowed text-xs font-bold"
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/web/app/arbitration-planner/page.tsx
+++ b/web/app/arbitration-planner/page.tsx
@@ -1,0 +1,80 @@
+import { fetchAndMergeData, LEAGUE_ID, MY_TEAM } from "@/lib/analysis";
+import { calculateSurplus } from "@/lib/surplus";
+import { supabase } from "@/lib/supabase";
+import type { PlannerPlayer, PlannerTeam } from "@/lib/types";
+import PlannerClient from "./PlannerClient";
+
+export const revalidate = 3600;
+
+export default async function ArbitrationPlannerPage() {
+  const allPlayers = await fetchAndMergeData();
+
+  // Calculate surplus without adjustments (raw)
+  const rawSurplus = calculateSurplus(allPlayers);
+
+  // Fetch adjustments for adjusted surplus
+  const { data: adjData } = await supabase
+    .from("surplus_adjustments")
+    .select("player_id, adjustment")
+    .eq("league_id", LEAGUE_ID)
+    .neq("adjustment", 0);
+
+  const adjustments = new Map<string, number>(
+    (adjData ?? []).map((r) => [String(r.player_id), Number(r.adjustment)])
+  );
+  const adjustedSurplus = calculateSurplus(allPlayers, adjustments);
+
+  // Build lookup for adjusted values
+  const adjustedMap = new Map(
+    adjustedSurplus.map((p) => [p.player_id, p])
+  );
+
+  // Filter to opponent-owned players (exclude MY_TEAM, free agents, kickers)
+  const opponentPlayers: PlannerPlayer[] = rawSurplus
+    .filter(
+      (p) =>
+        p.team_name != null &&
+        p.team_name !== "" &&
+        p.team_name !== "FA" &&
+        p.team_name !== MY_TEAM &&
+        p.position !== "K"
+    )
+    .map((p) => {
+      const adj = adjustedMap.get(p.player_id);
+      return {
+        player_id: p.player_id,
+        name: p.name,
+        position: p.position,
+        nfl_team: p.nfl_team,
+        price: p.price,
+        team_name: p.team_name!,
+        dollar_value: p.dollar_value,
+        surplus: p.surplus,
+        adjusted_surplus: adj ? adj.surplus : p.surplus,
+      };
+    });
+
+  // Group by team
+  const teamMap = new Map<string, PlannerPlayer[]>();
+  for (const p of opponentPlayers) {
+    const list = teamMap.get(p.team_name) ?? [];
+    list.push(p);
+    teamMap.set(p.team_name, list);
+  }
+
+  const teams: PlannerTeam[] = [...teamMap.entries()]
+    .map(([team_name, players]) => ({
+      team_name,
+      players: players.sort((a, b) => b.surplus - a.surplus),
+      total_salary: players.reduce((sum, p) => sum + p.price, 0),
+    }))
+    .sort((a, b) => a.team_name.localeCompare(b.team_name));
+
+  return (
+    <main className="min-h-screen bg-white dark:bg-black p-8">
+      <div className="max-w-7xl mx-auto">
+        <PlannerClient teams={teams} />
+      </div>
+    </main>
+  );
+}

--- a/web/components/Navigation.tsx
+++ b/web/components/Navigation.tsx
@@ -39,6 +39,7 @@ const PRIVATE_GROUPS = [
     links: [
       { href: "/arbitration", label: "Arbitration" },
       { href: "/arbitration-simulation", label: "Arb Simulation" },
+      { href: "/arbitration-planner", label: "Arb Planner" },
     ],
   },
 ];

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -185,6 +185,36 @@ export interface BacktestPlayer {
   [key: string]: string | number | null | undefined;
 }
 
+// === Arbitration Planner Types ===
+
+export interface ArbitrationPlan {
+  id: string;
+  league_id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+  allocations: Record<string, number>; // player_id -> amount (1-4)
+}
+
+export interface PlannerPlayer {
+  player_id: string;
+  name: string;
+  position: string;
+  nfl_team: string;
+  price: number;
+  team_name: string;
+  dollar_value: number;
+  surplus: number;
+  adjusted_surplus: number;
+  [key: string]: string | number | boolean | null | undefined;
+}
+
+export interface PlannerTeam {
+  team_name: string;
+  players: PlannerPlayer[];
+  total_salary: number;
+}
+
 // === DataTable Types ===
 
 export interface Column {


### PR DESCRIPTION
## Summary

Adds a new Arbitration Planner feature that allows users to create, save, and compare multiple arbitration allocation strategies. Users can allocate their arbitration budget ($50) across opponent rosters with per-team ($5-$20) and per-player ($1-$4) constraints, then compare different plans side-by-side.

## Changes

- **New page** `/arbitration-planner` with server-side data fetching that loads opponent rosters with surplus calculations
- **PlannerClient component** with interactive budget allocation UI:
  - Create/select/delete arbitration plans
  - Allocate $1-$4 per player with real-time validation
  - Per-team budget constraints ($5-$20 min/max)
  - Overall budget tracking ($50 total)
  - Unsaved changes indicator
  - Expandable team sections with player roster tables
- **PlanComparison component** for side-by-side plan analysis:
  - Select multiple plans to compare
  - Per-team allocation totals across plans
  - Player-by-player allocation differences highlighted
  - Summary cards showing budget utilization
- **API endpoints**:
  - `GET /api/arbitration-plans` — list all saved plans with allocations
  - `POST /api/arbitration-plans` — create new plan
  - `PUT /api/arbitration-plans/[id]` — update plan allocations
  - `DELETE /api/arbitration-plans/[id]` — delete plan
- **Database schema** with two new tables:
  - `arbitration_plans` — stores plan metadata (name, timestamps, league_id)
  - `arbitration_plan_allocations` — stores per-player dollar amounts per plan
  - Includes migration file and schema documentation updates
- **Type definitions** for `ArbitrationPlan`, `PlannerPlayer`, and `PlannerTeam`
- **Navigation** updated to include link to new planner page

## Test Plan

- [ ] TypeScript compiles (`make typecheck`)
- [ ] ESLint clean (`make lint`)
- [ ] Production build succeeds (`make build`)

https://claude.ai/code/session_014xLp7toH9HHcEDCujGbxb5