### PR TITLE
docs: projection system runbook and updated architecture docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,8 +46,13 @@ Each task type lives in its own module. `__init__.py` defines task type constant
 `scripts/run_all_analyses.py` orchestrates analysis in dependency order:
 
 ```
+feature projection system
+        │ promote.py → player_projections table
+        ▼
 update projections → projected salary → VORP → surplus value → arbitration → arbitration simulation → projected arbitration
 ```
+
+The feature projection system (see below) generates per-player PPG projections and stores them in `model_projections`. `promote.py` copies the active model's projections into `player_projections`, which is what the analysis pipeline reads.
 
 Shared config and DB helpers in `scripts/analysis_utils.py`. Five analysis scripts produce markdown reports in `reports/` (gitignored). VORP and surplus value expose `calculate_vorp()` and `calculate_surplus()` for import by downstream scripts. Arbitration simulation uses Monte Carlo methods to predict opponent spending patterns (100 runs with ±20% value variation per team).
 

--- a/docs/exec-plans/feature-projections.md
+++ b/docs/exec-plans/feature-projections.md
@@ -1,10 +1,14 @@
 # Feature-Based Player Projection System
 
-## Status: Phase 1-2 Complete (Foundation + Framework)
+## Status: Complete (Phases 1–3) | Phase 4 Deferred
+
+---
 
 ## Overview
 
 Iterative, ML-like framework for building PPG projections from composable features. Each feature computes a PPG-scale value, and a combiner aggregates them into a final projection. Models are versioned and tracked in the database so accuracy can be compared across model versions.
+
+---
 
 ## Architecture
 
@@ -18,48 +22,193 @@ scripts/feature_projections/
     games_played.py      # Availability/durability adjustment
     team_context.py      # Team offense quality adjustment
     usage_share.py       # Target/touch/attempt share projection
+  external_sources/
+    fantasypros_fetcher.py  # Scrape FP consensus projections
+    scoring.py              # Stat-line → Ottoneu PPG
+    player_matcher.py       # Fuzzy name matching to players table
+    ingest_external.py      # Register + upsert external model
   combiner.py            # Weighted addition of feature outputs → final PPG
-  model_config.py        # Model definitions (v1-v6)
+  model_config.py        # Model definitions (v1-v6 + external)
   runner.py              # Generate projections, upsert to model_projections
   backtest.py            # Compare to actuals, store in backtest_results
