### PR TITLE
feat: rewrite stat_efficiency as rate-based efficiency deltas (GH #278)

### DIFF
--- a/scripts/feature_projections/features/stat_efficiency.py
+++ b/scripts/feature_projections/features/stat_efficiency.py
@@ -1,4 +1,10 @@
-"""Stat efficiency feature — per-stat projection from nfl_stats → PPG."""
+"""Stat efficiency feature v2 — detect meaningful efficiency changes and return PPG deltas.
+
+Instead of recomputing PPG from component stats (which just adds noise),
+this version computes position-specific efficiency metrics (yards/attempt,
+catch rate, TD rate) and compares recent values to career baseline or
+league averages, returning a small clamped PPG adjustment.
+"""
 
 from __future__ import annotations
 
@@ -8,31 +14,94 @@ import pandas as pd
 
 from scripts.feature_projections.features.base import ProjectionFeature
 
-# Half PPR scoring weights matching config.json
-SCORING_WEIGHTS = {
-    "passing_yards": 0.04,
-    "passing_tds": 4,
-    "interceptions": -2,
-    "rushing_yards": 0.1,
-    "rushing_tds": 6,
-    "receptions": 0.5,
-    "receiving_yards": 0.1,
-    "receiving_tds": 6,
+# League-average efficiency rates (used as baseline for single-season players)
+LEAGUE_AVG = {
+    "ypa": 7.0,
+    "pass_td_rate": 0.045,
+    "int_rate": 0.025,
+    "ypc": 4.3,
+    "rush_td_rate": 0.035,
+    "catch_rate": 0.65,
+    "yards_per_target": 8.0,
+    "rec_td_rate": 0.07,
 }
 
-# Recency weights for up to 3 seasons (most recent first)
-RECENCY_WEIGHTS = [0.55, 0.30, 0.15]
+# Minimum attempts to consider a season valid for a given metric
+MIN_ATTEMPTS = {
+    "passing_attempts": 100,
+    "rushing_attempts": 50,
+    "targets": 30,
+}
+
+# How strongly deviations translate to PPG adjustment
+METRIC_SCALING = 0.07
+
+# Direction of deviation effect on PPG.
+# Positive = higher rate is better; negative = regression signal (high rates regress).
+METRIC_DIRECTION = {
+    "ypa": 1.0,
+    "pass_td_rate": -0.5,
+    "int_rate": -1.0,
+    "ypc": 1.0,
+    "rush_td_rate": -0.5,
+    "catch_rate": 1.0,
+    "yards_per_target": 1.0,
+    "rec_td_rate": -0.5,
+}
+
+# Recency weights for baseline computation (most recent older season first)
+RECENCY_WEIGHTS = [0.6, 0.3, 0.1]
+
+# Position → list of (metric_name, numerator_col, denominator_col)
+POSITION_METRICS: dict[str, list[tuple[str, str, str]]] = {
+    "QB": [
+        ("ypa", "passing_yards", "passing_attempts"),
+        ("pass_td_rate", "passing_tds", "passing_attempts"),
+        ("int_rate", "interceptions", "passing_attempts"),
+    ],
+    "RB": [
+        ("ypc", "rushing_yards", "rushing_attempts"),
+        ("rush_td_rate", "rushing_tds", "rushing_attempts"),
+    ],
+    "WR": [
+        ("catch_rate", "receptions", "targets"),
+        ("yards_per_target", "receiving_yards", "targets"),
+        ("rec_td_rate", "receiving_tds", "targets"),
+    ],
+    "TE": [
+        ("catch_rate", "receptions", "targets"),
+        ("yards_per_target", "receiving_yards", "targets"),
+        ("rec_td_rate", "receiving_tds", "targets"),
+    ],
+}
+
+
+def _safe_float(row: pd.Series, col: str) -> float:
+    """Extract a float from a row, returning 0.0 for missing/NaN."""
+    val = row.get(col)
+    if pd.isna(val):
+        return 0.0
+    return float(val)
+
+
+def _compute_rate(row: pd.Series, numerator_col: str, denominator_col: str) -> Optional[float]:
+    """Compute a rate stat, returning None if denominator is below threshold."""
+    denom = _safe_float(row, denominator_col)
+    min_att = MIN_ATTEMPTS.get(denominator_col, 0)
+    if denom < min_att:
+        return None
+    numer = _safe_float(row, numerator_col)
+    return numer / denom
 
 
 class StatEfficiencyFeature(ProjectionFeature):
-    """Projects individual stat categories from nfl_stats, applies scoring weights.
+    """Detects meaningful stat-level efficiency changes and returns a PPG delta.
 
-    For each stat category, computes a recency-weighted per-game average,
-    then multiplies by Half PPR scoring weights to get projected PPG.
-
-    Returns a PPG delta: stat_projected_ppg - weighted_ppg_baseline.
-    This captures situations where per-stat projection diverges from aggregate PPG
-    (e.g., a WR with increasing targets but flat PPG due to TD variance).
+    For each position-relevant metric:
+    1. Filter seasons with sufficient attempts
+    2. Compute per-season rate values
+    3. Compare recent season to recency-weighted baseline (or league avg for 1-season players)
+    4. Convert deviation to a small PPG delta, clamped to ±10% of base_ppg
     """
 
     @property
@@ -47,53 +116,62 @@ class StatEfficiencyFeature(ProjectionFeature):
         nfl_stats_df: pd.DataFrame,
         context: dict[str, Any],
     ) -> Optional[float]:
-        # Kickers have no passing/rushing/receiving stats, so stat_projected_ppg
-        # would be 0 while base_ppg is ~7, producing a -7 delta that breaks projections.
         if position == "K":
             return None
 
         if nfl_stats_df.empty:
             return None
 
-        sorted_df = nfl_stats_df.sort_values("season")
-        recent = sorted_df.tail(3)
-
-        if recent.empty:
-            return None
-
-        # Filter rows with valid games_played
-        recent = recent[recent["games_played"].fillna(0) > 0].copy()
-        if recent.empty:
-            return None
-
-        n = len(recent)
-        weights = RECENCY_WEIGHTS[:n]
-
-        # Compute weighted per-game stats
-        total_fantasy_points = 0.0
-        total_weight = 0.0
-
-        for i, (_, row) in enumerate(recent.iloc[::-1].iterrows()):
-            games = float(row["games_played"])
-            w = weights[i]
-
-            season_points = 0.0
-            for stat, scoring_weight in SCORING_WEIGHTS.items():
-                val = row.get(stat)
-                if pd.notna(val):
-                    season_points += float(val) * scoring_weight
-
-            ppg_from_stats = season_points / games
-            total_fantasy_points += ppg_from_stats * w
-            total_weight += w
-
-        if total_weight == 0:
-            return None
-
-        stat_projected_ppg = total_fantasy_points / total_weight
-
-        # Return as delta from weighted PPG baseline (if available)
         base_ppg = context.get("base_ppg")
-        if base_ppg is not None and base_ppg > 0:
-            return stat_projected_ppg - base_ppg
-        return None
+        if not base_ppg or base_ppg <= 0:
+            return None
+
+        metrics = POSITION_METRICS.get(position)
+        if not metrics:
+            return None
+
+        sorted_df = nfl_stats_df.sort_values("season")
+
+        deltas: list[float] = []
+
+        for metric_name, numer_col, denom_col in metrics:
+            # Compute rate for each valid season
+            season_rates: list[tuple[int, float]] = []
+            for _, row in sorted_df.iterrows():
+                rate = _compute_rate(row, numer_col, denom_col)
+                if rate is not None:
+                    season_rates.append((int(row["season"]), rate))
+
+            if not season_rates:
+                continue
+
+            recent_rate = season_rates[-1][1]
+
+            if len(season_rates) >= 2:
+                # Recency-weighted baseline from older seasons
+                older = season_rates[:-1]
+                # Most recent older season first
+                older.reverse()
+                weights = RECENCY_WEIGHTS[: len(older)]
+                total_w = sum(weights)
+                baseline = sum(r * w for (_, r), w in zip(older, weights)) / total_w
+            else:
+                # Single season: compare to league average
+                baseline = LEAGUE_AVG[metric_name]
+
+            if baseline == 0:
+                continue
+
+            deviation = (recent_rate - baseline) / baseline
+            direction = METRIC_DIRECTION[metric_name]
+            delta = deviation * direction * METRIC_SCALING * base_ppg
+            deltas.append(delta)
+
+        if not deltas:
+            return None
+
+        avg_delta = sum(deltas) / len(deltas)
+
+        # Clamp to ±10% of base_ppg
+        clamp = 0.10 * base_ppg
+        return max(-clamp, min(clamp, avg_delta))

--- a/scripts/feature_projections/model_config.py
+++ b/scripts/feature_projections/model_config.py
@@ -108,6 +108,12 @@ MODELS: dict[str, ModelDefinition] = {
         features=["weighted_ppg", "age_curve", "regression_to_mean"],
         position_overrides={},
     ),
+    "v10_stat_efficiency_v2": ModelDefinition(
+        name="v10_stat_efficiency_v2",
+        version=1,
+        description="v8 (age_curve + regression_to_mean) + rewritten stat_efficiency v2 with rate-based efficiency deltas.",
+        features=["weighted_ppg", "age_curve", "regression_to_mean", "stat_efficiency"],
+    ),
     "external_fantasypros_v1": ModelDefinition(
         name="external_fantasypros_v1",
         version=1,

--- a/scripts/tests/test_feature_projections.py
+++ b/scripts/tests/test_feature_projections.py
@@ -163,36 +163,109 @@ class TestStatEfficiencyFeature:
         result = self.feature.compute("p1", "QB", pd.DataFrame(), pd.DataFrame(), {})
         assert result is None
 
-    def test_returns_delta_from_base(self):
-        """Should return difference between stat-based and base PPG."""
-        nfl_df = make_nfl_stats_df([{
-            "season": 2024, "games_played": 17,
-            "passing_yards": 4000, "passing_tds": 30, "interceptions": 10,
-            "rushing_yards": 200, "rushing_tds": 2,
-            "receptions": 0, "receiving_yards": 0, "receiving_tds": 0,
-        }])
-        # Stat PPG: (4000*0.04 + 30*4 + (-10*2) + 200*0.1 + 2*6) / 17
-        # = (160 + 120 - 20 + 20 + 12) / 17 = 292 / 17 ≈ 17.18
-        ctx = {"base_ppg": 15.0}
-        result = self.feature.compute("p1", "QB", pd.DataFrame(), nfl_df, ctx)
-        assert result is not None
-        assert result == pytest.approx(17.176 - 15.0, abs=0.1)
-
-    def test_no_base_ppg_returns_none(self):
-        nfl_df = make_nfl_stats_df([{
-            "season": 2024, "games_played": 17,
-            "passing_yards": 4000, "passing_tds": 30, "interceptions": 10,
-        }])
-        result = self.feature.compute("p1", "QB", pd.DataFrame(), nfl_df, {})
-        assert result is None
-
     def test_kicker_returns_none(self):
         """K position has no passing/rushing/receiving stats — always return None."""
         nfl_df = make_nfl_stats_df([{
             "season": 2024, "games_played": 17,
+            "passing_yards": 4000, "passing_tds": 30, "passing_attempts": 500,
         }])
         ctx = {"base_ppg": 7.0}
         result = self.feature.compute("p1", "K", pd.DataFrame(), nfl_df, ctx)
+        assert result is None
+
+    def test_no_base_ppg_returns_none(self):
+        nfl_df = make_nfl_stats_df([{
+            "season": 2024, "games_played": 17,
+            "passing_yards": 4000, "passing_tds": 30, "passing_attempts": 500,
+        }])
+        result = self.feature.compute("p1", "QB", pd.DataFrame(), nfl_df, {})
+        assert result is None
+
+    def test_qb_high_ypa_positive_delta(self):
+        """QB with above-baseline YPA in recent season → positive adjustment."""
+        nfl_df = make_nfl_stats_df([
+            {"season": 2023, "games_played": 17, "passing_yards": 3500, "passing_tds": 22, "interceptions": 12, "passing_attempts": 500},
+            {"season": 2024, "games_played": 17, "passing_yards": 4500, "passing_tds": 23, "interceptions": 13, "passing_attempts": 500},
+        ])
+        # 2023 YPA=7.0, 2024 YPA=9.0 → deviation = (9-7)/7 = 0.286 → positive delta
+        ctx = {"base_ppg": 20.0}
+        result = self.feature.compute("p1", "QB", pd.DataFrame(), nfl_df, ctx)
+        assert result is not None
+        assert result > 0
+
+    def test_qb_high_td_rate_regression(self):
+        """QB with elevated TD rate → negative adjustment (regression signal)."""
+        nfl_df = make_nfl_stats_df([
+            {"season": 2023, "games_played": 17, "passing_yards": 3500, "passing_tds": 20, "interceptions": 12, "passing_attempts": 500},
+            {"season": 2024, "games_played": 17, "passing_yards": 3500, "passing_tds": 40, "interceptions": 12, "passing_attempts": 500},
+        ])
+        # 2023 TD rate=0.04, 2024 TD rate=0.08 → big deviation, negative direction
+        ctx = {"base_ppg": 20.0}
+        result = self.feature.compute("p1", "QB", pd.DataFrame(), nfl_df, ctx)
+        assert result is not None
+        # The TD rate regression signal should dominate (direction=-0.5)
+        # but YPA is flat (deviation≈0) and INT rate is flat, so net depends on TD rate
+        # TD deviation = (0.08-0.04)/0.04 = 1.0, delta = 1.0 * -0.5 * 0.07 * 20 = -0.7
+
+    def test_rb_efficiency_up(self):
+        """RB with improving YPC → positive adjustment."""
+        nfl_df = make_nfl_stats_df([
+            {"season": 2023, "games_played": 17, "rushing_yards": 200, "rushing_tds": 3, "rushing_attempts": 50},
+            {"season": 2024, "games_played": 17, "rushing_yards": 350, "rushing_tds": 4, "rushing_attempts": 50},
+        ])
+        # 2023 YPC=4.0, 2024 YPC=7.0 → positive deviation
+        ctx = {"base_ppg": 12.0}
+        result = self.feature.compute("p1", "RB", pd.DataFrame(), nfl_df, ctx)
+        assert result is not None
+        assert result > 0
+
+    def test_wr_catch_rate_down(self):
+        """WR with declining catch rate → negative adjustment."""
+        nfl_df = make_nfl_stats_df([
+            {"season": 2023, "games_played": 17, "receptions": 80, "receiving_yards": 1000, "receiving_tds": 6, "targets": 100},
+            {"season": 2024, "games_played": 17, "receptions": 40, "receiving_yards": 600, "receiving_tds": 3, "targets": 100},
+        ])
+        # Catch rate: 0.80 → 0.40, yards/target: 10→6, TD rate: 0.06→0.03
+        # All declining → negative delta (catch rate and yards/target have positive direction)
+        ctx = {"base_ppg": 10.0}
+        result = self.feature.compute("p1", "WR", pd.DataFrame(), nfl_df, ctx)
+        assert result is not None
+        assert result < 0
+
+    def test_single_season_uses_league_avg(self):
+        """1-season player compared to league averages."""
+        nfl_df = make_nfl_stats_df([{
+            "season": 2024, "games_played": 17,
+            "passing_yards": 4200, "passing_tds": 30, "interceptions": 10, "passing_attempts": 500,
+        }])
+        # YPA = 8.4 vs league avg 7.0 → deviation=(8.4-7)/7=0.2 → positive
+        # TD rate = 0.06 vs league avg 0.045 → deviation=(0.06-0.045)/0.045=0.33 → negative (direction=-0.5)
+        # INT rate = 0.02 vs league avg 0.025 → deviation=(0.02-0.025)/0.025=-0.2 → positive (direction=-1)
+        ctx = {"base_ppg": 20.0}
+        result = self.feature.compute("p1", "QB", pd.DataFrame(), nfl_df, ctx)
+        assert result is not None
+
+    def test_clamped_to_10_pct(self):
+        """Extreme deviations should be clamped to ±10% of base_ppg."""
+        nfl_df = make_nfl_stats_df([
+            {"season": 2023, "games_played": 17, "rushing_yards": 50, "rushing_tds": 0, "rushing_attempts": 50},
+            {"season": 2024, "games_played": 17, "rushing_yards": 500, "rushing_tds": 20, "rushing_attempts": 50},
+        ])
+        # Extreme YPC deviation: 1.0 → 10.0 = 900% increase
+        ctx = {"base_ppg": 10.0}
+        result = self.feature.compute("p1", "RB", pd.DataFrame(), nfl_df, ctx)
+        assert result is not None
+        assert abs(result) <= 10.0 * 0.10 + 0.001  # clamped to ±1.0
+
+    def test_low_attempts_filtered(self):
+        """Seasons below attempt threshold should be skipped."""
+        nfl_df = make_nfl_stats_df([{
+            "season": 2024, "games_played": 17,
+            "passing_yards": 500, "passing_tds": 3, "interceptions": 2, "passing_attempts": 50,
+        }])
+        # 50 attempts < 100 minimum → all QB metrics filtered out
+        ctx = {"base_ppg": 15.0}
+        result = self.feature.compute("p1", "QB", pd.DataFrame(), nfl_df, ctx)
         assert result is None
 
 


### PR DESCRIPTION
## Summary
- **Rewrote `stat_efficiency.py`** from scratch: instead of redundantly re-deriving PPG from component stats (which added +0.34 MAE), now computes position-specific efficiency metrics (yards/attempt, catch rate, TD rate regression) and returns small, clamped PPG deltas
- **Added `v10_stat_efficiency_v2` model** (v8 + rewritten stat_efficiency) for backtesting
- **Replaced all `TestStatEfficiencyFeature` tests** with 11 new tests covering QB/RB/WR efficiency, regression signals, single-season league-avg comparison, clamping, and attempt thresholds

## Backtest Results (v10 vs v8, all seasons)

| Metric | v8 | v10 | Delta |
|--------|-----|-----|-------|
| MAE | 2.530 | **2.525** | -0.005 |
| R² | 0.522 | **0.523** | +0.001 |
| RMSE | 3.454 | **3.449** | -0.005 |

Notable: RB MAE 2.916→2.884, RB R² 0.322→0.331. No degradation in any position.

Closes #278

## Test plan
- [x] All 66 feature projection tests pass
- [x] v10 projections generated for 2022-2025
- [x] Backtest confirms no MAE/R² degradation vs v8

🤖 Generated with [Claude Code](https://claude.com/claude-code)