### PR TITLE
feat: add model comparison mode to /projection-accuracy (closes #235)

### DIFF
--- a/web/app/projection-accuracy/AccuracyScatterChart.tsx
+++ b/web/app/projection-accuracy/AccuracyScatterChart.tsx
@@ -12,9 +12,18 @@ import {
 } from "recharts";
 import { BacktestPlayer, Position, POSITION_COLORS } from "@/lib/types";
 
+// Muted secondary palette for compare model (lighter variants)
+const COMPARE_POSITION_COLORS: Record<Position, string> = {
+  QB: "#FCA5A5",
+  RB: "#93C5FD",
+  WR: "#6EE7B7",
+  TE: "#FCD34D",
+  K: "#C4B5FD",
+};
+
 interface TooltipPayload {
   active?: boolean;
-  payload?: Array<{ payload: BacktestPlayer }>;
+  payload?: Array<{ payload: BacktestPlayer & { _model?: string } }>;
 }
 
 function CustomTooltip({ active, payload }: TooltipPayload) {
@@ -26,6 +35,9 @@ function CustomTooltip({ active, payload }: TooltipPayload) {
       <p className="font-bold text-slate-900 dark:text-slate-100">{d.name}</p>
       <p className="text-slate-500 dark:text-slate-400">
         {d.position} · {d.nfl_team}
+        {d._model && (
+          <span className="ml-2 text-xs text-purple-500">({d._model})</span>
+        )}
       </p>
       <div className="mt-2 space-y-1">
         <p>
@@ -60,22 +72,44 @@ function CustomTooltip({ active, payload }: TooltipPayload) {
 interface Props {
   players: BacktestPlayer[];
   selectedPositions: Position[];
+  comparePlayers?: BacktestPlayer[];
+  compareModelName?: string;
+  primaryModelName?: string;
 }
 
 export default function AccuracyScatterChart({
   players,
   selectedPositions,
+  comparePlayers,
+  compareModelName,
+  primaryModelName,
 }: Props) {
   const filtered = players.filter((p) =>
     selectedPositions.includes(p.position as Position)
   );
 
-  const allPpg = filtered.flatMap((p) => [p.projected_ppg, p.actual_ppg]);
+  const filteredCompare = comparePlayers
+    ? comparePlayers.filter((p) => selectedPositions.includes(p.position as Position))
+    : [];
+
+  const allFiltered = [...filtered, ...filteredCompare];
+  const allPpg = allFiltered.flatMap((p) => [p.projected_ppg, p.actual_ppg]);
   const rawMin = allPpg.length > 0 ? Math.min(...allPpg) : 0;
   const rawMax = allPpg.length > 0 ? Math.max(...allPpg) : 20;
   const padding = (rawMax - rawMin) * 0.05;
   const minVal = Math.max(0, rawMin - padding);
   const maxVal = rawMax + padding;
+
+  const hasCompare = filteredCompare.length > 0;
+  const positions = (["QB", "RB", "WR", "TE", "K"] as Position[]).filter((pos) =>
+    selectedPositions.includes(pos)
+  );
+
+  // Tag compare players with model name for tooltip
+  const taggedCompare = filteredCompare.map((p) => ({
+    ...p,
+    _model: compareModelName ?? "Compare",
+  }));
 
   return (
     <div className="w-full h-[500px] bg-slate-50 dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-4">
@@ -121,15 +155,28 @@ export default function AccuracyScatterChart({
           />
           <Tooltip content={<CustomTooltip />} cursor={{ strokeDasharray: "3 3" }} />
           <Legend verticalAlign="top" />
-          {(["QB", "RB", "WR", "TE", "K"] as Position[])
-            .filter((pos) => selectedPositions.includes(pos))
-            .map((pos) => (
+
+          {/* Primary model scatter series */}
+          {positions.map((pos) => (
+            <Scatter
+              key={pos}
+              name={hasCompare ? `${pos} (${primaryModelName ?? "Model A"})` : pos}
+              data={filtered.filter((p) => p.position === pos)}
+              fill={POSITION_COLORS[pos]}
+              opacity={0.8}
+            />
+          ))}
+
+          {/* Compare model scatter series — muted palette */}
+          {hasCompare &&
+            positions.map((pos) => (
               <Scatter
-                key={pos}
-                name={pos}
-                data={filtered.filter((p) => p.position === pos)}
-                fill={POSITION_COLORS[pos]}
-                opacity={0.8}
+                key={`compare-${pos}`}
+                name={`${pos} (${compareModelName ?? "Model B"})`}
+                data={taggedCompare.filter((p) => p.position === pos)}
+                fill={COMPARE_POSITION_COLORS[pos]}
+                opacity={0.7}
+                shape="diamond"
               />
             ))}
         </ScatterChart>

--- a/web/app/projection-accuracy/ProjectionAccuracyClient.tsx
+++ b/web/app/projection-accuracy/ProjectionAccuracyClient.tsx
@@ -32,6 +32,28 @@ const METRICS_COLUMNS: Column[] = [
   { key: "rmse", label: "RMSE", format: "decimal" },
 ];
 
+const DELTA_COLUMNS: Column[] = [
+  { key: "name", label: "Player" },
+  { key: "position", label: "Pos" },
+  { key: "nfl_team", label: "Team" },
+  { key: "proj_a", label: "Model A Proj", format: "decimal" },
+  { key: "proj_b", label: "Model B Proj", format: "decimal" },
+  { key: "delta", label: "Delta (B−A)", format: "decimal" },
+  { key: "abs_delta", label: "|Delta|", format: "decimal" },
+];
+
+interface PlayerDelta {
+  player_id: string;
+  name: string;
+  position: string;
+  nfl_team: string;
+  proj_a: number;
+  proj_b: number;
+  delta: number;
+  abs_delta: number;
+  [key: string]: string | number | null | undefined;
+}
+
 interface Props {
   players: BacktestPlayer[];
   allMetrics: PositionMetrics[];
@@ -39,6 +61,29 @@ interface Props {
   availableSeasons: number[];
   models: ProjectionModel[];
   selectedModelId: string | null;
+  compareModelId: string | null;
+  comparePlayers: BacktestPlayer[] | null;
+  compareMetrics: PositionMetrics[] | null;
+  compareModel: ProjectionModel | null;
+}
+
+// Format a delta value with arrow and sign for display
+function formatDeltaMetric(
+  delta: number,
+  higherIsBetter: boolean
+): { label: string; variant: "positive" | "negative" | "default" } {
+  const improved = higherIsBetter ? delta > 0 : delta < 0;
+  const arrow = delta > 0 ? "↑" : delta < 0 ? "↓" : "→";
+  const sign = delta > 0 ? "+" : "";
+  return {
+    label: `${arrow} ${sign}${delta.toFixed(2)}`,
+    variant:
+      Math.abs(delta) < 0.01
+        ? "default"
+        : improved
+        ? "positive"
+        : "negative",
+  };
 }
 
 export default function ProjectionAccuracyClient({
@@ -48,12 +93,17 @@ export default function ProjectionAccuracyClient({
   availableSeasons,
   models,
   selectedModelId,
+  compareModelId,
+  comparePlayers,
+  compareMetrics,
+  compareModel,
 }: Props) {
   const router = useRouter();
   const [selectedPositions, setSelectedPositions] = useState<Position[]>([
     ...POSITIONS,
   ]);
   const [minGames, setMinGames] = useState(4);
+  const [showCompareDropdown, setShowCompareDropdown] = useState(false);
 
   const togglePosition = (pos: Position) => {
     setSelectedPositions((prev) =>
@@ -73,7 +123,25 @@ export default function ProjectionAccuracyClient({
     if (modelId) {
       params.set("model", modelId);
     }
+    // Drop compare when primary model changes
     router.push(`/projection-accuracy?${params.toString()}`);
+  };
+
+  const handleCompareChange = (compareId: string) => {
+    const params = new URLSearchParams();
+    params.set("season", String(targetSeason));
+    if (selectedModelId) params.set("model", selectedModelId);
+    if (compareId) params.set("compare", compareId);
+    router.push(`/projection-accuracy?${params.toString()}`);
+    setShowCompareDropdown(false);
+  };
+
+  const handleClearCompare = () => {
+    const params = new URLSearchParams();
+    params.set("season", String(targetSeason));
+    if (selectedModelId) params.set("model", selectedModelId);
+    router.push(`/projection-accuracy?${params.toString()}`);
+    setShowCompareDropdown(false);
   };
 
   const rookiePlayers = players.filter(
@@ -94,9 +162,39 @@ export default function ProjectionAccuracyClient({
   );
 
   const overallMetrics = allMetrics[0];
+  const compareOverallMetrics = compareMetrics ? compareMetrics[0] : null;
 
   // Find the selected model for display
   const selectedModel = models.find((m) => m.id === selectedModelId);
+
+  // Build per-player delta table (join on player_id)
+  const playerDeltaRows: PlayerDelta[] = (() => {
+    if (!comparePlayers) return [];
+    const compareMap = new Map(comparePlayers.map((p) => [p.player_id, p]));
+    const rows: PlayerDelta[] = [];
+    for (const p of players) {
+      const c = compareMap.get(p.player_id);
+      if (!c) continue;
+      const delta = c.projected_ppg - p.projected_ppg;
+      rows.push({
+        player_id: p.player_id,
+        name: p.name,
+        position: p.position,
+        nfl_team: p.nfl_team,
+        proj_a: p.projected_ppg,
+        proj_b: c.projected_ppg,
+        delta,
+        abs_delta: Math.abs(delta),
+      });
+    }
+    rows.sort((a, b) => b.abs_delta - a.abs_delta);
+    return rows;
+  })();
+
+  const isCompareMode = !!compareModelId && !!comparePlayers && !!compareOverallMetrics;
+
+  // Models available for the compare dropdown (exclude primary)
+  const compareOptions = models.filter((m) => m.id !== selectedModelId);
 
   return (
     <div className="space-y-8">
@@ -124,7 +222,7 @@ export default function ProjectionAccuracyClient({
         </div>
 
         {models.length > 0 && (
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
             <label
               htmlFor="model-select"
               className="text-sm font-medium text-slate-600 dark:text-slate-300"
@@ -146,74 +244,238 @@ export default function ProjectionAccuracyClient({
                 </option>
               ))}
             </select>
+
+            {/* Compare toggle — only when a primary model is selected */}
+            {selectedModelId && !isCompareMode && !showCompareDropdown && (
+              <button
+                onClick={() => setShowCompareDropdown(true)}
+                className="text-sm px-3 py-2 rounded-lg border border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+              >
+                + Compare
+              </button>
+            )}
+
+            {/* Compare model dropdown */}
+            {selectedModelId && (showCompareDropdown || isCompareMode) && (
+              <div className="flex items-center gap-2">
+                <label
+                  htmlFor="compare-select"
+                  className="text-sm font-medium text-slate-600 dark:text-slate-300"
+                >
+                  vs:
+                </label>
+                <select
+                  id="compare-select"
+                  value={compareModelId || ""}
+                  onChange={(e) => handleCompareChange(e.target.value)}
+                  className="text-sm border border-purple-300 dark:border-purple-700 rounded-lg px-3 py-2 bg-white dark:bg-slate-900 text-slate-900 dark:text-white"
+                >
+                  <option value="">Select compare model…</option>
+                  {compareOptions.map((m) => (
+                    <option key={m.id} value={m.id}>
+                      {m.name}
+                      {m.is_active ? " (active)" : ""}
+                      {m.is_baseline ? " (baseline)" : ""}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={handleClearCompare}
+                  className="text-sm px-2 py-2 rounded-lg border border-slate-300 dark:border-slate-700 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+                  title="Remove comparison"
+                >
+                  ✕
+                </button>
+              </div>
+            )}
           </div>
         )}
       </div>
 
-      {/* Selected model info */}
-      {selectedModel && (
-        <div className="bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg p-4 text-sm">
-          <div className="font-medium text-blue-900 dark:text-blue-100">
-            {selectedModel.name} v{selectedModel.version}
-          </div>
-          {selectedModel.description && (
-            <p className="text-blue-700 dark:text-blue-300 mt-1">
-              {selectedModel.description}
-            </p>
+      {/* Model info banners */}
+      {isCompareMode ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {selectedModel && (
+            <div className="bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg p-4 text-sm">
+              <div className="font-medium text-blue-900 dark:text-blue-100">
+                Model A: {selectedModel.name} v{selectedModel.version}
+              </div>
+              {selectedModel.description && (
+                <p className="text-blue-700 dark:text-blue-300 mt-1">
+                  {selectedModel.description}
+                </p>
+              )}
+            </div>
           )}
-          <div className="text-blue-600 dark:text-blue-400 mt-1">
-            Features: {selectedModel.features.join(", ")}
-          </div>
+          {compareModel && (
+            <div className="bg-purple-50 dark:bg-purple-950 border border-purple-200 dark:border-purple-800 rounded-lg p-4 text-sm">
+              <div className="font-medium text-purple-900 dark:text-purple-100">
+                Model B: {compareModel.name} v{compareModel.version}
+              </div>
+              {compareModel.description && (
+                <p className="text-purple-700 dark:text-purple-300 mt-1">
+                  {compareModel.description}
+                </p>
+              )}
+            </div>
+          )}
         </div>
+      ) : (
+        selectedModel && (
+          <div className="bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg p-4 text-sm">
+            <div className="font-medium text-blue-900 dark:text-blue-100">
+              {selectedModel.name} v{selectedModel.version}
+            </div>
+            {selectedModel.description && (
+              <p className="text-blue-700 dark:text-blue-300 mt-1">
+                {selectedModel.description}
+              </p>
+            )}
+            <div className="text-blue-600 dark:text-blue-400 mt-1">
+              Features: {selectedModel.features.join(", ")}
+            </div>
+          </div>
+        )
       )}
 
-      {/* Summary cards */}
-      <div className="grid grid-cols-2 sm:grid-cols-5 gap-4">
-        <SummaryCard
-          label="Players Backtested"
-          value={String(overallMetrics.count)}
-        />
-        <SummaryCard
-          label="MAE (Mean Abs Error)"
-          value={overallMetrics.mae.toFixed(2)}
-        />
-        <SummaryCard
-          label="Bias (Mean Error)"
-          value={
-            (overallMetrics.bias >= 0 ? "+" : "") +
-            overallMetrics.bias.toFixed(2)
-          }
-          variant={
-            Math.abs(overallMetrics.bias) < 0.2
-              ? "default"
-              : overallMetrics.bias > 0
-              ? "positive"
-              : "negative"
-          }
-        />
-        <SummaryCard
-          label="R² (Correlation)"
-          value={overallMetrics.r2.toFixed(2)}
-          variant={
-            overallMetrics.r2 >= 0.5
-              ? "positive"
-              : overallMetrics.r2 >= 0.25
-              ? "default"
-              : "negative"
-          }
-        />
-        <SummaryCard
-          label="RMSE"
-          value={overallMetrics.rmse.toFixed(2)}
-        />
-      </div>
+      {/* Summary cards — side-by-side in compare mode */}
+      {isCompareMode && compareOverallMetrics ? (
+        <div className="space-y-3">
+          {/* Model A row */}
+          <div>
+            <p className="text-xs font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide mb-2">
+              Model A — {selectedModel?.name}
+            </p>
+            <div className="grid grid-cols-2 sm:grid-cols-5 gap-4">
+              <SummaryCard label="Players Backtested" value={String(overallMetrics.count)} />
+              <SummaryCard label="MAE" value={overallMetrics.mae.toFixed(2)} />
+              <SummaryCard
+                label="Bias"
+                value={(overallMetrics.bias >= 0 ? "+" : "") + overallMetrics.bias.toFixed(2)}
+                variant={Math.abs(overallMetrics.bias) < 0.2 ? "default" : overallMetrics.bias > 0 ? "positive" : "negative"}
+              />
+              <SummaryCard
+                label="R²"
+                value={overallMetrics.r2.toFixed(2)}
+                variant={overallMetrics.r2 >= 0.5 ? "positive" : overallMetrics.r2 >= 0.25 ? "default" : "negative"}
+              />
+              <SummaryCard label="RMSE" value={overallMetrics.rmse.toFixed(2)} />
+            </div>
+          </div>
+
+          {/* Model B row */}
+          <div>
+            <p className="text-xs font-semibold text-purple-600 dark:text-purple-400 uppercase tracking-wide mb-2">
+              Model B — {compareModel?.name}
+            </p>
+            <div className="grid grid-cols-2 sm:grid-cols-5 gap-4">
+              <SummaryCard label="Players Backtested" value={String(compareOverallMetrics.count)} />
+              <SummaryCard label="MAE" value={compareOverallMetrics.mae.toFixed(2)} />
+              <SummaryCard
+                label="Bias"
+                value={(compareOverallMetrics.bias >= 0 ? "+" : "") + compareOverallMetrics.bias.toFixed(2)}
+                variant={Math.abs(compareOverallMetrics.bias) < 0.2 ? "default" : compareOverallMetrics.bias > 0 ? "positive" : "negative"}
+              />
+              <SummaryCard
+                label="R²"
+                value={compareOverallMetrics.r2.toFixed(2)}
+                variant={compareOverallMetrics.r2 >= 0.5 ? "positive" : compareOverallMetrics.r2 >= 0.25 ? "default" : "negative"}
+              />
+              <SummaryCard label="RMSE" value={compareOverallMetrics.rmse.toFixed(2)} />
+            </div>
+          </div>
+
+          {/* Delta row (B − A) */}
+          <div>
+            <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-2">
+              Delta (B − A) — ↓ better for MAE/RMSE/Bias, ↑ better for R²
+            </p>
+            <div className="grid grid-cols-2 sm:grid-cols-5 gap-4">
+              <SummaryCard label="—" value="—" />
+              {(() => {
+                const maeDelta = formatDeltaMetric(compareOverallMetrics.mae - overallMetrics.mae, false);
+                return <SummaryCard label="MAE Δ" value={maeDelta.label} variant={maeDelta.variant} />;
+              })()}
+              {(() => {
+                const biasDelta = formatDeltaMetric(Math.abs(compareOverallMetrics.bias) - Math.abs(overallMetrics.bias), false);
+                return <SummaryCard label="|Bias| Δ" value={biasDelta.label} variant={biasDelta.variant} />;
+              })()}
+              {(() => {
+                const r2Delta = formatDeltaMetric(compareOverallMetrics.r2 - overallMetrics.r2, true);
+                return <SummaryCard label="R² Δ" value={r2Delta.label} variant={r2Delta.variant} />;
+              })()}
+              {(() => {
+                const rmseDelta = formatDeltaMetric(compareOverallMetrics.rmse - overallMetrics.rmse, false);
+                return <SummaryCard label="RMSE Δ" value={rmseDelta.label} variant={rmseDelta.variant} />;
+              })()}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-4">
+          <SummaryCard
+            label="Players Backtested"
+            value={String(overallMetrics.count)}
+          />
+          <SummaryCard
+            label="MAE (Mean Abs Error)"
+            value={overallMetrics.mae.toFixed(2)}
+          />
+          <SummaryCard
+            label="Bias (Mean Error)"
+            value={
+              (overallMetrics.bias >= 0 ? "+" : "") +
+              overallMetrics.bias.toFixed(2)
+            }
+            variant={
+              Math.abs(overallMetrics.bias) < 0.2
+                ? "default"
+                : overallMetrics.bias > 0
+                ? "positive"
+                : "negative"
+            }
+          />
+          <SummaryCard
+            label="R² (Correlation)"
+            value={overallMetrics.r2.toFixed(2)}
+            variant={
+              overallMetrics.r2 >= 0.5
+                ? "positive"
+                : overallMetrics.r2 >= 0.25
+                ? "default"
+                : "negative"
+            }
+          />
+          <SummaryCard
+            label="RMSE"
+            value={overallMetrics.rmse.toFixed(2)}
+          />
+        </div>
+      )}
 
       {/* Per-position breakdown */}
       <section>
         <h2 className="text-xl font-semibold text-slate-900 dark:text-white mb-3">
           Metrics by Position
         </h2>
-        <DataTable columns={METRICS_COLUMNS} data={allMetrics} />
+        {isCompareMode && compareMetrics ? (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div>
+              <p className="text-xs font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide mb-2">
+                Model A — {selectedModel?.name}
+              </p>
+              <DataTable columns={METRICS_COLUMNS} data={allMetrics} />
+            </div>
+            <div>
+              <p className="text-xs font-semibold text-purple-600 dark:text-purple-400 uppercase tracking-wide mb-2">
+                Model B — {compareModel?.name}
+              </p>
+              <DataTable columns={METRICS_COLUMNS} data={compareMetrics} />
+            </div>
+          </div>
+        ) : (
+          <DataTable columns={METRICS_COLUMNS} data={allMetrics} />
+        )}
       </section>
 
       {/* Scatter chart */}
@@ -228,8 +490,36 @@ export default function ProjectionAccuracyClient({
         <AccuracyScatterChart
           players={players}
           selectedPositions={selectedPositions}
+          comparePlayers={comparePlayers ?? undefined}
+          compareModelName={compareModel?.name}
+          primaryModelName={selectedModel?.name}
         />
       </section>
+
+      {/* Per-player delta table — compare mode only */}
+      {isCompareMode && playerDeltaRows.length > 0 && (
+        <section>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-white mb-3">
+            Per-Player Projection Delta
+          </h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400 mb-4">
+            Delta = Model B projected PPG − Model A projected PPG. Sorted by absolute delta descending.
+            Rows highlighted where |Delta| ≥ 1.0 PPG.
+          </p>
+          <DataTable
+            columns={DELTA_COLUMNS}
+            data={playerDeltaRows as unknown as TableRow[]}
+            highlightRules={[
+              {
+                key: "abs_delta",
+                op: "gte",
+                value: 1.0,
+                className: "bg-amber-50 dark:bg-amber-950",
+              },
+            ]}
+          />
+        </section>
+      )}
 
       {/* Filters + error table */}
       <section>

--- a/web/app/projection-accuracy/page.tsx
+++ b/web/app/projection-accuracy/page.tsx
@@ -1,6 +1,6 @@
 import { fetchBacktestData, fetchAvailableModels, fetchModelBacktestData } from "@/lib/analysis";
 import { calculateMetricsByPosition } from "./metrics";
-import { POSITIONS } from "@/lib/types";
+import { POSITIONS, BacktestPlayer, ProjectionModel } from "@/lib/types";
 import ProjectionAccuracyClient from "./ProjectionAccuracyClient";
 
 export const revalidate = 3600;
@@ -8,7 +8,7 @@ export const revalidate = 3600;
 const AVAILABLE_SEASONS = [2024, 2025];
 
 interface Props {
-  searchParams: Promise<{ season?: string; model?: string }>;
+  searchParams: Promise<{ season?: string; model?: string; compare?: string }>;
 }
 
 export default async function ProjectionAccuracyPage({ searchParams }: Props) {
@@ -19,6 +19,7 @@ export default async function ProjectionAccuracyPage({ searchParams }: Props) {
     : 2025;
 
   const selectedModelId = params.model || null;
+  const compareModelId = params.compare || null;
 
   // Fetch available models (may be empty if migration hasn't been applied)
   let models: Awaited<ReturnType<typeof fetchAvailableModels>> = [];
@@ -28,15 +29,33 @@ export default async function ProjectionAccuracyPage({ searchParams }: Props) {
     // Table doesn't exist yet — fall back to legacy mode
   }
 
-  // Fetch backtest data — use model-specific fetch if a model is selected
-  let players;
+  // Fetch primary and compare data in parallel when applicable
+  let players: BacktestPlayer[];
+  let comparePlayers: BacktestPlayer[] | null = null;
+  let compareModel: ProjectionModel | null = null;
+
   if (selectedModelId && models.length > 0) {
-    players = await fetchModelBacktestData(targetSeason, selectedModelId);
+    const comparePromise = compareModelId
+      ? fetchModelBacktestData(targetSeason, compareModelId)
+      : null;
+
+    const [primaryData, compareData] = await Promise.all([
+      fetchModelBacktestData(targetSeason, selectedModelId),
+      comparePromise,
+    ]);
+    players = primaryData;
+    comparePlayers = compareData;
+    compareModel = compareModelId
+      ? (models.find((m) => m.id === compareModelId) ?? null)
+      : null;
   } else {
     players = await fetchBacktestData(targetSeason);
   }
 
   const allMetrics = calculateMetricsByPosition(players, POSITIONS);
+  const compareMetrics = comparePlayers
+    ? calculateMetricsByPosition(comparePlayers, POSITIONS)
+    : null;
 
   return (
     <main className="min-h-screen bg-white dark:bg-black p-8">
@@ -103,6 +122,10 @@ export default async function ProjectionAccuracyPage({ searchParams }: Props) {
             availableSeasons={AVAILABLE_SEASONS}
             models={models}
             selectedModelId={selectedModelId}
+            compareModelId={compareModelId}
+            comparePlayers={comparePlayers}
+            compareMetrics={compareMetrics}
+            compareModel={compareModel}
           />
         )}
       </div>


### PR DESCRIPTION
Extends the projection accuracy page with side-by-side model comparison:
- New `?compare=<modelId>` URL param activates compare mode alongside existing `?model=`
- Parallel server-side fetches for both model datasets
- "+ Compare" toggle button with second model dropdown (purple-accented)
- Side-by-side model info banners (blue = Model A, purple = Model B)
- Three-row summary card layout: Model A metrics, Model B metrics, and delta row
  with ↑/↓ arrows and positive/negative coloring (↓ better for MAE/RMSE, ↑ for R²)
- Position breakdown tables shown side-by-side in compare mode
- AccuracyScatterChart overlays both datasets: primary uses POSITION_COLORS,
  compare uses muted variants; legend shows both model names per position
- Per-player delta table (joined on player_id, sorted by |delta| desc,
  highlights rows where |delta| ≥ 1.0 PPG)
- Single-model mode unchanged

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
