### PR TITLE
fix: exclude QB from usage_share feature (#232)

### DIFF
--- a/scripts/feature_projections/features/usage_share.py
+++ b/scripts/feature_projections/features/usage_share.py
@@ -9,8 +9,9 @@ import pandas as pd
 from scripts.feature_projections.features.base import ProjectionFeature
 
 # Which stat represents "usage" for each position
+# QB is excluded: QBs account for nearly all team passing volume,
+# so their share is always ~1.0 with massive swing potential (GH #232)
 USAGE_STAT_BY_POSITION = {
-    "QB": "passing_yards",  # proxy for passing volume
     "RB": "rushing_attempts",
     "WR": "targets",
     "TE": "targets",

--- a/scripts/feature_projections/runner.py
+++ b/scripts/feature_projections/runner.py
@@ -110,11 +110,10 @@ def _compute_team_aggregates(
             total_points = season_df["total_points"].fillna(0).sum()
             season_ppg[season] = float(total_points) / 17.0  # approximate team PPG
 
-            # Aggregate usage stats
+            # Aggregate usage stats (QB excluded from usage_share per GH #232)
             usage_by_season[season] = {
                 "targets": float(season_df["targets"].fillna(0).sum()),
                 "rushing_attempts": float(season_df["rushing_attempts"].fillna(0).sum()),
-                "passing_yards": float(season_df["passing_yards"].fillna(0).sum()),
             }
 
         # Compute offense rating: recency-weighted deviation from league average

--- a/scripts/tests/test_feature_projections.py
+++ b/scripts/tests/test_feature_projections.py
@@ -245,6 +245,60 @@ class TestTeamContextFeature:
 
 
 # ---------------------------------------------------------------------------
+# UsageShareFeature
+# ---------------------------------------------------------------------------
+
+class TestUsageShareFeature:
+    def setup_method(self):
+        self.feature = UsageShareFeature()
+
+    def test_qb_excluded(self):
+        """QB should return None — usage share is not meaningful for QBs (GH #232)."""
+        nfl_df = make_nfl_stats_df([
+            {"season": 2023, "games_played": 17, "passing_yards": 4000},
+            {"season": 2024, "games_played": 17, "passing_yards": 4500},
+        ])
+        ctx = {
+            "base_ppg": 20.0,
+            "team_usage": {
+                2023: {"passing_yards": 4200},
+                2024: {"passing_yards": 4600},
+            },
+        }
+        result = self.feature.compute("p1", "QB", pd.DataFrame(), nfl_df, ctx)
+        assert result is None
+
+    def test_wr_increasing_share_positive_delta(self):
+        """WR with increasing target share should get a positive PPG delta."""
+        nfl_df = make_nfl_stats_df([
+            {"season": 2023, "games_played": 17, "targets": 80},
+            {"season": 2024, "games_played": 17, "targets": 120},
+        ])
+        ctx = {
+            "base_ppg": 12.0,
+            "team_usage": {
+                2023: {"targets": 500},
+                2024: {"targets": 500},
+            },
+        }
+        result = self.feature.compute("p1", "WR", pd.DataFrame(), nfl_df, ctx)
+        assert result is not None
+        assert result > 0  # increasing share → positive delta
+
+    def test_insufficient_data_returns_none(self):
+        """With only 1 season, should return None (need >= 2 for trend)."""
+        nfl_df = make_nfl_stats_df([
+            {"season": 2024, "games_played": 17, "targets": 100},
+        ])
+        ctx = {
+            "base_ppg": 10.0,
+            "team_usage": {2024: {"targets": 500}},
+        }
+        result = self.feature.compute("p1", "WR", pd.DataFrame(), nfl_df, ctx)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
 # Combiner
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #232

## Problem

The `usage_share` feature used `passing_yards` as a QB usage proxy. Since QBs account for nearly all team passing yards, the share was always ~1.0, and small fluctuations created massive PPG swings (v6 QB MAE: 13.08 vs 3.95 for v1 baseline in 2024).

## Fix

**Option 3 from the issue: exclude QB from usage_share entirely.** QBs don't have a meaningful "share" concept the way skill positions do.

- Removed `QB: passing_yards` from `USAGE_STAT_BY_POSITION`
- Removed unused `passing_yards` from team aggregates in `runner.py`
- Added 3 `TestUsageShareFeature` unit tests:
  - QB excluded (core fix validation)
  - WR increasing share → positive delta
  - Insufficient data guard

> Note: The `nfl_stats` table does not have `passing_attempts`, so option 1 (use attempts instead) would require a schema migration. Excluding QB is the cleanest fix.

## Tests

All 32 unit tests pass, all 36 architecture tests pass.