+  accuracy_report.py     # Markdown comparison table across all models/seasons
   promote.py             # Copy model_projections → player_projections
   cli.py                 # CLI: run, backtest, compare, promote, list
 ```
 
+---
+
 ## Database Tables
 
-- `projection_models` — Model registry (name, version, features, config)
-- `model_projections` — Per-model projections (model_id × player_id × season)
+- `projection_models` — Model registry (name, version, features, config, is_baseline, is_active)
+- `model_projections` — Per-model projections (model_id × player_id × season), with `feature_values` jsonb for audit
 - `backtest_results` — Cached accuracy metrics (model_id × season × position)
 
-## Models (v1-v6)
+See `docs/generated/db-schema.md` for full column details.
+
+---
+
+## Models (v1–v6 + external)
 
 | Model | Features | Description |
 |-------|----------|-------------|
-| v1_baseline_weighted_ppg | weighted_ppg | Exact port of existing system (control baseline) |
-| v2_age_adjusted | + age_curve | Positional aging adjustment |
-| v3_stat_weighted | + stat_efficiency | Per-stat projection from nfl_stats |
-| v4_availability_adjusted | + games_played | Injury/availability discount |
-| v5_team_context | + team_context | Team offensive quality boost/penalty |
-| v6_usage_share | + usage_share | Target/touch share trend |
+| `v1_baseline_weighted_ppg` _(baseline)_ | weighted_ppg | Exact port of existing system |
+| `v2_age_adjusted` | + age_curve | Positional aging adjustment |
+| `v3_stat_weighted` | + stat_efficiency | Per-stat projection from nfl_stats |
+| `v4_availability_adjusted` | + games_played | Injury/availability discount |
+| `v5_team_context` | + team_context | Team offensive quality boost/penalty |
+| `v6_usage_share` | + usage_share | Target/touch share trend |
+| `external_fantasypros_v1` | external | FantasyPros consensus (industry benchmark) |
 
-## Frontend
+---
 
-The `/projection-accuracy` page has a model selector dropdown. When a model is selected, backtest data comes from `model_projections` instead of `player_projections`.
+## Backtest Findings (2022–2025, all seasons combined)
 
-## Adding a New Feature
+Run on 844 player-seasons per internal model, 766 for FantasyPros (player matching coverage).
 
-1. Create `scripts/feature_projections/features/your_feature.py` (implement `ProjectionFeature`)
-2. Register in `features/__init__.py` FEATURE_REGISTRY
-3. Write tests in `scripts/tests/test_feature_projections.py`
-4. Define new model in `model_config.py`
-5. Run: `python scripts/feature_projections/cli.py run --model vX --seasons 2024,2025`
-6. Backtest: `python scripts/feature_projections/cli.py backtest --model vX --test-seasons 2024`
-7. Compare: `python scripts/feature_projections/cli.py compare --models v1_baseline_weighted_ppg,vX --season 2024`
-8. Promote if better: `python scripts/feature_projections/cli.py promote --model vX`
+### Overall (all positions)
 
-## Next Steps
+| Model | MAE | Bias | R² |
+|-------|-----|------|----|
+| `v1_baseline_weighted_ppg` _(baseline)_ | 2.677 | −0.385 | 0.470 |
+| **`v2_age_adjusted`** | **2.615** | −0.408 | **0.489** |
+| `v3_stat_weighted` | 2.993 | −0.154 | 0.340 |
+| `v4_availability_adjusted` | 3.005 | +0.342 | 0.328 |
+| `v5_team_context` | 3.405 | −0.519 | 0.202 |
+| `v6_usage_share` | 3.995 | −1.186 | −0.267 |
+| `external_fantasypros_v1` | **2.607** | +1.317 | **0.561** |
 
-- **Phase 3**: Run models v1-v6, backtest, compare accuracy by position
-- **Phase 4**: Model comparison UI (side-by-side metrics, feature value breakdown)
-- **Phase 5**: Production integration (promote command, update downstream pipeline)
+### By position (combined seasons)
+
+| Position | Best internal | MAE | FP MAE | FP R² |
+|----------|--------------|-----|--------|-------|
+| QB | v1/v2 (tie) | 4.025 | 4.083 | 0.176 |
+| RB | v2 | 3.047 | **2.778** | 0.525 |
+| WR | v2 | 2.474 | **2.189** | 0.405 |
+| TE | v2 | 1.794 | **1.630** | 0.563 |
+| K | v1/v2 (tie) | 1.421 | — | — |
+
+### Key conclusions
+
+1. **v2_age_adjusted is the best internal model.** Age curve is the only feature that reliably improves over the baseline. Every subsequent feature (v3–v6) adds noise, not signal, when evaluated on MAE.
+
+2. **FantasyPros beats all internal models** on MAE and R² overall (2.607 vs 2.615 for v2), and by a meaningful margin on RB, WR, and TE. Use it as the industry-standard benchmark.
+
+3. **v6_usage_share is the worst model** (MAE 3.995, R² −0.267). The usage share trend signal introduces too much variance, particularly on WRs (R² −1.929). Do not promote.
+
+4. **QBs are the hardest position to project.** All models sit at MAE ~4.0. FantasyPros is no better (4.083). Underlying cause: large high-variance tail from injury, benching, and breakout seasons.
+
+5. **Kicker projections are essentially random** (all models R² < 0). The weighted PPG baseline is as good as anything else for K. Don't invest in kicker-specific features.
+
+6. **FP over-projects by +1.3 PPG on average** (positive bias = model projects higher than actual). Draft-time consensus projections are optimistic — factor this in when using FP projections for roster decisions.
+
+---
+
+## Tuning Recommendations
+
+### Short-term (low effort, high value)
+
+- **Promote v2_age_adjusted** as the active production model. It consistently beats v1 on every position except K.
+- **Use FantasyPros as the forward projection** for 2026 (once available) rather than relying on v2. Re-run `ingest_external.py --seasons 2026` in late July when FP publishes preseason consensus.
+- **Discount FP projections by ~1.3 PPG** for top-projected players (or apply position-specific bias correction: QB −2.5, RB −1.2, WR −0.7, TE −0.9).
+
+### Medium-term (new features worth exploring)
+
+- **Snap share** — more predictive than target share for WRs, less volatile than usage_share trend. Snap data is already in `nfl_stats.offense_snaps`.
+- **Contract year effect** — players in walk-year seasons show small positive PPG boost (~0.3 PPG). Could be implemented as a binary flag from `league_prices` salary data.
+- **Breakout/regression detection** — flag players whose most recent season PPG is ±2σ from their 3-year trend. Weight prior seasons more heavily for likely-regression candidates.
+
+### Do not pursue
+
+- **QB usage share** — excluded from v6 (GH #232) because QB pass volume share is always ~1.0 per team, making the signal meaningless. No further work warranted.
+- **Kicker-specific features** — R² is negative for all models. Kicker scoring is too random relative to sample sizes.
+- **v3 stat_efficiency / v4 games_played / v5 team_context as additive features** — individually they may have value, but their interaction in the combiner adds noise. If re-exploring, test each in isolation against v1, not stacked.
+
+---
+
+## Runbook: Adding a New Internal Feature
+
+### Step-by-step
+
+1. **Create the feature file**
+   ```
+   scripts/feature_projections/features/your_feature.py
+   ```
+   Implement `ProjectionFeature` (see `base.py`). Key decisions:
+   - `is_base = True` → returns absolute PPG (only `weighted_ppg` should do this)
+   - `is_base = False` → returns a PPG delta (positive = boost, negative = penalty)
+   - Return `None` to skip this feature for a player (combiner will treat it as 0 delta)
+
+2. **Register in FEATURE_REGISTRY**
+   ```python
+   # features/__init__.py
+   from scripts.feature_projections.features.your_feature import YourFeature
+   FEATURE_REGISTRY["your_feature"] = YourFeature
+   ```
+
+3. **Write tests**
+   ```
+   scripts/tests/test_feature_projections.py
+   ```
+   At minimum: test `compute()` returns a float or None, test edge cases (empty history, missing context keys).
+
+4. **Define a new model in `model_config.py`**
+   ```python
+   "v7_your_feature": ModelDefinition(
+       name="v7_your_feature",
+       version=1,
+       description="...",
+       features=["weighted_ppg", "age_curve", "your_feature"],
+   )
+   ```
+   Build incrementally on v2 (the current best model), not v6.
+
+5. **Generate projections**
+   ```bash
+   python scripts/feature_projections/cli.py run \
+       --model v7_your_feature --seasons 2022,2023,2024,2025
+   ```
+
+6. **Backtest and compare**
+   ```bash
+   python scripts/feature_projections/cli.py backtest \
+       --model v7_your_feature --test-seasons 2022,2023,2024,2025
+
+   python scripts/feature_projections/accuracy_report.py --seasons 2022,2023,2024,2025
+   ```
+   The new model will appear in the report alongside all others.
+
+7. **Promote if better than v2 overall**
+   ```bash
+   python scripts/feature_projections/cli.py promote --model v7_your_feature
+   ```
+   This copies projections to `player_projections`, which feeds the analysis pipeline.
+
+### Common pitfalls
+
+**Kicker handling**
+- Kickers (`position = "K"`) have no rushing, receiving, or passing stats in `nfl_stats`. Most features will naturally return `None` for kickers, which is correct — the combiner falls back to the base PPG. Do not add kicker-specific branches to features; just ensure `None` is returned gracefully when the needed stats are missing.
+
+**QB usage metrics**
+- QBs account for essentially 100% of a team's pass volume, so any target/pass-attempt share calculation for QBs is always ~1.0 with high noise. The `usage_share` feature explicitly excludes QBs via `USAGE_STAT_BY_POSITION` (which has no `QB` entry). If you build a feature using team-level volume metrics, follow the same pattern: skip QBs or use a QB-specific signal (e.g., pass attempt volume vs. league average, not share).
+
+**Adjustment feature scale**
+- Adjustment features return PPG *deltas*, not absolute values. A delta of +2.0 for a player projecting 8 PPG is a 25% boost — probably too large. Keep deltas within ±20% of `base_ppg` to avoid one feature dominating the combiner. Check with `context.get("base_ppg")` before scaling.
+
+**Sparse history**
+- Always guard for `history_df.empty` and `len(history_df) < N`. Rookies and players with limited data will trigger these. Return `None` rather than imputing or using a default — the combiner handles `None` gracefully.
+
+**Recency weights**
+- The standard recency weight pattern is `[0.60, 0.25, 0.15]` for 3 seasons (most recent first). Use `weights[:n]` then re-normalize if fewer seasons are available: `weights = [w / sum(weights[:n]) for w in weights[:n]]`.
+
+---
+
+## Phase Status
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Phase 1: Foundation (tables, base class, runner) | ✅ Complete | |
+| Phase 2: Features v1–v6 + CLI | ✅ Complete | |
+| Phase 3: Backtest + accuracy report + external benchmark | ✅ Complete | FantasyPros ingested 2022–2025 |
+| Phase 4: Model comparison UI | Deferred | Low ROI given backtest results; v2 dominates |
+| Phase 5: Production integration | In progress | v2 should be promoted; run `promote --model v2_age_adjusted` |

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -1,6 +1,6 @@
 # Database Schema
 
-Eleven tables, all with UUID primary keys.
+Fourteen tables, all with UUID primary keys.
 
 ## Tables
 
@@ -13,10 +13,42 @@ Eleven tables, all with UUID primary keys.
 | `league_prices` | Current salaries (FK -> `players`) | `(player_id, league_id)` |
 | `transactions` | Event log of all roster moves (adds, cuts, trades, auctions) | -- |
 | `surplus_adjustments` | Manual value overrides per player per league per user (FK -> `players`, `users`) | `(player_id, league_id, user_id)` |
-| `player_projections` | Calculated projection outputs from Python backend | `(player_id, season)` |
+| `player_projections` | Active projection outputs promoted from `model_projections` (FK -> `players`) | `(player_id, season)` |
 | `arbitration_plans` | Named arbitration budget allocation plans per user (FK -> `users`) | `(league_id, name, user_id)` |
 | `arbitration_plan_allocations` | Per-player dollar allocations within a plan (FK -> `arbitration_plans`, `players`) | `(plan_id, player_id)` |
 | `scraper_jobs` | Persistent job queue with status tracking, dependencies, and retry logic | -- |
+| `projection_models` | Registry of versioned projection models (internal v1–v6 and external sources) | `(name, version)` |
+| `model_projections` | Per-model projected PPG with raw feature values (FK -> `projection_models`, `players`) | `(model_id, player_id, season)` |
+| `backtest_results` | Cached accuracy metrics per model × season × position (FK -> `projection_models`) | `(model_id, season, position)` |
+
+### Projection tables detail
+
+**`projection_models`**
+- `id` UUID PK
+- `name` text — model identifier (e.g. `v2_age_adjusted`, `external_fantasypros_v1`)
+- `version` int — version number
+- `description` text
+- `features` jsonb — list of feature names used
+- `config` jsonb — weight configuration
+- `is_baseline` bool — marks the v1 control model
+- `is_active` bool — whether this model's projections are promoted to `player_projections`
+
+**`model_projections`**
+- `model_id` UUID FK -> `projection_models`
+- `player_id` UUID FK -> `players`
+- `season` int
+- `projected_ppg` float
+- `feature_values` jsonb — per-feature computed values for audit/debug
+
+**`backtest_results`**
+- `model_id` UUID FK -> `projection_models`
+- `season` int
+- `position` text (`ALL`, `QB`, `RB`, `WR`, `TE`, `K`)
+- `mae` float — Mean Absolute Error
+- `bias` float — mean(actual − projected); positive = model under-projects
+- `r_squared` float — goodness of fit
+- `rmse` float — Root Mean Square Error
+- `player_count` int — sample size for this season × position
 
 ## Schema Files
 


### PR DESCRIPTION
Closes #238.

## Summary

- **`ARCHITECTURE.md`** — Adds the feature projection system to the analysis pipeline diagram, showing how `promote.py` feeds `player_projections` from `model_projections`
- **`docs/generated/db-schema.md`** — Adds `projection_models`, `model_projections`, and `backtest_results` tables with full column descriptions; updates table count from 11 to 14
- **`docs/exec-plans/feature-projections.md`** — Full rewrite of the exec plan:
  - Marks phases 1–3 complete, phase 4 deferred, phase 5 in progress
  - Adds backtest findings section with MAE/R²/Bias table across all models for 2022–2025 (844 player-seasons) and FantasyPros benchmark comparison
  - Adds tuning recommendations (promote v2, use FP for 2026 forward projections, bias correction guidance)
  - Expands runbook with step-by-step instructions and documented pitfalls: kicker handling, QB usage metric exclusion, adjustment feature scale, sparse history guards, recency weight normalization

## Key findings documented

- `v2_age_adjusted` is the best internal model (MAE 2.615, R² 0.489)
- FantasyPros outperforms all internal models overall (MAE 2.607, R² 0.561) and by a larger margin on RB/WR/TE
- `v6_usage_share` is the worst model (R² −0.267); do not promote
- Kicker projections are random across all models (R² < 0 for all)
- FantasyPros over-projects by +1.3 PPG on average (draft-time optimism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)