### PR TITLE
retro: document venv path, test coupling, and overfitting caveat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ Comprehensive database and analytics platform for Ottoneu Fantasy Football Leagu
 
 **Package Manager:** Always use `npm` for frontend dependencies and scripts. Do not use `pnpm`, `yarn`, or `bun`.
 
+**Python:** Always use `venv/bin/python` (not `python` or `python3`). The virtualenv is at `venv/`, not `.venv/`.
+
 ## Quick Reference
 
 - **Commands:** See [docs/COMMANDS.md](docs/COMMANDS.md) for all CLI commands (frontend, backend, make, cron)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -23,6 +23,12 @@ cd web && ./node_modules/.bin/tsc --noEmit
 
 `npm run build` requires `config.json` (present in CI/production, absent in local dev) and will fail with a "Module not found" error unrelated to your changes.
 
+## Coupled Test Data
+
+Some tests have hardcoded expected values tied to configuration constants. When updating these constants, the corresponding tests must be updated too:
+
+- **`POSITION_AGE_CURVES`** in `features/age_curve.py` → `test_feature_projections.py::TestAgeCurveFeature` (test_qb_at_peak, test_qb_past_peak, test_rb_young)
+
 ## Structural / Architectural Tests
 
 Harness engineering tests that enforce architectural rules mechanically. Each test failure includes a teaching message with the fix.

--- a/docs/exec-plans/projection-accuracy-improvement.md
+++ b/docs/exec-plans/projection-accuracy-improvement.md
@@ -25,9 +25,9 @@ The combiner stacks features additively. When a feature adds noise (even small),
 
 | Model | MAE | R² | Bias |
 |-------|-----|-----|------|
-| `v1_baseline` | 2.677 | 0.470 | -0.385 |
-| **`v2_age_adjusted`** | **2.615** | **0.489** | -0.408 |
-| v3-v6 | 2.96–4.39 | degrades | — |
+| `v1_baseline` | 2.666 | 0.472 | -0.389 |
+| **`v2_age_adjusted`** | **2.584** | **0.499** | -0.120 |
+| v3-v6 | 2.95–4.01 | degrades | — |
 | **FantasyPros** | **2.607** | **0.561** | +1.317 |
 
 ---
@@ -38,8 +38,8 @@ The combiner stacks features additively. When a feature adds noise (even small),
 
 Tune existing model parameters and add simple features. Expected: MAE ~2.50, R² ~0.52.
 
-- [#271](https://github.com/alex-monroe/ottoneu-db/issues/271) — Tune base feature recency weights
-- [#272](https://github.com/alex-monroe/ottoneu-db/issues/272) — Tune age curve parameters via grid search
+- [#271](https://github.com/alex-monroe/ottoneu-db/issues/271) — ~~Tune base feature recency weights~~ ✅
+- [#272](https://github.com/alex-monroe/ottoneu-db/issues/272) — ~~Tune age curve parameters via grid search~~ ✅ (MAE 2.615→2.584, R² 0.489→0.499)
 - [#273](https://github.com/alex-monroe/ottoneu-db/issues/273) — Add regression-to-positional-mean feature
 - [#276](https://github.com/alex-monroe/ottoneu-db/issues/276) — Per-player backtest diagnostics
 

--- a/scripts/feature_projections/tune_age_curve.py
+++ b/scripts/feature_projections/tune_age_curve.py
@@ -4,9 +4,14 @@ Tests combinations of peak_age, decline_rate, growth_rate, and scale for each
 position. Computes in-memory projections (base weighted_ppg + age curve delta)
 and compares to actuals to find the optimal parameter set.
 
+**Overfitting caveat:** By default, the same seasons are used for both parameter
+search and evaluation. Results may overfit to historical data. Consider holding
+out one season (e.g., search on 2022-2024, evaluate on 2025) for more robust
+estimates of improvement.
+
 Usage:
-    python scripts/feature_projections/tune_age_curve.py [--seasons 2022,2023,2024,2025]
-    python scripts/feature_projections/tune_age_curve.py --positions QB,WR
+    venv/bin/python scripts/feature_projections/tune_age_curve.py [--seasons 2022,2023,2024,2025]
+    venv/bin/python scripts/feature_projections/tune_age_curve.py --positions QB,WR
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Retrospective from #272 (tune age curve parameters via grid search).

| # | What happened | Category | Fix |
|---|--------------|----------|-----|
| 1 | Agent used `python` instead of `venv/bin/python` (recurring) | missing-guardrail | Added venv path to CLAUDE.md Project Overview — always in context |
| 2 | CI tests failed due to hardcoded expected values tied to old params | missing-guardrail | Added "Coupled Test Data" section to TESTING.md |
| 3 | Grid search used same seasons for search and evaluation | missing-docs | Added overfitting caveat to tune_age_curve.py docstring |

## Files changed

- **CLAUDE.md** — Added `**Python:** Always use venv/bin/python` next to the existing npm package manager note
- **docs/TESTING.md** — New "Coupled Test Data" section documenting age curve test coupling
- **scripts/feature_projections/tune_age_curve.py** — Added overfitting caveat to module docstring
- **docs/exec-plans/projection-accuracy-improvement.md** — Marked #271 and #272 as complete, refreshed accuracy numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)