### PR TITLE
fix: GitHub MCP repo name and Python permission rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,14 @@ docs/
     └── ottoneu-rules.md               # Scoring, roster, salary cap, arbitration rules
 ```
 
+## GitHub Repository
+
+When using GitHub MCP tools or `gh` CLI, the repository coordinates are:
+- **Owner:** `alex-monroe`
+- **Repo:** `ottoneu-db` (hyphen, not underscore)
+
+Note: The local directory is `ottoneu_db` (underscore) but the GitHub repo name uses a hyphen.
+
 ## Critical Rules
 
 - **Update documentation:** Always try to update the agent documentation after completing a task. Update existing documents or add new documents and sections as needed to reflect architectural or contextual changes.


### PR DESCRIPTION
## Summary
- Adds explicit GitHub repo coordinates (`alex-monroe`/`ottoneu-db`) to CLAUDE.md to prevent "entity not found" errors from MCP tools using the wrong repo name (local dir uses underscore `ottoneu_db`, GitHub uses hyphen `ottoneu-db`)
- Adds broad `venv/bin/python:*` and `venv/bin/pytest:*` permission rules to `.claude/settings.local.json` (local-only, not committed) so Python commands no longer require individual approval

## Test plan
- [x] CLAUDE.md renders correctly with new section
- [ ] Future GitHub MCP calls use correct owner/repo from docs
- [ ] Future `venv/bin/python` commands auto-approve without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)