### PR TITLE
feat: add regression-to-positional-mean feature (#273)

### DIFF
--- a/.context/retros/2026-03-17-1.json
+++ b/.context/retros/2026-03-17-1.json
@@ -1,0 +1,23 @@
+{
+  "date": "2026-03-17",
+  "window": "7d",
+  "metrics": {
+    "commits": 38,
+    "prs_merged": 38,
+    "insertions": 13907,
+    "deletions": 800,
+    "net_loc": 13107,
+    "test_ratio": 0.07,
+    "active_days": 6,
+    "sessions": 10,
+    "deep_sessions": 1,
+    "avg_session_minutes": 40,
+    "loc_per_session_hour": 2076,
+    "feat_pct": 0.34,
+    "fix_pct": 0.26,
+    "peak_hour": 21,
+    "ai_assisted_commits": 38
+  },
+  "streak_days": 3,
+  "friction_points": 6
+}

--- a/docs/generated/player-diagnostics.md
+++ b/docs/generated/player-diagnostics.md
@@ -1,0 +1,309 @@
+# Per-Player Backtest Diagnostics
+
+_Generated: 2026-03-17 19:49_
+
+**Model:** `v6_usage_share`  
+**Season:** 2025  
+**Players analyzed:** 261
+
+## Error Category Summary
+
+| Category | Count | % |
+| --- | --- | --- |
+| normal | 82 | 31.4% |
+| injury | 63 | 24.1% |
+| bust | 55 | 21.1% |
+| breakout | 26 | 10.0% |
+| rookie_bust | 25 | 9.6% |
+| rookie_breakout | 10 | 3.8% |
+
+## Position Summary
+
+| Position | Count | Mean |Error| | Max |Error| |
+| --- | --- | --- | --- |
+| QB | 53 | 8.208 | 54.170 |
+| RB | 54 | 4.735 | 17.970 |
+| WR | 62 | 4.382 | 16.880 |
+| TE | 62 | 3.099 | 12.000 |
+| K | 30 | 2.653 | 6.740 |
+
+## Top 10 Worst Projections
+
+| Rank | Player | Pos | Team | Projected | Actual | Error | |Error| | Category | GP | Features |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Jacoby Brissett | QB | ARI | 70.34 | 16.17 | -54.17 | 54.17 | bust | 14 | age_curve=-0.25, games_played=-2.82, stat_efficiency=+2.46, team_context=-1.37, usage_share=+62.92, weighted_ppg=9.39 |
+| 2 | Carson Wentz | QB | MIN | 66.00 | 13.87 | -52.13 | 52.13 | injury | 5 | age_curve=-0.24, games_played=-4.62, stat_efficiency=+9.54, team_context=+1.45, usage_share=+48.91, weighted_ppg=10.95 |
+| 3 | Marcus Mariota | QB | WAS | 42.97 | 11.32 | -31.65 | 31.65 | bust | 11 | age_curve=-0.17, games_played=-5.32, stat_efficiency=-4.35, team_context=+1.22, usage_share=+37.40, weighted_ppg=14.19 |
+| 4 | Aaron Rodgers | QB | PIT | 38.40 | 14.10 | -24.30 | 24.30 | bust | 16 | age_curve=-1.06, games_played=+0.00, stat_efficiency=-9.45, team_context=+0.57, usage_share=+33.84, weighted_ppg=14.50 |
+| 5 | Joe Milton | QB | DAL | 22.04 | 2.58 | -19.46 | 19.46 | injury | 4 | age_curve=+0.36, games_played=+0.00, stat_efficiency=None, team_context=+0.44, usage_share=None, weighted_ppg=21.24 |
+| 6 | Jerome Ford | RB | CLE | 20.32 | 2.35 | -17.97 | 17.97 | bust | 13 | age_curve=-0.23, games_played=+0.00, stat_efficiency=-0.57, team_context=-1.80, usage_share=+15.12, weighted_ppg=7.81 |
+| 7 | Christian Kirk | WR | HOU | 22.83 | 5.95 | -16.88 | 16.88 | bust | 13 | age_curve=-0.89, games_played=-1.90, stat_efficiency=+1.26, team_context=+1.57, usage_share=+13.08, weighted_ppg=9.71 |
+| 8 | Justin Jefferson | WR | MIN | 26.20 | 9.38 | -16.82 | 16.82 | bust | 17 | age_curve=+0.32, games_played=+0.00, stat_efficiency=+0.88, team_context=+1.45, usage_share=+7.13, weighted_ppg=16.42 |
+| 9 | Nick Mullens | QB | JAC | 15.65 | -0.01 | -15.66 | 15.66 | injury | 5 | age_curve=-0.04, games_played=-2.01, stat_efficiency=+4.32, team_context=-0.13, usage_share=+8.16, weighted_ppg=5.36 |
+| 10 | Tanner McKee | QB | PHI | 17.86 | 3.44 | -14.42 | 14.42 | injury | 4 | age_curve=+0.36, games_played=+0.00, stat_efficiency=None, team_context=+3.09, usage_share=None, weighted_ppg=14.41 |
+
+## All Players (sorted by |Error|)
+
+| Player | Pos | Projected | Actual | Error | Category |
+| --- | --- | --- | --- | --- | --- |
+| Jacoby Brissett | QB | 70.34 | 16.17 | -54.17 | bust |
+| Carson Wentz | QB | 66.00 | 13.87 | -52.13 | injury |
+| Marcus Mariota | QB | 42.97 | 11.32 | -31.65 | bust |
+| Aaron Rodgers | QB | 38.40 | 14.10 | -24.30 | bust |
+| Joe Milton | QB | 22.04 | 2.58 | -19.46 | injury |
+| Jerome Ford | RB | 20.32 | 2.35 | -17.97 | bust |
+| Christian Kirk | WR | 22.83 | 5.95 | -16.88 | bust |
+| Justin Jefferson | WR | 26.20 | 9.38 | -16.82 | bust |
+| Nick Mullens | QB | 15.65 | -0.01 | -15.66 | injury |
+| Tanner McKee | QB | 17.86 | 3.44 | -14.42 | injury |
+| Raheem Mostert | RB | 15.51 | 1.95 | -13.56 | bust |
+| Aaron Jones | RB | 21.61 | 8.72 | -12.89 | bust |
+| Isiah Pacheco | RB | 18.73 | 5.98 | -12.75 | bust |
+| Brian Robinson | RB | 15.91 | 3.44 | -12.47 | bust |
+| Jordan Love | QB | 4.07 | 16.48 | +12.41 | breakout |
+| Cooper Rush | QB | 12.67 | 0.43 | -12.24 | injury |
+| Trey McBride | TE | 2.88 | 14.88 | +12.00 | breakout |
+| Tyreek Hill | WR | 22.63 | 10.75 | -11.88 | injury |
+| Rico Dowdle | RB | 0.00 | 11.58 | +11.58 | breakout |
+| Kyren Williams | RB | 3.76 | 15.18 | +11.42 | breakout |
+| J.K. Dobbins | RB | 21.96 | 11.04 | -10.92 | injury |
+| Malik Willis | QB | 2.17 | 12.79 | +10.62 | injury |
+| Brian Thomas | WR | 18.77 | 8.24 | -10.53 | rookie_bust |
+| Keenan Allen | WR | 18.82 | 8.36 | -10.46 | bust |
+| Jayden Daniels | QB | 26.57 | 16.18 | -10.39 | injury |
+| Cole Kmet | TE | 13.59 | 3.76 | -9.83 | bust |
+| Jonathan Taylor | RB | 10.33 | 19.96 | +9.63 | breakout |
+| Xavier Worthy | WR | 15.67 | 6.35 | -9.32 | rookie_bust |
+| Kenny Pickett | QB | 10.22 | 1.29 | -8.93 | injury |
+| Chase Brown | RB | 5.70 | 14.59 | +8.89 | breakout |
+| Deebo Samuel | WR | 18.24 | 9.51 | -8.73 | bust |
+| Nick Chubb | RB | 13.14 | 4.60 | -8.54 | bust |
+| Gardner Minshew | QB | 8.42 | -0.08 | -8.50 | injury |
+| A.J. Brown | WR | 20.66 | 12.27 | -8.39 | bust |
+| Mark Andrews | TE | 14.50 | 6.29 | -8.21 | bust |
+| Dameon Pierce | RB | 8.89 | 0.72 | -8.17 | injury |
+| Davis Mills | QB | 3.19 | 11.27 | +8.08 | injury |
+| Brock Purdy | QB | 28.19 | 20.20 | -7.99 | injury |
+| Isaac Guerendo | RB | 7.80 | 0.00 | -7.80 | rookie_bust |
+| Johnny Mundt | TE | 8.76 | 0.97 | -7.79 | bust |
+| Tyrod Taylor | QB | 2.26 | 9.91 | +7.65 | injury |
+| Jaylen Waddle | WR | 17.51 | 10.13 | -7.38 | bust |
+| Ladd McConkey | WR | 16.18 | 8.89 | -7.29 | rookie_bust |
+| Adam Thielen | WR | 9.24 | 1.98 | -7.26 | bust |
+| Jalen McMillan | WR | 13.10 | 5.97 | -7.13 | injury |
+| Ray Davis | RB | 10.59 | 3.48 | -7.11 | rookie_bust |
+| Jalen Hurts | QB | 24.98 | 17.93 | -7.05 | bust |
+| Tucker Kraft | TE | 5.74 | 12.65 | +6.91 | injury |
+| Bijan Robinson | RB | 12.65 | 19.49 | +6.84 | breakout |
+| Younghoe Koo | K | 11.57 | 4.83 | -6.74 | injury |
+| Jaxon Smith-Njigba | WR | 10.83 | 17.49 | +6.66 | breakout |
+| Patrick Mahomes | QB | 26.79 | 20.23 | -6.56 | bust |
+| Chris Olave | WR | 20.18 | 13.62 | -6.56 | bust |
+| Rashod Bateman | WR | 10.08 | 3.53 | -6.55 | bust |
+| Jameson Williams | WR | 4.54 | 11.02 | +6.48 | breakout |
+| Jayden Reed | WR | 12.03 | 5.57 | -6.46 | injury |
+| DeVonta Smith | WR | 16.42 | 10.07 | -6.35 | bust |
+| Josh Allen | QB | 27.78 | 21.48 | -6.30 | bust |
+| Kylen Granson | TE | 6.69 | 0.44 | -6.25 | bust |
+| Tyler Conklin | TE | 7.30 | 1.06 | -6.24 | bust |
+| Geno Smith | QB | 17.75 | 11.53 | -6.22 | bust |
+| Joe Burrow | QB | 22.97 | 16.81 | -6.16 | injury |
+| Noah Gray | TE | 7.91 | 1.77 | -6.14 | bust |
+| Matthew Stafford | QB | 15.86 | 21.98 | +6.12 | breakout |
+| Brenton Strange | TE | 1.38 | 7.42 | +6.04 | breakout |
+| Travis Kelce | TE | 15.08 | 9.13 | -5.95 | rookie_bust |
+| Keon Coleman | WR | 12.32 | 6.42 | -5.90 | rookie_bust |
+| Russell Wilson | QB | 14.18 | 8.31 | -5.87 | injury |
+| C.J. Stroud | QB | 20.70 | 14.84 | -5.86 | bust |
+| Justin Herbert | QB | 22.60 | 16.81 | -5.79 | bust |
+| Mason Rudolph | QB | 8.69 | 3.02 | -5.67 | injury |
+| Joe Flacco | QB | 16.77 | 11.13 | -5.64 | bust |
+| T.J. Hockenson | TE | 11.44 | 5.82 | -5.62 | bust |
+| Zach Charbonnet | RB | 5.21 | 10.71 | +5.50 | rookie_breakout |
+| Jordan Addison | WR | 13.61 | 8.15 | -5.46 | bust |
+| Rachaad White | RB | 12.69 | 7.24 | -5.45 | bust |
+| Breece Hall | RB | 17.29 | 11.85 | -5.44 | bust |
+| Devin Culp | TE | 5.96 | 0.55 | -5.41 | rookie_bust |
+| Jake Elliott | K | 11.66 | 6.35 | -5.31 | bust |
+| Isaiah Likely | TE | 8.52 | 3.44 | -5.08 | bust |
+| Joshua Dobbs | QB | 5.54 | 0.53 | -5.01 | injury |
+| Andy Dalton | QB | 7.39 | 2.38 | -5.01 | injury |
+| Dawson Knox | TE | 10.03 | 5.04 | -4.99 | bust |
+| Ja'Marr Chase | WR | 20.66 | 15.69 | -4.97 | bust |
+| Jake Ferguson | TE | 3.69 | 8.65 | +4.96 | breakout |
+| Drake London | WR | 9.09 | 13.99 | +4.90 | breakout |
+| Tua Tagovailoa | QB | 16.26 | 11.41 | -4.85 | rookie_bust |
+| Nico Collins | WR | 7.84 | 12.69 | +4.85 | breakout |
+| George Pickens | WR | 9.59 | 14.44 | +4.85 | breakout |
+| Saquon Barkley | RB | 18.08 | 13.25 | -4.83 | bust |
+| Courtland Sutton | WR | 5.96 | 10.75 | +4.79 | breakout |
+| Javonte Williams | RB | 9.36 | 14.08 | +4.72 | breakout |
+| Roschon Johnson | RB | 4.89 | 0.24 | -4.65 | injury |
+| Chris Godwin | WR | 12.03 | 7.39 | -4.64 | injury |
+| Matt Gay | K | 11.71 | 7.08 | -4.63 | bust |
+| Brock Bowers | TE | 16.63 | 12.02 | -4.61 | rookie_bust |
+| Justice Hill | RB | 10.02 | 5.47 | -4.55 | injury |
+| Bryce Young | QB | 9.83 | 14.37 | +4.54 | breakout |
+| Wan'Dale Robinson | WR | 6.21 | 10.74 | +4.53 | breakout |
+| Dak Prescott | QB | 13.79 | 18.28 | +4.49 | breakout |
+| Jordan Mason | RB | 3.13 | 7.62 | +4.49 | breakout |
+| Will Dissly | TE | 6.12 | 1.69 | -4.43 | injury |
+| Zane Gonzalez | K | 5.80 | 10.22 | +4.42 | injury |
+| Dyami Brown | WR | 7.23 | 2.84 | -4.39 | bust |
+| Sam LaPorta | TE | 13.97 | 9.66 | -4.31 | injury |
+| Matthew Wright | K | 9.77 | 5.50 | -4.27 | injury |
+| Michael Wilson | WR | 6.42 | 10.68 | +4.26 | breakout |
+| Spencer Shrader | K | 6.98 | 11.20 | +4.22 | injury |
+| Jonnu Smith | TE | 7.54 | 3.36 | -4.18 | bust |
+| George Kittle | TE | 16.26 | 12.09 | -4.17 | bust |
+| Joshua Karty | K | 10.42 | 6.25 | -4.17 | injury |
+| Taysom Hill | TE | 6.93 | 2.79 | -4.14 | rookie_bust |
+| Caleb Williams | QB | 14.48 | 18.56 | +4.08 | rookie_breakout |
+| Josh Johnson | QB | 0.97 | 4.88 | +3.91 | injury |
+| Kyle Pitts | TE | 5.92 | 9.81 | +3.89 | breakout |
+| Noah Fant | TE | 7.71 | 3.85 | -3.86 | bust |
+| Khalil Shakir | WR | 12.29 | 8.45 | -3.84 | bust |
+| Will Reichard | K | 13.04 | 9.24 | -3.80 | rookie_bust |
+| Mitchell Trubisky | QB | 11.30 | 7.53 | -3.77 | injury |
+| Kirk Cousins | QB | 14.00 | 10.35 | -3.65 | injury |
+| Cam Little | K | 5.73 | 9.35 | +3.62 | rookie_breakout |
+| CeeDee Lamb | WR | 15.27 | 11.67 | -3.60 | bust |
+| Will Shipley | RB | 4.36 | 0.77 | -3.59 | rookie_bust |
+| Drew Lock | QB | 3.59 | 0.02 | -3.57 | injury |
+| Graham Gano | K | 4.04 | 7.60 | +3.56 | injury |
+| Daniel Carlson | K | 9.26 | 5.71 | -3.55 | bust |
+| David Montgomery | RB | 12.64 | 9.11 | -3.53 | bust |
+| Luke Musgrave | TE | 5.71 | 2.22 | -3.49 | bust |
+| Trey Lance | QB | 6.72 | 3.38 | -3.34 | injury |
+| Jason Myers | K | 8.10 | 11.41 | +3.31 | breakout |
+| Mac Jones | QB | 13.13 | 9.83 | -3.30 | bust |
+| Grant Calcaterra | TE | 4.50 | 1.21 | -3.29 | bust |
+| Jauan Jennings | WR | 6.01 | 9.28 | +3.27 | breakout |
+| Jake Bates | K | 11.65 | 8.41 | -3.24 | rookie_bust |
+| Malik Nabers | WR | 15.26 | 12.03 | -3.23 | injury |
+| Spencer Rattler | QB | 7.72 | 10.90 | +3.18 | injury |
+| Trevor Lawrence | QB | 16.72 | 19.89 | +3.17 | rookie_breakout |
+| Pat Freiermuth | TE | 8.52 | 5.36 | -3.16 | bust |
+| Trey Benson | RB | 4.10 | 7.22 | +3.12 | injury |
+| Travis Etienne | RB | 10.76 | 13.88 | +3.12 | rookie_breakout |
+| Baker Mayfield | QB | 12.83 | 15.88 | +3.05 | breakout |
+| Stefon Diggs | WR | 12.92 | 9.91 | -3.01 | bust |
+| Miles Sanders | RB | 8.66 | 5.67 | -2.99 | injury |
+| Tyler Higbee | TE | 9.09 | 6.16 | -2.93 | injury |
+| Hunter Henry | TE | 10.64 | 7.72 | -2.92 | normal |
+| Bucky Irving | RB | 15.23 | 12.35 | -2.88 | injury |
+| Chris Rodriguez | RB | 4.10 | 6.96 | +2.86 | normal |
+| Tyrone Tracy | RB | 12.23 | 9.52 | -2.71 | rookie_bust |
+| Foster Moreau | TE | 3.55 | 0.85 | -2.70 | normal |
+| Cade Stover | TE | 4.39 | 1.69 | -2.70 | injury |
+| Marvin Harrison | WR | 11.61 | 8.94 | -2.67 | rookie_bust |
+| Evan McPherson | K | 10.29 | 7.65 | -2.64 | normal |
+| D'Andre Swift | RB | 10.59 | 13.22 | +2.63 | normal |
+| Mike Evans | WR | 11.31 | 8.72 | -2.59 | injury |
+| Cade Otton | TE | 8.38 | 5.79 | -2.59 | normal |
+| Blake Corum | RB | 4.65 | 7.19 | +2.54 | rookie_breakout |
+| Justin Fields | QB | 18.02 | 15.52 | -2.50 | injury |
+| Julian Hill | TE | 4.10 | 1.68 | -2.42 | normal |
+| Joey Slye | K | 5.53 | 7.94 | +2.41 | normal |
+| Calvin Ridley | WR | 7.91 | 5.54 | -2.37 | injury |
+| Alec Pierce | WR | 8.29 | 10.65 | +2.36 | normal |
+| Jahmyr Gibbs | RB | 16.98 | 19.32 | +2.34 | normal |
+| Cameron Dicker | K | 11.71 | 9.41 | -2.30 | normal |
+| Ricky Pearsall | WR | 9.22 | 7.04 | -2.18 | injury |
+| Tank Bigsby | RB | 5.26 | 3.08 | -2.18 | normal |
+| Tony Pollard | RB | 12.12 | 9.96 | -2.16 | rookie_bust |
+| Rashid Shaheed | WR | 4.69 | 6.81 | +2.12 | normal |
+| Theo Johnson | TE | 4.92 | 7.02 | +2.10 | rookie_breakout |
+| Puka Nacua | WR | 17.94 | 20.04 | +2.10 | normal |
+| Harrison Butker | K | 10.28 | 8.24 | -2.04 | normal |
+| Mike Gesicki | TE | 6.39 | 4.36 | -2.03 | normal |
+| Alvin Kamara | RB | 9.65 | 7.65 | -2.00 | normal |
+| Cairo Santos | K | 6.47 | 8.47 | +2.00 | normal |
+| Davante Adams | WR | 15.95 | 13.96 | -1.99 | normal |
+| Ben Sinnott | TE | 3.38 | 1.43 | -1.95 | rookie_bust |
+| Luke Schoonmaker | TE | 3.14 | 1.19 | -1.95 | normal |
+| Dalton Kincaid | TE | 10.82 | 8.88 | -1.94 | normal |
+| Chris Boswell | K | 10.00 | 8.06 | -1.94 | normal |
+| Josh Downs | WR | 8.60 | 6.71 | -1.89 | normal |
+| Juwan Johnson | TE | 6.43 | 8.32 | +1.89 | normal |
+| Darnell Mooney | WR | 6.29 | 4.42 | -1.87 | normal |
+| James Cook | RB | 17.90 | 16.06 | -1.84 | normal |
+| Chase McLaughlin | K | 10.58 | 8.76 | -1.82 | normal |
+| Ka'imi Fairbairn | K | 11.07 | 12.87 | +1.80 | normal |
+| Kenneth Walker | RB | 12.18 | 10.38 | -1.80 | normal |
+| Jared Goff | QB | 19.26 | 17.47 | -1.79 | normal |
+| Darnell Washington | TE | 1.85 | 3.62 | +1.77 | normal |
+| Quentin Johnston | WR | 7.30 | 9.06 | +1.76 | normal |
+| Daniel Jones | QB | 15.60 | 17.34 | +1.74 | normal |
+| Tyler Allgeier | RB | 8.55 | 6.82 | -1.73 | normal |
+| Jakobi Meyers | WR | 9.59 | 7.89 | -1.70 | normal |
+| Josh Jacobs | RB | 16.26 | 14.61 | -1.65 | normal |
+| Josh Whyle | TE | 3.30 | 1.66 | -1.64 | injury |
+| Brandon McManus | K | 9.17 | 7.57 | -1.60 | normal |
+| Jaylen Warren | RB | 10.28 | 11.84 | +1.56 | normal |
+| Brock Wright | TE | 4.26 | 2.71 | -1.55 | normal |
+| Jerry Jeudy | WR | 7.17 | 5.63 | -1.54 | normal |
+| Terry McLaurin | WR | 10.94 | 9.52 | -1.42 | injury |
+| Evan Engram | TE | 6.46 | 5.04 | -1.42 | normal |
+| De'Von Achane | RB | 19.47 | 18.08 | -1.39 | normal |
+| Isaiah Davis | RB | 5.16 | 3.79 | -1.37 | rookie_bust |
+| Matt Prater | K | 8.20 | 6.87 | -1.33 | normal |
+| Kendre Miller | RB | 3.10 | 4.40 | +1.30 | injury |
+| Rome Odunze | WR | 7.22 | 8.43 | +1.21 | rookie_breakout |
+| Cooper Kupp | WR | 7.74 | 6.55 | -1.19 | normal |
+| Lamar Jackson | QB | 17.62 | 16.45 | -1.17 | normal |
+| Chuba Hubbard | RB | 8.50 | 7.36 | -1.14 | normal |
+| Romeo Doubs | WR | 8.40 | 9.53 | +1.13 | normal |
+| Tee Higgins | WR | 13.24 | 12.14 | -1.10 | normal |
+| Jake Moody | K | 9.64 | 8.56 | -1.08 | injury |
+| Blake Grupe | K | 8.61 | 7.56 | -1.05 | normal |
+| Austin Hooper | TE | 1.65 | 2.69 | +1.04 | normal |
+| Brandon Aubrey | K | 11.64 | 10.62 | -1.02 | normal |
+| Dalton Schultz | TE | 9.09 | 8.12 | -0.97 | normal |
+| Christian McCaffrey | RB | 19.96 | 20.93 | +0.97 | normal |
+| DK Metcalf | WR | 11.14 | 10.17 | -0.97 | normal |
+| Amon-Ra St. Brown | WR | 16.58 | 15.62 | -0.96 | normal |
+| Garrett Wilson | WR | 10.69 | 11.64 | +0.95 | injury |
+| Darren Waller | TE | 9.47 | 8.52 | -0.95 | injury |
+| Tanner Hudson | TE | 3.50 | 2.55 | -0.95 | normal |
+| Drake Maye | QB | 20.60 | 19.68 | -0.92 | rookie_bust |
+| Dallas Goedert | TE | 11.25 | 10.34 | -0.91 | normal |
+| David Njoku | TE | 4.94 | 5.82 | +0.88 | normal |
+| Zay Flowers | WR | 12.62 | 11.78 | -0.84 | rookie_bust |
+| Chad Ryland | K | 6.42 | 7.24 | +0.82 | normal |
+| Jeremy Ruckert | TE | 2.88 | 2.08 | -0.80 | normal |
+| Elijah Higgins | TE | 1.75 | 2.54 | +0.79 | normal |
+| Michael Pittman | WR | 10.29 | 9.55 | -0.74 | normal |
+| Michael Mayer | TE | 5.06 | 4.33 | -0.73 | normal |
+| Derrick Henry | RB | 16.64 | 16.00 | -0.64 | normal |
+| Demario Douglas | WR | 5.84 | 5.21 | -0.63 | normal |
+| Jake Browning | QB | 9.12 | 9.75 | +0.63 | injury |
+| Darius Slayton | WR | 5.11 | 5.74 | +0.63 | normal |
+| Colby Parkinson | TE | 7.59 | 8.21 | +0.62 | normal |
+| Quintin Morris | TE | 1.66 | 1.04 | -0.62 | normal |
+| Braelon Allen | RB | 4.19 | 3.58 | -0.61 | injury |
+| AJ Barner | TE | 5.93 | 6.54 | +0.61 | rookie_breakout |
+| Adam Trautman | TE | 1.48 | 2.09 | +0.61 | normal |
+| Daniel Bellinger | TE | 2.54 | 3.13 | +0.59 | normal |
+| Stone Smartt | TE | 1.16 | 0.58 | -0.58 | normal |
+| Rashee Rice | WR | 14.88 | 15.45 | +0.57 | injury |
+| Kyler Murray | QB | 15.07 | 15.56 | +0.49 | injury |
+| Josh Oliver | TE | 3.65 | 3.17 | -0.48 | normal |
+| DJ Moore | WR | 8.52 | 8.98 | +0.46 | normal |
+| Nick Folk | K | 7.42 | 7.88 | +0.46 | normal |
+| Jaylen Wright | RB | 4.97 | 4.57 | -0.40 | injury |
+| Sam Darnold | QB | 13.37 | 13.73 | +0.36 | normal |
+| Michael Penix | QB | 12.90 | 13.25 | +0.35 | injury |
+| Wil Lutz | K | 7.32 | 7.06 | -0.26 | rookie_bust |
+| Bo Nix | QB | 17.95 | 17.70 | -0.25 | rookie_bust |
+| Tyjae Spears | RB | 6.61 | 6.86 | +0.25 | normal |
+| Ja'Tavion Sanders | TE | 3.28 | 3.04 | -0.24 | rookie_bust |
+| Kareem Hunt | RB | 7.82 | 8.02 | +0.20 | normal |
+| Eddy Pineiro | K | 9.76 | 9.93 | +0.17 | normal |
+| Tommy Tremble | TE | 2.81 | 2.96 | +0.15 | rookie_breakout |
+| Drew Sample | TE | 1.57 | 1.44 | -0.13 | normal |
+| Marvin Mims | WR | 5.55 | 5.45 | -0.10 | normal |
+| Tyler Huntley | QB | 7.98 | 8.03 | +0.05 | injury |
+| Zach Ertz | TE | 7.84 | 7.80 | -0.04 | rookie_bust |
+| Ty Johnson | RB | 5.18 | 5.19 | +0.01 | normal |
+| Rhamondre Stevenson | RB | 11.02 | 11.01 | -0.01 | normal |

--- a/docs/generated/projection-accuracy.md
+++ b/docs/generated/projection-accuracy.md
@@ -1,156 +1,8 @@
 # Projection Model Accuracy Report
 
-_Generated: 2026-03-17 20:22_
+_Generated: 2026-03-17 20:41_
 
 Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed error (positive = under-projection), **R²** = Goodness of fit (higher is better), **RMSE** = Root mean square error, **N** = player sample size.
-
-## Season 2022
-
-### ALL
-
-| Model | mae | bias | r_squared | rmse | player_count |
-| --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 2.224 | -0.001 | 0.626 | 2.992 | 154 |
-| `v2_age_adjusted` | **2.185** | +0.129 | **0.640** | **2.936** | 154 |
-| `v3_stat_weighted` | 2.660 | +0.133 | 0.379 | 3.858 | 154 |
-| `v4_availability_adjusted` | 2.729 | +0.564 | 0.354 | 3.933 | 154 |
-| `v5_team_context` | 3.290 | -0.325 | 0.188 | 4.412 | 154 |
-| `v6_usage_share` | 4.323 | -1.554 | -1.614 | 7.915 | 154 |
-| `external_fantasypros_v1` | 2.768 | +1.662 | 0.540 | 3.668 | 133 |
-
-### QB
-
-| Model | mae | bias | r_squared | rmse | player_count |
-| --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 3.635 | -0.249 | 0.191 | 4.625 | 36 |
-| `v2_age_adjusted` | **3.595** | +0.057 | **0.224** | **4.527** | 36 |
-| `v3_stat_weighted` | 4.702 | +0.265 | -0.485 | 6.264 | 36 |
-| `v4_availability_adjusted` | 4.977 | +1.027 | -0.580 | 6.461 | 36 |
-| `v5_team_context` | 5.266 | +0.259 | -0.789 | 6.876 | 36 |
-| `v6_usage_share` | 5.266 | +0.259 | -0.789 | 6.876 | 36 |
-| `external_fantasypros_v1` | 4.669 | +3.096 | -0.055 | 5.825 | 32 |
-
-### RB
-
-| Model | mae | bias | r_squared | rmse | player_count |
-| --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 2.689 | -0.876 | 0.502 | 3.246 | 25 |
-| `v2_age_adjusted` | 2.755 | -0.762 | 0.491 | 3.281 | 25 |
-| `v3_stat_weighted` | 3.099 | -0.657 | 0.258 | 3.961 | 25 |
-| `v4_availability_adjusted` | 2.965 | +0.246 | 0.329 | 3.766 | 25 |
-| `v5_team_context` | 3.583 | -0.437 | 0.151 | 4.237 | 25 |
-| `v6_usage_share` | 6.484 | -3.861 | -4.626 | 10.908 | 25 |
-| `external_fantasypros_v1` | **2.643** | +1.210 | **0.579** | **3.179** | 30 |
-
-### WR
-
-| Model | mae | bias | r_squared | rmse | player_count |
-| --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 1.869 | +0.554 | 0.626 | 2.200 | 33 |
-| `v2_age_adjusted` | **1.621** | +0.598 | **0.699** | **1.975** | 33 |
-| `v3_stat_weighted` | **1.797** | +0.551 | 0.604 | 2.264 | 33 |
-| `v4_availability_adjusted` | **1.746** | +0.716 | 0.613 | 2.239 | 33 |
-| `v5_team_context` | 2.480 | -0.046 | 0.311 | 2.987 | 33 |
-| `v6_usage_share` | 3.072 | -0.846 | -0.166 | 3.886 | 33 |
-| `external_fantasypros_v1` | 1.927 | +1.295 | 0.623 | 2.401 | 36 |
-
-### TE
-
-| Model | mae | bias | r_squared | rmse | player_count |
-| --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 1.538 | +0.260 | 0.581 | 1.845 | 36 |
-| `v2_age_adjusted` | 1.596 | +0.478 | 0.557 | 1.896 | 36 |
-| `v3_stat_weighted` | 2.119 | +0.261 | 0.123 | 2.670 | 36 |
-| `v4_availability_adjusted` | 2.225 | +0.508 | 0.044 | 2.788 | 36 |
-| `v5_team_context` | 2.478 | -0.591 | -0.274 | 3.218 | 36 |
-| `v6_usage_share` | 4.339 | -2.735 | -13.680 | 10.922 | 36 |
-| `external_fantasypros_v1` | 2.001 | +1.117 | 0.368 | 2.346 | 35 |
-
-### K
-
-| Model | mae | bias | r_squared | rmse | player_count |
-| --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 1.141 | +0.129 | -1.296 | 1.618 | 24 |
-| `v2_age_adjusted` | **1.137** | -0.006 | **-1.272** | **1.609** | 24 |
-| `v3_stat_weighted` | **1.137** | -0.006 | **-1.272** | **1.609** | 24 |
-| `v4_availability_adjusted` | 1.221 | +0.078 | -1.911 | 1.822 | 24 |
-| `v5_team_context` | 2.354 | -1.070 | -5.536 | 2.730 | 24 |
-| `v6_usage_share` | 2.354 | -1.070 | -5.536 | 2.730 | 24 |
-| `external_fantasypros_v1` | — | — | — | — | — |
-
-## Season 2023
-
-### ALL
-
-| Model | mae | bias | r_squared | rmse | player_count |
-| --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 2.643 | -0.089 | 0.446 | 3.720 | 188 |
-| `v2_age_adjusted` | **2.638** | +0.106 | 0.431 | 3.768 | 188 |
-| `v3_stat_weighted` | 2.942 | -0.092 | 0.360 | 3.996 | 188 |
-| `v4_availability_adjusted` | 2.954 | +0.396 | 0.312 | 4.144 | 188 |
-| `v5_team_context` | 3.493 | -0.534 | 0.132 | 4.656 | 188 |
-| `v6_usage_share` | 3.840 | -0.816 | -0.036 | 5.087 | 188 |
-| `external_fantasypros_v1` | **2.267** | +1.633 | **0.630** | **3.196** | 176 |
-
-### QB
-
-| Model | mae | bias | r_squared | rmse | player_count |
-| --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 3.847 | -0.835 | 0.181 | 5.258 | 39 |
-| `v2_age_adjusted` | 3.947 | -0.559 | 0.155 | 5.341 | 39 |
-| `v3_stat_weighted` | 4.350 | -0.920 | 0.075 | 5.588 | 39 |
-| `v4_availability_adjusted` | 4.300 | +0.491 | 0.006 | 5.791 | 39 |
-| `v5_team_context` | 4.883 | -0.213 | -0.183 | 6.317 | 39 |
-| `v6_usage_share` | 4.883 | -0.213 | -0.183 | 6.317 | 39 |
-| `external_fantasypros_v1` | **3.640** | +2.361 | 0.166 | **4.770** | 40 |
-
-### RB
-
-| Model | mae | bias | r_squared | rmse | player_count |
-| --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 3.531 | +0.672 | -0.253 | 4.758 | 37 |
-| `v2_age_adjusted` | **3.471** | +0.890 | -0.291 | 4.829 | 37 |
-| `v3_stat_weighted` | 3.803 | +0.606 | -0.334 | 4.908 | 37 |
-| `v4_availability_adjusted` | 3.926 | +0.918 | -0.447 | 5.113 | 37 |
-| `v5_team_context` | 4.618 | -0.048 | -0.863 | 5.801 | 37 |
-| `v6_usage_share` | 5.088 | -0.039 | -1.400 | 6.584 | 37 |
-| `external_fantasypros_v1` | **2.548** | +2.210 | **0.466** | **3.472** | 40 |
-
-### WR
-
-| Model | mae | bias | r_squared | rmse | player_count |
-| --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 2.558 | +0.107 | 0.422 | 3.139 | 44 |
-| `v2_age_adjusted` | 2.699 | +0.275 | 0.376 | 3.261 | 44 |
-| `v3_stat_weighted` | 2.946 | +0.082 | 0.258 | 3.557 | 44 |
-| `v4_availability_adjusted` | 2.981 | +0.331 | 0.189 | 3.717 | 44 |
-| `v5_team_context` | 3.102 | -0.465 | 0.142 | 3.824 | 44 |
-| `v6_usage_share` | 3.708 | -0.983 | -0.172 | 4.470 | 44 |
-| `external_fantasypros_v1` | **1.903** | +1.239 | **0.602** | **2.450** | 49 |
-
-### TE
-
-| Model | mae | bias | r_squared | rmse | player_count |
-| --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 1.778 | -0.307 | 0.415 | 2.208 | 44 |
-| `v2_age_adjusted` | **1.604** | -0.023 | **0.490** | **2.062** | 44 |
-| `v3_stat_weighted` | 2.017 | -0.116 | 0.186 | 2.605 | 44 |
-| `v4_availability_adjusted` | 1.981 | +0.185 | 0.161 | 2.645 | 44 |
-| `v5_team_context` | 2.670 | -0.879 | -0.423 | 3.444 | 44 |
-| `v6_usage_share` | 3.148 | -1.574 | -0.956 | 4.038 | 44 |
-| `external_fantasypros_v1` | **1.237** | +0.931 | **0.743** | **1.535** | 47 |
-
-### K
-
-| Model | mae | bias | r_squared | rmse | player_count |
-| --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 1.062 | -0.007 | -0.504 | 1.262 | 24 |
-| `v2_age_adjusted` | **1.012** | -0.099 | -0.514 | 1.266 | 24 |
-| `v3_stat_weighted` | **1.012** | -0.099 | -0.514 | 1.266 | 24 |
-| `v4_availability_adjusted` | **0.999** | -0.061 | **-0.503** | **1.262** | 24 |
-| `v5_team_context` | 1.728 | -1.298 | -3.245 | 2.120 | 24 |
-| `v6_usage_share` | 1.728 | -1.298 | -3.245 | 2.120 | 24 |
-| `external_fantasypros_v1` | — | — | — | — | — |
 
 ## Season 2024
 
@@ -164,6 +16,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v4_availability_adjusted` | 2.852 | +0.495 | 0.365 | 3.897 | 241 |
 | `v5_team_context` | 3.297 | -0.417 | 0.246 | 4.246 | 241 |
 | `v6_usage_share` | 3.872 | -1.148 | -0.202 | 5.361 | 241 |
+| `v7_regression_to_mean` | 3.703 | -0.681 | -0.095 | 5.115 | 241 |
 | `external_fantasypros_v1` | 2.782 | +1.531 | **0.543** | **3.602** | 211 |
 
 ### QB
@@ -176,6 +29,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v4_availability_adjusted` | **3.952** | +0.113 | 0.357 | 5.230 | 49 |
 | `v5_team_context` | 4.362 | -0.600 | 0.285 | 5.515 | 49 |
 | `v6_usage_share` | 4.362 | -0.600 | 0.285 | 5.515 | 49 |
+| `v7_regression_to_mean` | 4.223 | -0.015 | 0.300 | 5.457 | 49 |
 | `external_fantasypros_v1` | 4.015 | +2.650 | 0.313 | **5.163** | 47 |
 
 ### RB
@@ -188,6 +42,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v4_availability_adjusted` | 3.440 | +1.230 | -0.036 | 4.520 | 49 |
 | `v5_team_context` | 3.607 | +0.416 | -0.065 | 4.582 | 49 |
 | `v6_usage_share` | 3.879 | +0.292 | -0.255 | 4.975 | 49 |
+| `v7_regression_to_mean` | 3.736 | +0.589 | -0.185 | 4.835 | 49 |
 | `external_fantasypros_v1` | 3.281 | +1.622 | **0.409** | **3.898** | 51 |
 
 ### WR
@@ -200,6 +55,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v4_availability_adjusted` | **2.760** | +0.539 | -0.358 | 3.573 | 55 |
 | `v5_team_context` | 3.100 | -0.401 | -0.691 | 3.988 | 55 |
 | `v6_usage_share` | 4.780 | -2.481 | -4.623 | 7.272 | 55 |
+| `v7_regression_to_mean` | 4.485 | -1.676 | -3.836 | 6.743 | 55 |
 | `external_fantasypros_v1` | **2.353** | +1.365 | **0.187** | **2.832** | 58 |
 
 ### TE
@@ -212,6 +68,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v4_availability_adjusted` | 2.142 | +0.118 | 0.195 | 2.703 | 56 |
 | `v5_team_context` | 2.774 | -0.786 | -0.317 | 3.458 | 56 |
 | `v6_usage_share` | 3.358 | -1.783 | -1.035 | 4.298 | 56 |
+| `v7_regression_to_mean` | 3.215 | -1.358 | -0.845 | 4.092 | 56 |
 | `external_fantasypros_v1` | **1.719** | +0.666 | **0.486** | **2.106** | 55 |
 
 ### K
@@ -224,6 +81,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v4_availability_adjusted` | 1.667 | +0.540 | -1.191 | 2.540 | 32 |
 | `v5_team_context` | 2.447 | -0.793 | -1.986 | 2.965 | 32 |
 | `v6_usage_share` | 2.447 | -0.793 | -1.986 | 2.965 | 32 |
+| `v7_regression_to_mean` | 2.369 | -0.747 | -1.792 | 2.868 | 32 |
 | `external_fantasypros_v1` | — | — | — | — | — |
 
 ## Season 2025
@@ -238,6 +96,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v4_availability_adjusted` | 3.192 | -0.142 | 0.308 | 4.268 | 261 |
 | `v5_team_context` | 3.568 | -1.036 | 0.181 | 4.640 | 261 |
 | `v6_usage_share` | 4.083 | -1.688 | -0.104 | 5.388 | 261 |
+| `v7_regression_to_mean` | 3.902 | -1.299 | -0.029 | 5.202 | 261 |
 | `external_fantasypros_v1` | **2.613** | +0.721 | **0.538** | **3.637** | 246 |
 
 ### QB
@@ -250,6 +109,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v4_availability_adjusted` | 4.605 | -0.378 | 0.135 | 5.969 | 53 |
 | `v5_team_context` | 5.037 | -1.281 | 0.028 | 6.330 | 53 |
 | `v6_usage_share` | 5.037 | -1.281 | 0.028 | 6.330 | 53 |
+| `v7_regression_to_mean` | 4.857 | -0.624 | 0.075 | 6.175 | 53 |
 | `external_fantasypros_v1` | **4.124** | +2.526 | **0.202** | **5.673** | 52 |
 
 ### RB
@@ -262,6 +122,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v4_availability_adjusted` | 3.840 | +0.669 | 0.198 | 4.835 | 54 |
 | `v5_team_context` | 3.815 | -0.306 | 0.159 | 4.951 | 54 |
 | `v6_usage_share` | 4.730 | -1.617 | -0.373 | 6.324 | 54 |
+| `v7_regression_to_mean` | 4.663 | -1.401 | -0.312 | 6.184 | 54 |
 | `external_fantasypros_v1` | **2.584** | +0.361 | **0.628** | **3.252** | 64 |
 
 ### WR
@@ -274,6 +135,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v4_availability_adjusted` | 3.075 | -0.706 | -0.177 | 3.827 | 62 |
 | `v5_team_context` | 3.435 | -1.511 | -0.462 | 4.266 | 62 |
 | `v6_usage_share` | 4.369 | -2.518 | -1.595 | 5.682 | 62 |
+| `v7_regression_to_mean` | 4.062 | -2.016 | -1.318 | 5.371 | 62 |
 | `external_fantasypros_v1` | **2.398** | -0.494 | **0.333** | **3.004** | 66 |
 
 ### TE
@@ -286,6 +148,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v4_availability_adjusted` | 2.139 | -0.166 | 0.307 | 2.916 | 62 |
 | `v5_team_context` | 2.668 | -1.058 | 0.009 | 3.487 | 62 |
 | `v6_usage_share` | 3.103 | -1.655 | -0.317 | 4.020 | 62 |
+| `v7_regression_to_mean` | 2.911 | -1.270 | -0.206 | 3.848 | 62 |
 | `external_fantasypros_v1` | **1.637** | +0.867 | **0.604** | **2.192** | 64 |
 
 ### K
@@ -298,6 +161,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v4_availability_adjusted` | 1.947 | +0.030 | **-0.718** | **2.361** | 30 |
 | `v5_team_context` | 2.667 | -0.890 | -1.983 | 3.111 | 30 |
 | `v6_usage_share` | 2.667 | -0.890 | -1.983 | 3.111 | 30 |
+| `v7_regression_to_mean` | 2.561 | -0.889 | -1.784 | 3.005 | 30 |
 | `external_fantasypros_v1` | — | — | — | — | — |
 
 ## All Seasons Combined
@@ -308,70 +172,76 @@ _Weighted averages across all seasons (weighted by player count N). RMSE is appr
 
 | Model | mae | bias | r_squared | rmse | player_count |
 | --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 2.666 | -0.389 | 0.472 | 3.630 | 844 |
-| `v2_age_adjusted` | **2.584** | -0.120 | **0.499** | **3.534** | 844 |
-| `v3_stat_weighted` | 2.953 | -0.196 | 0.347 | 4.039 | 844 |
-| `v4_availability_adjusted` | 2.957 | +0.289 | 0.334 | 4.076 | 844 |
-| `v5_team_context` | 3.424 | -0.618 | 0.190 | 4.493 | 844 |
-| `v6_usage_share` | 4.012 | -1.315 | -0.392 | 5.864 | 844 |
-| `external_fantasypros_v1` | **2.607** | +1.317 | **0.561** | **3.536** | 766 |
+| `v1_baseline_weighted_ppg` _(baseline)_ | 2.810 | -0.620 | 0.435 | 3.771 | 502 |
+| `v2_age_adjusted` | **2.686** | -0.281 | **0.481** | **3.610** | 502 |
+| `v3_stat_weighted` | 3.047 | -0.335 | 0.332 | 4.108 | 502 |
+| `v4_availability_adjusted` | 3.029 | +0.164 | 0.335 | 4.094 | 502 |
+| `v5_team_context` | 3.438 | -0.739 | 0.212 | 4.455 | 502 |
+| `v6_usage_share` | 3.982 | -1.429 | -0.151 | 5.375 | 502 |
+| `v7_regression_to_mean` | 3.807 | -1.002 | -0.060 | 5.161 | 502 |
+| `external_fantasypros_v1` | **2.691** | +1.095 | **0.541** | **3.621** | 457 |
 
 ### QB
 
 | Model | mae | bias | r_squared | rmse | player_count |
 | --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 4.008 | -1.278 | 0.229 | 5.312 | 177 |
-| `v2_age_adjusted` | **3.950** | -0.912 | **0.249** | **5.238** | 177 |
-| `v3_stat_weighted` | 4.541 | -1.057 | 0.024 | 5.871 | 177 |
-| `v4_availability_adjusted` | 4.433 | +0.235 | 0.023 | 5.841 | 177 |
-| `v5_team_context` | 4.863 | -0.544 | -0.114 | 6.231 | 177 |
-| `v6_usage_share` | 4.863 | -0.544 | -0.114 | 6.231 | 177 |
-| `external_fantasypros_v1` | 4.083 | +2.628 | 0.176 | 5.365 | 171 |
+| `v1_baseline_weighted_ppg` _(baseline)_ | 4.201 | -1.810 | 0.261 | 5.554 | 102 |
+| `v2_age_adjusted` | **4.077** | -1.389 | **0.294** | **5.428** | 102 |
+| `v3_stat_weighted` | 4.558 | -1.575 | 0.185 | 5.833 | 102 |
+| `v4_availability_adjusted` | 4.291 | -0.142 | 0.242 | 5.626 | 102 |
+| `v5_team_context` | 4.713 | -0.954 | 0.151 | 5.953 | 102 |
+| `v6_usage_share` | 4.713 | -0.954 | 0.151 | 5.953 | 102 |
+| `v7_regression_to_mean` | 4.553 | -0.331 | 0.183 | 5.841 | 102 |
+| `external_fantasypros_v1` | **4.072** | +2.585 | 0.254 | **5.437** | 99 |
 
 ### RB
 
 | Model | mae | bias | r_squared | rmse | player_count |
 | --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 3.065 | -0.170 | 0.252 | 3.968 | 165 |
-| `v2_age_adjusted` | **2.989** | +0.181 | **0.287** | **3.846** | 165 |
-| `v3_stat_weighted` | 3.565 | +0.365 | 0.036 | 4.599 | 165 |
-| `v4_availability_adjusted` | 3.608 | +0.827 | 0.004 | 4.662 | 165 |
-| `v5_team_context` | 3.898 | -0.054 | -0.138 | 4.952 | 165 |
-| `v6_usage_share` | 4.823 | -1.036 | -1.212 | 6.942 | 165 |
-| `external_fantasypros_v1` | **2.778** | +1.246 | **0.525** | **3.478** | 185 |
+| `v1_baseline_weighted_ppg` _(baseline)_ | 2.989 | -0.301 | 0.373 | 3.813 | 103 |
+| `v2_age_adjusted` | **2.873** | +0.156 | **0.445** | **3.565** | 103 |
+| `v3_stat_weighted` | 3.593 | +0.526 | 0.115 | 4.628 | 103 |
+| `v4_availability_adjusted` | 3.650 | +0.936 | 0.087 | 4.688 | 103 |
+| `v5_team_context` | 3.716 | +0.037 | 0.053 | 4.779 | 103 |
+| `v6_usage_share` | 4.325 | -0.709 | -0.317 | 5.722 | 103 |
+| `v7_regression_to_mean` | 4.222 | -0.454 | -0.252 | 5.583 | 103 |
+| `external_fantasypros_v1` | **2.893** | +0.920 | **0.531** | **3.553** | 115 |
 
 ### WR
 
 | Model | mae | bias | r_squared | rmse | player_count |
 | --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 2.666 | -0.211 | 0.104 | 3.270 | 194 |
-| `v2_age_adjusted` | **2.471** | +0.074 | **0.207** | **3.090** | 194 |
-| `v3_stat_weighted` | 2.725 | -0.076 | 0.025 | 3.440 | 194 |
-| `v4_availability_adjusted` | 2.738 | +0.124 | -0.011 | 3.505 | 194 |
-| `v5_team_context` | 3.102 | -0.710 | -0.258 | 3.893 | 194 |
-| `v6_usage_share` | 4.115 | -1.875 | -1.887 | 5.693 | 194 |
-| `external_fantasypros_v1` | **2.189** | +0.737 | **0.405** | **2.734** | 209 |
+| `v1_baseline_weighted_ppg` _(baseline)_ | 2.931 | -0.546 | -0.164 | 3.557 | 117 |
+| `v2_age_adjusted` | **2.625** | -0.149 | **0.004** | **3.276** | 117 |
+| `v3_stat_weighted` | **2.904** | -0.313 | -0.227 | 3.662 | 117 |
+| `v4_availability_adjusted` | **2.927** | -0.121 | -0.262 | 3.710 | 117 |
+| `v5_team_context` | 3.278 | -0.989 | -0.570 | 4.137 | 117 |
+| `v6_usage_share` | 4.562 | -2.501 | -3.018 | 6.478 | 117 |
+| `v7_regression_to_mean` | 4.261 | -1.856 | -2.502 | 6.055 | 117 |
+| `external_fantasypros_v1` | **2.377** | +0.376 | **0.265** | **2.924** | 124 |
 
 ### TE
 
 | Model | mae | bias | r_squared | rmse | player_count |
 | --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 1.817 | -0.225 | 0.467 | 2.280 | 198 |
-| `v2_age_adjusted` | **1.777** | +0.073 | **0.492** | **2.214** | 198 |
-| `v3_stat_weighted` | 2.092 | -0.126 | 0.228 | 2.720 | 198 |
-| `v4_availability_adjusted` | 2.120 | +0.115 | 0.195 | 2.774 | 198 |
-| `v5_team_context` | 2.664 | -0.856 | -0.231 | 3.422 | 198 |
-| `v6_usage_share` | 3.410 | -1.870 | -3.092 | 5.966 | 198 |
-| `external_fantasypros_v1` | **1.630** | +0.871 | **0.563** | **2.062** | 201 |
+| `v1_baseline_weighted_ppg` _(baseline)_ | 1.916 | -0.342 | 0.451 | 2.421 | 118 |
+| `v2_age_adjusted` | **1.896** | -0.015 | **0.472** | **2.354** | 118 |
+| `v3_stat_weighted` | 2.111 | -0.248 | 0.275 | 2.776 | 118 |
+| `v4_availability_adjusted` | 2.140 | -0.031 | 0.254 | 2.817 | 118 |
+| `v5_team_context` | 2.718 | -0.929 | -0.146 | 3.473 | 118 |
+| `v6_usage_share` | 3.224 | -1.716 | -0.658 | 4.154 | 118 |
+| `v7_regression_to_mean` | 3.055 | -1.312 | -0.509 | 3.965 | 118 |
+| `external_fantasypros_v1` | **1.675** | +0.774 | **0.549** | **2.153** | 119 |
 
 ### K
 
 | Model | mae | bias | r_squared | rmse | player_count |
 | --- | --- | --- | --- | --- | --- |
-| `v1_baseline_weighted_ppg` _(baseline)_ | 1.438 | +0.105 | -0.778 | 1.966 | 110 |
-| `v2_age_adjusted` | **1.430** | +0.013 | **-0.755** | **1.951** | 110 |
-| `v3_stat_weighted` | **1.430** | +0.013 | **-0.755** | **1.951** | 110 |
-| `v4_availability_adjusted` | 1.500 | +0.169 | -1.069 | 2.114 | 110 |
-| `v5_team_context` | 2.330 | -0.990 | -3.034 | 2.794 | 110 |
-| `v6_usage_share` | 2.330 | -0.990 | -3.034 | 2.794 | 110 |
+| `v1_baseline_weighted_ppg` _(baseline)_ | 1.698 | +0.139 | -0.684 | 2.286 | 62 |
+| `v2_age_adjusted` | 1.705 | +0.063 | **-0.648** | **2.265** | 62 |
+| `v3_stat_weighted` | 1.705 | +0.063 | **-0.648** | **2.265** | 62 |
+| `v4_availability_adjusted` | 1.802 | +0.293 | -0.962 | 2.455 | 62 |
+| `v5_team_context` | 2.554 | -0.840 | -1.984 | 3.037 | 62 |
+| `v6_usage_share` | 2.554 | -0.840 | -1.984 | 3.037 | 62 |
+| `v7_regression_to_mean` | 2.462 | -0.816 | -1.788 | 2.935 | 62 |
 | `external_fantasypros_v1` | — | — | — | — | — |

--- a/scripts/feature_projections/features/__init__.py
+++ b/scripts/feature_projections/features/__init__.py
@@ -9,6 +9,7 @@ from scripts.feature_projections.features.stat_efficiency import StatEfficiencyF
 from scripts.feature_projections.features.games_played import GamesPlayedFeature
 from scripts.feature_projections.features.team_context import TeamContextFeature
 from scripts.feature_projections.features.usage_share import UsageShareFeature
+from scripts.feature_projections.features.regression_to_mean import RegressionToMeanFeature
 
 FEATURE_REGISTRY: dict[str, type] = {
     "weighted_ppg": WeightedPPGFeature,
@@ -17,4 +18,5 @@ FEATURE_REGISTRY: dict[str, type] = {
     "games_played": GamesPlayedFeature,
     "team_context": TeamContextFeature,
     "usage_share": UsageShareFeature,
+    "regression_to_mean": RegressionToMeanFeature,
 }

--- a/scripts/feature_projections/features/regression_to_mean.py
+++ b/scripts/feature_projections/features/regression_to_mean.py
@@ -1,0 +1,46 @@
+"""Regression-to-positional-mean feature — pulls outlier projections toward positional average."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pandas as pd
+
+from scripts.feature_projections.features.base import ProjectionFeature
+
+
+class RegressionToMeanFeature(ProjectionFeature):
+    """Adjusts projection toward the positional mean PPG.
+
+    Extreme performances regress naturally. This feature models that
+    by nudging the base projection toward the positional average,
+    weighted by a regression factor.
+
+    delta = (positional_mean_ppg - base_ppg) * regression_factor
+
+    A positive delta means the player is below the positional mean
+    and gets a boost; negative means above mean and gets pulled down.
+    """
+
+    REGRESSION_FACTOR = 0.12
+
+    @property
+    def name(self) -> str:
+        return "regression_to_mean"
+
+    def compute(
+        self,
+        player_id: str,
+        position: str,
+        history_df: pd.DataFrame,
+        nfl_stats_df: pd.DataFrame,
+        context: dict[str, Any],
+    ) -> Optional[float]:
+        base_ppg = context.get("base_ppg")
+        positional_mean_ppg = context.get("positional_mean_ppg")
+
+        if base_ppg is None or positional_mean_ppg is None:
+            return None
+
+        delta = (positional_mean_ppg - base_ppg) * self.REGRESSION_FACTOR
+        return delta

--- a/scripts/feature_projections/model_config.py
+++ b/scripts/feature_projections/model_config.py
@@ -68,6 +68,20 @@ MODELS: dict[str, ModelDefinition] = {
             "usage_share",
         ],
     ),
+    "v7_regression_to_mean": ModelDefinition(
+        name="v7_regression_to_mean",
+        version=1,
+        description="Usage-share model + regression toward positional mean PPG.",
+        features=[
+            "weighted_ppg",
+            "age_curve",
+            "stat_efficiency",
+            "games_played",
+            "team_context",
+            "usage_share",
+            "regression_to_mean",
+        ],
+    ),
     "external_fantasypros_v1": ModelDefinition(
         name="external_fantasypros_v1",
         version=1,

--- a/scripts/feature_projections/runner.py
+++ b/scripts/feature_projections/runner.py
@@ -52,6 +52,41 @@ def _ensure_model_in_db(supabase, model_def: ModelDefinition) -> str:
     return result.data[0]["id"]
 
 
+def _compute_positional_mean_ppg(
+    history_df: pd.DataFrame,
+    players_df: pd.DataFrame,
+    min_games: int = MIN_GAMES,
+) -> dict[str, float]:
+    """Compute mean PPG per position from historical player_stats.
+
+    Only includes players who meet the minimum games threshold.
+    Returns dict mapping position -> mean PPG.
+    """
+    if history_df.empty or players_df.empty:
+        return {}
+
+    merged = history_df.merge(
+        players_df[["player_id_ref", "position"]],
+        left_on="player_id",
+        right_on="player_id_ref",
+        how="left",
+    )
+
+    # Filter to players meeting min games
+    merged["games_played"] = pd.to_numeric(merged["games_played"], errors="coerce").fillna(0)
+    merged["ppg"] = pd.to_numeric(merged["ppg"], errors="coerce").fillna(0)
+    qualified = merged[merged["games_played"] >= min_games]
+
+    if qualified.empty:
+        return {}
+
+    # Average PPG per player first (across seasons), then per position
+    player_avg = qualified.groupby(["player_id", "position"])["ppg"].mean().reset_index()
+    pos_means = player_avg.groupby("position")["ppg"].mean()
+
+    return {str(pos): float(val) for pos, val in pos_means.items()}
+
+
 def _build_context(
     player_id: str,
     position: str,
@@ -59,6 +94,7 @@ def _build_context(
     nfl_stats_all: pd.DataFrame,
     target_season: int,
     team_aggregates: dict[str, Any],
+    positional_means: dict[str, float] | None = None,
 ) -> dict[str, Any]:
     """Build the context dict for a player's feature computation."""
     context: dict[str, Any] = {"target_season": target_season}
@@ -76,6 +112,10 @@ def _build_context(
         team_data = team_aggregates[nfl_team]
         context["team_offense_rating"] = team_data.get("offense_rating", 0.0)
         context["team_usage"] = team_data.get("usage_by_season", {})
+
+    # Positional mean PPG for regression-to-mean feature
+    if positional_means and position in positional_means:
+        context["positional_mean_ppg"] = positional_means[position]
 
     return context
 
@@ -204,6 +244,9 @@ def run_model(
         # Compute team aggregates
         team_aggregates = _compute_team_aggregates(nfl_stats_all, players_df)
 
+        # Compute positional mean PPG for regression-to-mean feature
+        positional_means = _compute_positional_mean_ppg(history_df, players_df)
+
         # Generate projections for each player
         records = []
         for player_id, player_history in history_df.groupby("player_id"):
@@ -223,7 +266,7 @@ def run_model(
             # Build context
             context = _build_context(
                 player_id_str, position, players_df, nfl_stats_all,
-                target_season, team_aggregates,
+                target_season, team_aggregates, positional_means,
             )
 
             # Run combiner

--- a/scripts/tests/test_feature_projections.py
+++ b/scripts/tests/test_feature_projections.py
@@ -14,6 +14,7 @@ from scripts.feature_projections.features.stat_efficiency import StatEfficiencyF
 from scripts.feature_projections.features.games_played import GamesPlayedFeature
 from scripts.feature_projections.features.team_context import TeamContextFeature
 from scripts.feature_projections.features.usage_share import UsageShareFeature
+from scripts.feature_projections.features.regression_to_mean import RegressionToMeanFeature
 from scripts.feature_projections.combiner import combine_features
 from scripts.feature_projections.model_config import get_model, MODELS
 
@@ -299,6 +300,54 @@ class TestUsageShareFeature:
 
 
 # ---------------------------------------------------------------------------
+# RegressionToMeanFeature
+# ---------------------------------------------------------------------------
+
+class TestRegressionToMeanFeature:
+    def setup_method(self):
+        self.feature = RegressionToMeanFeature()
+
+    def test_name(self):
+        assert self.feature.name == "regression_to_mean"
+        assert self.feature.is_base is False
+
+    def test_missing_context_returns_none(self):
+        """Missing base_ppg or positional_mean_ppg → None."""
+        result = self.feature.compute("p1", "QB", pd.DataFrame(), pd.DataFrame(), {})
+        assert result is None
+
+        result = self.feature.compute("p1", "QB", pd.DataFrame(), pd.DataFrame(), {"base_ppg": 15.0})
+        assert result is None
+
+        result = self.feature.compute("p1", "QB", pd.DataFrame(), pd.DataFrame(), {"positional_mean_ppg": 12.0})
+        assert result is None
+
+    def test_above_mean_gets_negative_delta(self):
+        """Player PPG above positional mean should get pulled down."""
+        ctx = {"base_ppg": 20.0, "positional_mean_ppg": 12.0}
+        result = self.feature.compute("p1", "QB", pd.DataFrame(), pd.DataFrame(), ctx)
+        assert result is not None
+        # delta = (12 - 20) * 0.12 = -0.96
+        assert result == pytest.approx(-0.96)
+        assert result < 0
+
+    def test_below_mean_gets_positive_delta(self):
+        """Player PPG below positional mean should get boosted."""
+        ctx = {"base_ppg": 8.0, "positional_mean_ppg": 12.0}
+        result = self.feature.compute("p1", "WR", pd.DataFrame(), pd.DataFrame(), ctx)
+        assert result is not None
+        # delta = (12 - 8) * 0.12 = 0.48
+        assert result == pytest.approx(0.48)
+        assert result > 0
+
+    def test_at_mean_returns_zero(self):
+        """Player at positional mean → zero delta."""
+        ctx = {"base_ppg": 12.0, "positional_mean_ppg": 12.0}
+        result = self.feature.compute("p1", "RB", pd.DataFrame(), pd.DataFrame(), ctx)
+        assert result == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
 # Combiner
 # ---------------------------------------------------------------------------
 
@@ -368,6 +417,7 @@ class TestModelConfig:
             "v4_availability_adjusted",
             "v5_team_context",
             "v6_usage_share",
+            "v7_regression_to_mean",
         ]
         for name in expected:
             model = get_model(name)
@@ -381,7 +431,8 @@ class TestModelConfig:
         """Each model should include all features from previous models."""
         prev_features: list[str] = []
         for name in ["v1_baseline_weighted_ppg", "v2_age_adjusted", "v3_stat_weighted",
-                      "v4_availability_adjusted", "v5_team_context", "v6_usage_share"]:
+                      "v4_availability_adjusted", "v5_team_context", "v6_usage_share",
+                      "v7_regression_to_mean"]:
             model = get_model(name)
             for f in prev_features:
                 assert f in model.features, f"{name} missing feature {f}"


### PR DESCRIPTION
## Summary

Closes #273. Adds a regression-to-positional-mean adjustment feature that pulls outlier projections toward the positional average PPG.

### Changes

- **New**: `scripts/feature_projections/features/regression_to_mean.py` — adjustment feature with formula `delta = (positional_mean_ppg - base_ppg) * 0.12`
- **Modified**: `features/__init__.py` — registered `regression_to_mean` in `FEATURE_REGISTRY`
- **Modified**: `model_config.py` — added `v7_regression_to_mean` model (builds on v6)
- **Modified**: `runner.py` — compute positional mean PPG from historical player_stats and pass into context
- **Modified**: `test_feature_projections.py` — added `TestRegressionToMeanFeature` + updated model config assertions

### v7 vs v6 Improvements (Combined Seasons)

v7 consistently improves over v6 across all positions:

| Position | v6 MAE | v7 MAE | Δ MAE | v6 R² | v7 R² | Δ R² |
|----------|--------|--------|-------|-------|-------|------|
| ALL | 3.982 | 3.807 | -0.175 | -0.151 | -0.060 | +0.091 |
| QB | 4.713 | 4.553 | -0.160 | 0.151 | 0.183 | +0.032 |
| RB | 4.325 | 4.222 | -0.103 | -0.317 | -0.252 | +0.065 |
| WR | 4.562 | 4.261 | -0.301 | -3.018 | -2.502 | +0.516 |
| TE | 3.224 | 3.055 | -0.169 | -0.658 | -0.509 | +0.149 |
| K | 2.554 | 2.462 | -0.092 | -1.984 | -1.788 | +0.196 |

v2 (age-adjusted) remains the best internal model with overall MAE 2.686 and R² 0.481.

## Projection Accuracy

Full accuracy report from `docs/generated/projection-accuracy.md`:

### All Seasons Combined — ALL

| Model | mae | bias | r_squared | rmse | player_count |
| --- | --- | --- | --- | --- | --- |
| `v1_baseline_weighted_ppg` _(baseline)_ | 2.810 | -0.620 | 0.435 | 3.771 | 502 |
| `v2_age_adjusted` | **2.686** | -0.281 | **0.481** | **3.610** | 502 |
| `v3_stat_weighted` | 3.047 | -0.335 | 0.332 | 4.108 | 502 |
| `v4_availability_adjusted` | 3.029 | +0.164 | 0.335 | 4.094 | 502 |
| `v5_team_context` | 3.438 | -0.739 | 0.212 | 4.455 | 502 |
| `v6_usage_share` | 3.982 | -1.429 | -0.151 | 5.375 | 502 |
| `v7_regression_to_mean` | 3.807 | -1.002 | -0.060 | 5.161 | 502 |
| `external_fantasypros_v1` | **2.691** | +1.095 | **0.541** | **3.621** | 457 |

## Verification

- ✅ 49/49 unit tests pass
- ✅ 14/14 architecture checks pass
- ✅ Backtest run for 2024, 2025 seasons