### PR TITLE
Fix stat_efficiency inflating kicker projections (closes #231)

### DIFF
--- a/scripts/feature_projections/features/stat_efficiency.py
+++ b/scripts/feature_projections/features/stat_efficiency.py
@@ -47,6 +47,11 @@ class StatEfficiencyFeature(ProjectionFeature):
         nfl_stats_df: pd.DataFrame,
         context: dict[str, Any],
     ) -> Optional[float]:
+        # Kickers have no passing/rushing/receiving stats, so stat_projected_ppg
+        # would be 0 while base_ppg is ~7, producing a -7 delta that breaks projections.
+        if position == "K":
+            return None
+
         if nfl_stats_df.empty:
             return None
 

--- a/scripts/tests/test_feature_projections.py
+++ b/scripts/tests/test_feature_projections.py
@@ -184,6 +184,15 @@ class TestStatEfficiencyFeature:
         result = self.feature.compute("p1", "QB", pd.DataFrame(), nfl_df, {})
         assert result is None
 
+    def test_kicker_returns_none(self):
+        """K position has no passing/rushing/receiving stats — always return None."""
+        nfl_df = make_nfl_stats_df([{
+            "season": 2024, "games_played": 17,
+        }])
+        ctx = {"base_ppg": 7.0}
+        result = self.feature.compute("p1", "K", pd.DataFrame(), nfl_df, ctx)
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # GamesPlayedFeature


### PR DESCRIPTION
Kickers have no passing/rushing/receiving stats, so stat_projected_ppg
was 0 while base_ppg was ~7, producing a -7 delta that caused ~7 MAE.
Return None early for K position so the feature is skipped entirely.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
