### PR TITLE
feat: add expandable feature breakdown to per-player backtest table

### DIFF
--- a/web/app/projection-accuracy/FeatureBreakdown.tsx
+++ b/web/app/projection-accuracy/FeatureBreakdown.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+interface FeatureBreakdownProps {
+  featureValues: Record<string, number | null>;
+  projectedPpg: number;
+}
+
+export default function FeatureBreakdown({
+  featureValues,
+  projectedPpg,
+}: FeatureBreakdownProps) {
+  const entries = Object.entries(featureValues).filter(
+    ([, v]) => v != null
+  ) as [string, number][];
+
+  if (entries.length === 0) return null;
+
+  // Use max absolute value among features as bar scale reference
+  const maxAbs = Math.max(...entries.map(([, v]) => Math.abs(v)), 0.01);
+
+  return (
+    <div className="px-4 py-3 bg-slate-50 dark:bg-slate-900 border-t border-slate-100 dark:border-slate-800">
+      <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-2">
+        Feature Breakdown — Proj PPG: {projectedPpg.toFixed(2)}
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-1.5">
+        {entries.map(([feature, value]) => {
+          const barPct = Math.abs(value) / maxAbs;
+          const isPositive = value >= 0;
+          return (
+            <div key={feature} className="flex flex-col gap-0.5">
+              <div className="flex justify-between items-center text-xs">
+                <span className="text-slate-600 dark:text-slate-300 font-mono">
+                  {feature.replace(/_/g, " ")}
+                </span>
+                <span
+                  className={`font-semibold tabular-nums ${
+                    isPositive
+                      ? "text-green-700 dark:text-green-400"
+                      : "text-red-600 dark:text-red-400"
+                  }`}
+                >
+                  {isPositive ? "+" : ""}
+                  {value.toFixed(2)}
+                </span>
+              </div>
+              {/* Bar */}
+              <div className="relative h-1.5 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden">
+                <div
+                  className={`absolute top-0 h-full rounded-full ${
+                    isPositive
+                      ? "bg-green-500 dark:bg-green-400 left-0"
+                      : "bg-red-500 dark:bg-red-400 right-0"
+                  }`}
+                  style={{ width: `${(barPct * 100).toFixed(1)}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/app/projection-accuracy/ProjectionAccuracyClient.tsx
+++ b/web/app/projection-accuracy/ProjectionAccuracyClient.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { BacktestPlayer, Position, POSITIONS, ProjectionModel, TableRow } from "@/lib/types";
 import { calculateMetrics, PositionMetrics } from "./metrics";
 import AccuracyScatterChart from "./AccuracyScatterChart";
+import FeatureBreakdown from "./FeatureBreakdown";
 import DataTable, { Column } from "@/components/DataTable";
 import PositionFilter from "@/components/PositionFilter";
 import SummaryCard from "@/components/SummaryCard";
@@ -565,6 +566,20 @@ export default function ProjectionAccuracyClient({
               className: "bg-red-50 dark:bg-red-950",
             },
           ]}
+          renderExpandedRow={
+            filteredPlayers.some((p) => p.feature_values)
+              ? (row) => {
+                  const p = row as unknown as BacktestPlayer;
+                  if (!p.feature_values) return null;
+                  return (
+                    <FeatureBreakdown
+                      featureValues={p.feature_values}
+                      projectedPpg={p.projected_ppg}
+                    />
+                  );
+                }
+              : undefined
+          }
         />
       </section>
 

--- a/web/components/DataTable.tsx
+++ b/web/components/DataTable.tsx
@@ -11,6 +11,7 @@ interface DataTableProps<T extends TableRow = TableRow> {
   data: T[];
   highlightRow?: (row: T) => string | undefined;
   highlightRules?: HighlightRule[];
+  renderExpandedRow?: (row: T) => React.ReactNode;
 }
 
 function applyRules<T extends TableRow>(row: T, rules: HighlightRule[]): string | undefined {
@@ -39,9 +40,20 @@ export default function DataTable<T extends TableRow = TableRow>({
   data,
   highlightRow,
   highlightRules,
+  renderExpandedRow,
 }: DataTableProps<T>) {
   const [sortKey, setSortKey] = useState<string | null>(null);
   const [sortAsc, setSortAsc] = useState(true);
+  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
+
+  const toggleExpanded = (i: number) => {
+    setExpandedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      return next;
+    });
+  };
 
   const handleSort = (key: string) => {
     if (sortKey === key) {
@@ -85,6 +97,9 @@ export default function DataTable<T extends TableRow = TableRow>({
       <table className="min-w-full text-sm">
         <thead>
           <tr className="bg-slate-100 dark:bg-slate-800">
+            {renderExpandedRow && (
+              <th className="px-2 py-2 w-6" aria-label="expand" />
+            )}
             {columns.map((col) => (
               <th
                 key={col.key}
@@ -122,25 +137,43 @@ export default function DataTable<T extends TableRow = TableRow>({
             const highlight =
               highlightRow?.(row) ??
               (highlightRules ? applyRules(row, highlightRules) : undefined);
+            const isExpanded = expandedRows.has(i);
+            const rowBg =
+              highlight ??
+              (i % 2 === 0
+                ? "bg-white dark:bg-slate-950"
+                : "bg-slate-50 dark:bg-slate-900");
             return (
-              <tr
-                key={i}
-                className={`border-t border-slate-100 dark:border-slate-800 ${
-                  highlight ??
-                  (i % 2 === 0
-                    ? "bg-white dark:bg-slate-950"
-                    : "bg-slate-50 dark:bg-slate-900")
-                }`}
-              >
-                {columns.map((col) => (
-                  <td
-                    key={col.key}
-                    className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap"
-                  >
-                    {formatCell(row[col.key], col.format)}
-                  </td>
-                ))}
-              </tr>
+              <>
+                <tr
+                  key={i}
+                  className={`border-t border-slate-100 dark:border-slate-800 ${rowBg} ${
+                    renderExpandedRow ? "cursor-pointer hover:brightness-95" : ""
+                  }`}
+                  onClick={renderExpandedRow ? () => toggleExpanded(i) : undefined}
+                >
+                  {renderExpandedRow && (
+                    <td className="px-2 py-2 text-slate-400 dark:text-slate-500 text-xs select-none">
+                      {isExpanded ? "▼" : "▶"}
+                    </td>
+                  )}
+                  {columns.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap"
+                    >
+                      {formatCell(row[col.key], col.format)}
+                    </td>
+                  ))}
+                </tr>
+                {renderExpandedRow && isExpanded && (
+                  <tr key={`${i}-expanded`} className={rowBg}>
+                    <td colSpan={columns.length + 1} className="p-0">
+                      {renderExpandedRow(row)}
+                    </td>
+                  </tr>
+                )}
+              </>
             );
           })}
         </tbody>


### PR DESCRIPTION
## Summary
- Adds a `FeatureBreakdown` component that renders per-feature contributions (signed value + proportional bar) for any player with `feature_values`
- Extends `DataTable` with a generic `renderExpandedRow` prop — when provided, rows become clickable and toggle an inline expanded section (▶/▼ chevron)
- Wires up `FeatureBreakdown` in `ProjectionAccuracyClient` for the per-player errors table; rows without `feature_values` gracefully show nothing

## Test plan
- [x] All Python tests pass (138)
- [x] All web tests pass (97)
- [ ] Verify feature breakdown renders correctly for a model run that populates `feature_values` in `model_projections`
- [ ] Verify rows without `feature_values` (legacy mode) have no expand indicator

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)