### PR TITLE
retro: document external source pitfalls and add lxml dependency guard

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,3 +107,9 @@ python scripts/feature_projections/external_sources/ingest_external.py \
 ```
 
 Model name: `external_fantasypros_v1`. No DB schema changes required — uses existing `model_projections` table with `feature_values` jsonb for raw stat storage.
+
+**Adding a new external model — checklist:**
+1. **Verify column names before writing parsers.** FP HTML uses multi-level headers; always test-fetch one position and print `df.columns` before finalizing column mappings. The actual flattened names (e.g. `passing_yds`, `receiving_rec`) differ from the raw header labels (`YDS`, `REC`).
+2. **Deduplicate by `player_id` before upserting.** Fuzzy name matching can map two different source rows to the same `player_id`. Postgres's `ON CONFLICT DO UPDATE` rejects duplicate keys within the same batch — deduplicate first.
+3. **Register in `model_config.py`.** `accuracy_report.py` iterates `MODELS` in `model_config.py` to build comparison tables. External models must be added there (with `features=["external"]`) to appear in the report.
+4. **Ensure `lxml` is installed.** `pandas.read_html` requires `lxml` as its HTML parser. It is in `requirements.txt` but must be explicitly installed (`pip install lxml`) if the venv was created before it was added.

--- a/scripts/feature_projections/external_sources/ingest_external.py
+++ b/scripts/feature_projections/external_sources/ingest_external.py
@@ -16,6 +16,16 @@ import json
 import os
 import sys
 
+try:
+    import lxml  # noqa: F401 — required by pandas.read_html for HTML parsing
+except ImportError:
+    print(
+        "ERROR: lxml is required but not installed.\n"
+        "Run: pip install lxml\n"
+        "(It is listed in requirements.txt — re-run pip install -r requirements.txt)"
+    )
+    sys.exit(1)
+
 import pandas as pd
 
 # Setup paths so imports work when run directly from repo root or this dir


### PR DESCRIPTION
## Summary

Retrospective on the FantasyPros ingestion task (PR #260). Four friction points encountered during implementation, three of which are preventable in future external source work.

## Friction points

| # | What happened | Category | Root cause | Fix |
|---|---------------|----------|------------|-----|
| 1 | `lxml not found` at runtime despite being in `requirements.txt` | `agent-error` | Didn't verify venv state before running | Added `ImportError` guard in `ingest_external.py` with a clear `pip install lxml` message |
| 2 | `ON CONFLICT DO UPDATE` error — two FP players fuzzy-matched to same `player_id` | `agent-error` | Didn't anticipate fuzzy matching producing duplicate player_ids in one batch | Already fixed in PR #260; documented as a required pattern in ARCHITECTURE.md |
| 3 | All `projected_ppg` stored as `0.0` — column mapping used `"yds"` but actual flattened names were `"passing_yds"` | `agent-error` | Wrote column mapping without test-fetching a sample page first | Documented: always print `df.columns` from a live fetch before finalizing parsers |
| 4 | `accuracy_report.py` silently excluded FantasyPros — had to add it to `model_config.py` | `missing-docs` | Architecture doc didn't note that external models must be in `MODELS` to appear in reports | Documented in ARCHITECTURE.md external sources checklist |

## Files changed

- **`docs/ARCHITECTURE.md`** — Added 4-point checklist under External Projection Sources: column name verification, deduplication requirement, `model_config.py` registration, and `lxml` install requirement
- **`scripts/feature_projections/external_sources/ingest_external.py`** — Added `lxml` import guard with actionable error message instead of a cryptic pandas traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)