### PR TITLE
feat: add self-service registration from login page

### DIFF
--- a/web/app/api/auth/register/route.ts
+++ b/web/app/api/auth/register/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { supabase } from "@/lib/supabase";
+import { setAuthCookie } from "@/lib/auth";
+
+export async function POST(request: NextRequest) {
+    try {
+        const { email, password, confirmPassword } = await request.json();
+
+        if (!email || !password || !confirmPassword) {
+            return NextResponse.json(
+                { error: "Email, password, and password confirmation are required" },
+                { status: 400 }
+            );
+        }
+
+        if (password.length < 6) {
+            return NextResponse.json(
+                { error: "Password must be at least 6 characters" },
+                { status: 400 }
+            );
+        }
+
+        if (password !== confirmPassword) {
+            return NextResponse.json(
+                { error: "Passwords do not match" },
+                { status: 400 }
+            );
+        }
+
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(email)) {
+            return NextResponse.json(
+                { error: "Please enter a valid email address" },
+                { status: 400 }
+            );
+        }
+
+        const password_hash = await bcrypt.hash(password, 12);
+
+        const { data, error } = await supabase
+            .from("users")
+            .insert({
+                email: email.toLowerCase().trim(),
+                password_hash,
+                is_admin: false,
+                has_projections_access: false,
+            })
+            .select("id, is_admin, has_projections_access")
+            .single();
+
+        if (error) {
+            if (error.code === "23505") {
+                return NextResponse.json(
+                    { error: "An account with that email already exists" },
+                    { status: 409 }
+                );
+            }
+            return NextResponse.json(
+                { error: error.message },
+                { status: 500 }
+            );
+        }
+
+        // Auto-login: set auth cookie for the newly created user
+        await setAuthCookie(data.id, data.is_admin, data.has_projections_access);
+
+        return NextResponse.json({ success: true }, { status: 201 });
+    } catch (error) {
+        console.error("Registration error:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        );
+    }
+}

--- a/web/app/login/LoginForm.tsx
+++ b/web/app/login/LoginForm.tsx
@@ -3,9 +3,13 @@
 import { useState, FormEvent } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
+type Mode = "login" | "register";
+
 export default function LoginForm() {
+  const [mode, setMode] = useState<Mode>("login");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -13,23 +17,42 @@ export default function LoginForm() {
   const searchParams = useSearchParams();
   const redirect = searchParams.get("redirect") || "/";
 
+  const isRegister = mode === "register";
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError("");
+
+    if (isRegister) {
+      if (password.length < 6) {
+        setError("Password must be at least 6 characters");
+        return;
+      }
+      if (password !== confirmPassword) {
+        setError("Passwords do not match");
+        return;
+      }
+    }
+
     setIsLoading(true);
 
     try {
-      const response = await fetch("/api/auth/login", {
+      const endpoint = isRegister ? "/api/auth/register" : "/api/auth/login";
+      const body = isRegister
+        ? { email, password, confirmPassword }
+        : { email, password };
+
+      const response = await fetch(endpoint, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify(body),
       });
 
       if (!response.ok) {
         const data = await response.json();
-        setError(data.error || "Invalid email or password");
+        setError(data.error || (isRegister ? "Registration failed" : "Invalid email or password"));
         setIsLoading(false);
         return;
       }
@@ -38,10 +61,16 @@ export default function LoginForm() {
       router.push(redirect);
       router.refresh();
     } catch (err) {
-      console.error("Login error:", err);
+      console.error(`${isRegister ? "Registration" : "Login"} error:`, err);
       setError("An error occurred. Please try again.");
       setIsLoading(false);
     }
+  };
+
+  const toggleMode = () => {
+    setMode(isRegister ? "login" : "register");
+    setError("");
+    setConfirmPassword("");
   };
 
   return (
@@ -49,10 +78,12 @@ export default function LoginForm() {
       <div className="max-w-md w-full space-y-8">
         <div>
           <h2 className="mt-6 text-center text-3xl font-bold text-slate-900 dark:text-white">
-            Sign in to continue
+            {isRegister ? "Create an account" : "Sign in to continue"}
           </h2>
           <p className="mt-2 text-center text-sm text-slate-600 dark:text-slate-400">
-            Enter your credentials to access analysis pages
+            {isRegister
+              ? "Sign up to get started"
+              : "Enter your credentials to access analysis pages"}
           </p>
         </div>
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
@@ -82,7 +113,7 @@ export default function LoginForm() {
                 id="password"
                 name="password"
                 type={showPassword ? "text" : "password"}
-                autoComplete="current-password"
+                autoComplete={isRegister ? "new-password" : "current-password"}
                 required
                 className="appearance-none rounded-md relative block w-full px-3 py-2 border border-slate-300 dark:border-slate-700 placeholder-slate-500 dark:placeholder-slate-400 text-slate-900 dark:text-white bg-white dark:bg-slate-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
                 placeholder="Password"
@@ -132,6 +163,25 @@ export default function LoginForm() {
                 )}
               </button>
             </div>
+            {isRegister && (
+              <div>
+                <label htmlFor="confirmPassword" className="sr-only">
+                  Confirm Password
+                </label>
+                <input
+                  id="confirmPassword"
+                  name="confirmPassword"
+                  type={showPassword ? "text" : "password"}
+                  autoComplete="new-password"
+                  required
+                  className="appearance-none rounded-md relative block w-full px-3 py-2 border border-slate-300 dark:border-slate-700 placeholder-slate-500 dark:placeholder-slate-400 text-slate-900 dark:text-white bg-white dark:bg-slate-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                  placeholder="Confirm password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  disabled={isLoading}
+                />
+              </div>
+            )}
           </div>
 
           {error && (
@@ -165,10 +215,28 @@ export default function LoginForm() {
               disabled={isLoading}
               className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
-              {isLoading ? "Signing in..." : "Sign in"}
+              {isLoading
+                ? isRegister
+                  ? "Creating account..."
+                  : "Signing in..."
+                : isRegister
+                  ? "Create account"
+                  : "Sign in"}
             </button>
           </div>
         </form>
+
+        <div className="text-center">
+          <button
+            type="button"
+            onClick={toggleMode}
+            className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-300 transition-colors"
+          >
+            {isRegister
+              ? "Already have an account? Sign in"
+              : "Don\u2019t have an account? Create one"}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -18,6 +18,7 @@ export const ADMIN_ROUTES = ["/admin"];
 export const PUBLIC_API_ROUTES = [
   "/api/auth/login",
   "/api/auth/logout",
+  "/api/auth/register",
 ];
 
 export async function middleware(request: NextRequest) {


### PR DESCRIPTION
## Summary
Adds a self-service account registration flow from the login page. New accounts are created with `has_projections_access = false` by default.

## Changes
- **New**: `web/app/api/auth/register/route.ts` — Public registration API endpoint
  - Email format, password length (≥6), and password confirmation validation
  - Bcrypt hashing (12 rounds) matching existing auth
  - Auto-login on successful registration  
  - 409 on duplicate email
- **Modified**: `web/middleware.ts` — Added `/api/auth/register` to public API routes
- **Modified**: `web/app/login/LoginForm.tsx` — Dual-mode login/register form
  - Toggle link between 'Sign in' and 'Create account' modes
  - Confirm password field in register mode
  - Client-side validation before API call

## Testing
Verified via curl:
- Short password → 400
- Mismatched passwords → 400  
- Invalid email → 400
- Successful registration → 201 (user created with `is_admin: false`, `has_projections_access: false`)
- Duplicate email → 409