### PR TITLE
retro: document local TypeScript type-check command and npm run build limitation

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -12,6 +12,16 @@
 - **Config:** `web/jest.config.ts`
 - **Run:** `npm test` from `web/`
 
+### TypeScript type-checking
+
+Use `tsc --noEmit` for local type-checking — **do not use `npm run build`** for this purpose:
+
+```bash
+cd web && ./node_modules/.bin/tsc --noEmit
+```
+
+`npm run build` requires `config.json` (present in CI/production, absent in local dev) and will fail with a "Module not found" error unrelated to your changes.
+
 ## Structural / Architectural Tests
 
 Harness engineering tests that enforce architectural rules mechanically. Each test failure includes a teaching message with the fix.


### PR DESCRIPTION
## Summary

Triggered by retro on #255 (feature breakdown for per-player backtest table).

## Friction points addressed

| # | What happened | Category | Root cause | Fix |
|---|--------------|----------|------------|-----|
| 1 | `npm run build` failed locally with unrelated "Module not found: config.json" error | `missing-docs` | No note that build requires config.json absent in local dev | Add note to TESTING.md |
| 2 | `npx tsc` installed a wrong package; needed `./node_modules/.bin/tsc --noEmit` | `missing-docs` | Correct type-check command not documented | Document exact command |

## Files changed

- **`docs/TESTING.md`** — added a "TypeScript type-checking" sub-section under Web Tests explaining that `npm run build` is not usable locally and the correct command is `./node_modules/.bin/tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)