### PR TITLE
fix: reset isLoggingOut state after successful sign out

### DIFF
--- a/web/components/Navigation.tsx
+++ b/web/components/Navigation.tsx
@@ -136,6 +136,7 @@ export default function Navigation({ isAuthenticated, isAdmin }: NavigationProps
     setIsLoggingOut(true);
     try {
       await fetch("/api/auth/logout", { method: "POST" });
+      setIsLoggingOut(false);
       router.push("/");
       router.refresh();
     } catch (error) {


### PR DESCRIPTION
## Problem

After signing in → signing out → signing in again, the sign-in button in the nav was stuck displaying **"Signing out..."** indefinitely.

## Root Cause

In `Navigation.tsx`, `handleLogout` sets `isLoggingOut = true` but only resets it in the `catch` block. On a *successful* logout, `setIsLoggingOut(false)` was never called — only `router.push()` and `router.refresh()`.

Since `Navigation` is a client component that **persists across client-side navigations** (never fully unmounted), the stale `true` value carried over. The next time the component re-rendered with `isAuthenticated: true` (after signing back in), the button showed "Signing out..." forever.

## Fix

Added `setIsLoggingOut(false)` in the `try` block before the router navigation calls, so the state is cleanly reset on success — not just on error.