### PR TITLE
Clean up working tree and add Claude Code commands

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,22 @@
+---
+description: Create a pull request for current changes
+---
+Follow these steps to create a pull request:
+
+// turbo
+1. Check out and update the main branch
+`git checkout main && git pull origin main`
+
+2. Create a new feature branch from main
+`git checkout -b <descriptive-branch-name>`
+
+3. Make your changes and commit them
+`git add . && git commit -m "<clear-description-of-changes>"`
+
+// turbo
+4. Push the branch
+`git push -u origin <descriptive-branch-name>`
+
+// turbo
+5. Create the pull request
+`gh pr create --fill`

--- a/.claude/commands/run-analyses.md
+++ b/.claude/commands/run-analyses.md
@@ -1,0 +1,8 @@
+---
+description: Run the full analysis suite
+---
+Follow these steps to run the full analysis suite:
+
+// turbo
+1. Run all analysis scripts
+`source venv/bin/activate && python scripts/run_all_analyses.py`

--- a/.claude/commands/run-scraper.md
+++ b/.claude/commands/run-scraper.md
@@ -1,0 +1,8 @@
+---
+description: Run the full scraping pipeline to update data
+---
+Follow these steps to run the scraping pipeline:
+
+// turbo
+1. Run the Ottoneu scraper
+`source venv/bin/activate && python scripts/ottoneu_scraper.py`

--- a/.claude/commands/run-tests.md
+++ b/.claude/commands/run-tests.md
@@ -1,0 +1,12 @@
+---
+description: Run all tests (Python and Web)
+---
+Follow these steps to run all tests:
+
+// turbo
+1. Run Python tests
+`source venv/bin/activate && python -m pytest`
+
+// turbo
+2. Run Web tests
+`cd web && npm test`

--- a/.claude/commands/start-dev.md
+++ b/.claude/commands/start-dev.md
@@ -1,0 +1,7 @@
+---
+description: Start the Next.js development server
+---
+Follow these steps to start the dev server:
+
+1. Start the development server
+`cd web && npm run dev`

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # VS Code
 .vscode/
 
+# Claude Code worktrees
+.claude/worktrees/
+
 # Python / Backend
 venv/
 __pycache__/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2024-03-13 - [Python Regex Pre-compilation Optimization]
-**Learning:** Python's inline `re.sub` and `re.search` calls recompile their regex patterns on each invocation. While Python has an internal regex cache, pre-compiling the regex object with `re.compile()` at the module level completely avoids this overhead and provides significant performance speedups (around ~30%) when iterating in tight or large data extraction loops, like processing thousands of scraped elements.
-**Action:** When working in data processing pipelines or scraping logic (like `scrape_roster.py` or `name_utils.py`), extract complex regexes or those run inside loops to the module level via `re.compile()`.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2024-03-11 - Bcrypt DoS via Unbounded Password Length
-**Vulnerability:** The `/api/auth/register` and `/api/admin/users` endpoints accepted unbounded password lengths before hashing them with `bcrypt.hash(password, 12)`.
-**Learning:** Bcrypt is computationally expensive by design, scaling with input length. Allowing unbounded password lengths allows attackers to send massive payloads (e.g., 10MB strings), causing CPU exhaustion and leading to an algorithmic Denial of Service (DoS) attack. Additionally, bcrypt typically truncates inputs after 72 bytes, so characters beyond that do not add security anyway.
-**Prevention:** Always enforce a strict maximum length (e.g., 72 characters) on passwords before hashing them with bcrypt or similar algorithms.


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/` to `.gitignore` to prevent agent worktree artifacts from being tracked
- Remove duplicate `.jules/` (lowercase) index entries that conflicted with `.Jules/` on case-insensitive macOS
- Add Claude Code slash command definitions (create-pr, run-analyses, run-scraper, run-tests, start-dev)
- Delete throwaway `scripts/apply_migration.py`

## Test plan
- [x] `git status` shows clean working tree
- [ ] Verify `.claude/worktrees/` no longer appears as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)