### PR TITLE
docs: narrow projection plan for early 2026 projections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,7 @@ Comprehensive database and analytics platform for Ottoneu Fantasy Football Leagu
 - **Git workflow:** See [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md) for branch and PR requirements
 - **Ottoneu rules:** See [docs/references/ottoneu-rules.md](docs/references/ottoneu-rules.md) for scoring, roster, salary cap, and arbitration rules
 - **Environment:** See [docs/references/environment-variables.md](docs/references/environment-variables.md) for `.env` setup
-- **Market Projections:** See [docs/exec-plans/market-projections.md](docs/exec-plans/market-projections.md) for the market-based projection system implementation plan
-- **Projection Accuracy Plan:** See [docs/exec-plans/projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md) for the 5-phase accuracy improvement roadmap (Issues #271-#285)
+- **Projection Accuracy Plan:** See [docs/exec-plans/projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md) for the 4-phase accuracy improvement roadmap (Issues #271-#285)
 - **Projection Accuracy:** Use `/projection-accuracy` skill (or run `python scripts/feature_projections/accuracy_report.py`) to generate a model comparison table. **Required when updating any projection code** — see Projection Model Update Requirements in [AGENTS.md](AGENTS.md).
 - **Retrospective:** Use `/retro` skill after completing a task to surface friction points and open a PR with doc/skill improvements.
 
@@ -39,8 +38,8 @@ docs/
 ├── GIT_WORKFLOW.md                    # Branch strategy, PR requirements
 ├── TESTING.md                         # Python + web test setup and CI
 ├── exec-plans/
-│   ├── market-projections.md          # Market-based projection system implementation plan
-│   └── projection-accuracy-improvement.md  # 5-phase accuracy improvement roadmap
+│   ├── market-projections.md          # Market-based projection system (DEFERRED)
+│   └── projection-accuracy-improvement.md  # 4-phase accuracy improvement roadmap
 ├── generated/
 │   └── db-schema.md                   # Database tables, keys, relationships
 └── references/

--- a/docs/exec-plans/market-projections.md
+++ b/docs/exec-plans/market-projections.md
@@ -1,5 +1,7 @@
 # Market-Based Season Projection System — Implementation Plan
 
+> **Status: DEFERRED** (2026-03-17) — Deprioritized in favor of tried-and-true techniques for generating early 2026 projections. This remains an interesting future direction but is not on the active roadmap.
+
 ## Context
 
 The existing simple projection system (`scripts/projection_methods.py` + `scripts/update_projections.py`) uses recency-weighted historical PPG as its only signal. It cannot account for team context changes, opponent adjustments, depth chart shifts, or market expectations. This plan introduces a separate, parallel projection system with two main advances:

--- a/docs/exec-plans/projection-accuracy-improvement.md
+++ b/docs/exec-plans/projection-accuracy-improvement.md
@@ -43,20 +43,13 @@ Tune existing model parameters and add simple features. Expected: MAE ~2.50, R²
 - [#273](https://github.com/alex-monroe/ottoneu-db/issues/273) — Add regression-to-positional-mean feature
 - [#276](https://github.com/alex-monroe/ottoneu-db/issues/276) — Per-player backtest diagnostics
 
-### Phase 2: Ensemble
-
-Blend internal + external models. Expected: MAE ~2.35-2.45, R² ~0.58.
-
-- [#274](https://github.com/alex-monroe/ottoneu-db/issues/274) — Simple ensemble: blend v2 + FantasyPros
-- [#275](https://github.com/alex-monroe/ottoneu-db/issues/275) — Bias-correct FantasyPros projections
-
-### Phase 3: Position-Specific Models
+### Phase 2: Position-Specific Models
 
 Different features per position. Expected: further MAE improvement.
 
 - [#277](https://github.com/alex-monroe/ottoneu-db/issues/277) — Position-specific model configurations
 
-### Phase 4: Fix Broken Features
+### Phase 3: Fix Broken Features
 
 Repair v3-v6 features so they contribute positively.
 
@@ -65,11 +58,10 @@ Repair v3-v6 features so they contribute positively.
 - [#280](https://github.com/alex-monroe/ottoneu-db/issues/280) — Test snap_trend feature
 - [#281](https://github.com/alex-monroe/ottoneu-db/issues/281) — Improve rookie projection
 
-### Phase 5: New Data & ML
+### Phase 4: New Data & ML
 
 New data sources and learned models. Expected: MAE < 2.3, R² > 0.60.
 
-- [#282](https://github.com/alex-monroe/ottoneu-db/issues/282) — Market projections system (Vegas lines + ML shares)
 - [#283](https://github.com/alex-monroe/ottoneu-db/issues/283) — Stacked ensemble with learned weights
 - [#284](https://github.com/alex-monroe/ottoneu-db/issues/284) — ADP integration as projection signal
 - [#285](https://github.com/alex-monroe/ottoneu-db/issues/285) — Fix usage_share: complete rethink
@@ -88,8 +80,8 @@ python scripts/feature_projections/accuracy_report.py --run-backtest --seasons 2
 | Phase | MAE Target | R² Target |
 |-------|-----------|-----------|
 | Phase 1-2 | < 2.607 (beat FP) | > 0.53 |
-| Phase 3-4 | < 2.50 | > 0.56 (match FP) |
-| Phase 5 | < 2.30 | > 0.60 (beat FP) |
+| Phase 3 | < 2.50 | > 0.56 (match FP) |
+| Phase 4 | < 2.30 | > 0.60 (beat FP) |
 
 ---
 
@@ -104,4 +96,3 @@ python scripts/feature_projections/accuracy_report.py --run-backtest --seasons 2
 | `scripts/feature_projections/backtest.py` | Validation framework for measuring all changes |
 | `scripts/feature_projections/accuracy_report.py` | Comparison table generation |
 | `scripts/feature_projections/features/__init__.py` | Feature registry — add new features here |
-| `docs/exec-plans/market-projections.md` | Full market projections plan (Issue 12) |


### PR DESCRIPTION
## Summary
- Removed FantasyPros blending (old Phase 2: issues #274, #275) from the accuracy improvement plan — FP won't have 2026 data early enough
- Removed market projections system (#282) — deferred in favor of tried-and-true techniques
- Consolidated plan from 5 phases to 4, renumbered phases and success criteria
- Marked `market-projections.md` as DEFERRED with rationale
- Updated CLAUDE.md references

## Closed Issues
- #274 — Simple ensemble: blend v2 + FantasyPros
- #275 — Bias-correct FantasyPros projections
- #282 — Implement market projections system

## Test plan
- [ ] Verify closed issues show correct close reason on GitHub
- [ ] Review updated projection-accuracy-improvement.md for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)