### PR TITLE
retro: document base feature dependency and venv path

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,6 +91,9 @@ model_config.py  →  runner.py  →  model_projections table
 - `combiner.py` — base feature PPG + weighted sum of adjustment feature deltas
 - `backtest.py` — compares projected_ppg to actual actuals (MAE, RMSE per model)
 - `accuracy_report.py` — side-by-side model comparison table across all seasons
+- `sweep_recency_weights.py` — in-memory weight sweep for base feature tuning (no DB writes)
+
+**Important dependency:** All internal models (v1–v6) share the `weighted_ppg` base feature. Changing `WeightedPPGFeature.RECENCY_WEIGHTS` requires regenerating projections for **every** internal model via `cli.py run`, not just re-running backtests. The `--run-backtest` flag on `accuracy_report.py` only re-backtests existing projections — it does not regenerate them.
 
 ### External Projection Sources (`external_sources/`)
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -13,6 +13,8 @@ npm start            # Production server
 
 ## Backend (run from project root, venv must be active)
 
+All Python commands below assume the venv is activated. If running without activation, use `venv/bin/python` instead of `python`.
+
 ```bash
 source venv/bin/activate
 

--- a/scripts/feature_projections/accuracy_report.py
+++ b/scripts/feature_projections/accuracy_report.py
@@ -5,7 +5,9 @@ Usage:
 
 Options:
     --seasons       Comma-separated seasons to include (default: 2024,2025)
-    --run-backtest  Re-run backtest for all models before generating report (slow, hits DB)
+    --run-backtest  Re-run backtest for all models before generating report (slow, hits DB).
+                    Note: this only re-backtests existing projections. If you changed a feature
+                    (e.g. recency weights), you must first regenerate projections via cli.py run.
     --output        Path to write markdown report (default: docs/generated/projection-accuracy.md)
 """
 


### PR DESCRIPTION
## Summary
Retrospective from #289 (tune recency weights, closes #271). Surfaces friction points and adds documentation to prevent repeat issues.

## Friction Points

| # | What happened | Category | Root cause | Proposed fix |
|---|--------------|----------|------------|--------------|
| 1 | Used `python` instead of venv Python, got ModuleNotFoundError | agent-error | No documented fallback path | Add venv note to COMMANDS.md |
| 2 | `--run-backtest` didn't regenerate projections after weight change | agent-error | Not obvious backtest ≠ re-projection | Clarify in docstring + ARCHITECTURE.md |
| 5 | Had to manually discover all models need re-projection | missing-docs | No documented dependency chain | Add note to ARCHITECTURE.md |

## Changes
- **`docs/COMMANDS.md`** — Added note about `venv/bin/python` as fallback
- **`docs/ARCHITECTURE.md`** — Documented that all internal models share `weighted_ppg` base feature; changing weights requires full re-projection, not just re-backtest
- **`scripts/feature_projections/accuracy_report.py`** — Clarified `--run-backtest` help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)