### PR TITLE
fix: rewrite team_context with position-specific scaling + team change handling

### DIFF
--- a/docs/exec-plans/projection-accuracy-improvement.md
+++ b/docs/exec-plans/projection-accuracy-improvement.md
@@ -53,8 +53,8 @@ Different features per position. Expected: further MAE improvement.
 
 Repair v3-v6 features so they contribute positively.
 
-- [#278](https://github.com/alex-monroe/ottoneu-db/issues/278) — Fix stat_efficiency
-- [#279](https://github.com/alex-monroe/ottoneu-db/issues/279) — Fix team_context
+- [#278](https://github.com/alex-monroe/ottoneu-db/issues/278) — ~~Fix stat_efficiency~~ ✅ (v10: rate-based efficiency deltas)
+- [#279](https://github.com/alex-monroe/ottoneu-db/issues/279) — ~~Fix team_context~~ ✅ (v11: K exclusion, position-specific scaling 0.02-0.05, historical team tracking via `nfl_stats.recent_team`, team-change dampening. Neutral to v8: MAE 2.535 vs 2.530)
 - [#280](https://github.com/alex-monroe/ottoneu-db/issues/280) — Test snap_trend feature
 - [#281](https://github.com/alex-monroe/ottoneu-db/issues/281) — Improve rookie projection
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -52,7 +52,7 @@ Fourteen tables, all with UUID primary keys.
 
 ### `nfl_stats` columns
 
-Core stat columns: `games_played`, `passing_yards`, `passing_tds`, `interceptions`, `passing_attempts`, `completions`, `rushing_yards`, `rushing_tds`, `rushing_attempts`, `receptions`, `targets`, `receiving_yards`, `receiving_tds`, `fg_made_0_39`, `fg_made_40_49`, `fg_made_50_plus`, `pat_made`, `total_points`, `ppg`, `offense_snaps`, `defense_snaps`, `st_snaps`, `total_snaps`.
+Core stat columns: `games_played`, `passing_yards`, `passing_tds`, `interceptions`, `passing_attempts`, `completions`, `rushing_yards`, `rushing_tds`, `rushing_attempts`, `receptions`, `targets`, `receiving_yards`, `receiving_tds`, `fg_made_0_39`, `fg_made_40_49`, `fg_made_50_plus`, `pat_made`, `total_points`, `ppg`, `offense_snaps`, `defense_snaps`, `st_snaps`, `total_snaps`, `recent_team`.
 
 ## Schema Files
 

--- a/docs/generated/projection-accuracy.md
+++ b/docs/generated/projection-accuracy.md
@@ -1,6 +1,6 @@
 # Projection Model Accuracy Report
 
-_Generated: 2026-03-18 19:35_
+_Generated: 2026-03-18 20:35_
 
 Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed error (positive = under-projection), **R²** = Goodness of fit (higher is better), **RMSE** = Root mean square error, **N** = player sample size.
 
@@ -19,6 +19,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | — | — | — | — | — |
 | `v8_age_regression` | **2.160** | +0.467 | **0.662** | **2.844** | 154 |
 | `v9_pos_specific` | **2.160** | +0.467 | **0.662** | **2.844** | 154 |
+| `v10_stat_efficiency_v2` | **2.141** | +0.479 | **0.665** | **2.832** | 154 |
+| `v11_team_context_v2` | **2.178** | +0.430 | **0.660** | **2.853** | 154 |
 | `external_fantasypros_v1` | 2.768 | +1.662 | 0.540 | 3.668 | 133 |
 
 ### QB
@@ -34,6 +36,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | — | — | — | — | — |
 | `v8_age_regression` | **3.467** | +0.289 | **0.293** | **4.321** | 36 |
 | `v9_pos_specific` | **3.467** | +0.289 | **0.293** | **4.321** | 36 |
+| `v10_stat_efficiency_v2` | **3.433** | +0.327 | **0.298** | **4.308** | 36 |
+| `v11_team_context_v2` | **3.521** | +0.242 | **0.286** | **4.345** | 36 |
 | `external_fantasypros_v1` | 4.669 | +3.096 | -0.055 | 5.825 | 32 |
 
 ### RB
@@ -49,6 +53,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | — | — | — | — | — |
 | `v8_age_regression` | **2.506** | -0.059 | **0.558** | **3.059** | 25 |
 | `v9_pos_specific` | **2.506** | -0.059 | **0.558** | **3.059** | 25 |
+| `v10_stat_efficiency_v2` | **2.462** | -0.034 | **0.568** | **3.023** | 25 |
+| `v11_team_context_v2` | **2.567** | -0.106 | **0.539** | **3.121** | 25 |
 | `external_fantasypros_v1` | **2.643** | +1.210 | **0.579** | **3.179** | 30 |
 
 ### WR
@@ -64,6 +70,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | — | — | — | — | — |
 | `v8_age_regression` | 1.930 | +1.161 | 0.615 | 2.235 | 33 |
 | `v9_pos_specific` | 1.930 | +1.161 | 0.615 | 2.235 | 33 |
+| `v10_stat_efficiency_v2` | 1.920 | +1.136 | 0.616 | 2.231 | 33 |
+| `v11_team_context_v2` | 1.932 | +1.118 | 0.623 | 2.209 | 33 |
 | `external_fantasypros_v1` | 1.927 | +1.295 | 0.623 | 2.401 | 36 |
 
 ### TE
@@ -79,6 +87,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | — | — | — | — | — |
 | `v8_age_regression` | 1.560 | +0.651 | **0.592** | **1.821** | 36 |
 | `v9_pos_specific` | 1.560 | +0.651 | **0.592** | **1.821** | 36 |
+| `v10_stat_efficiency_v2` | 1.554 | +0.668 | **0.594** | **1.817** | 36 |
+| `v11_team_context_v2` | 1.538 | +0.610 | **0.610** | **1.780** | 36 |
 | `external_fantasypros_v1` | 2.001 | +1.117 | 0.368 | 2.346 | 35 |
 
 ### K
@@ -94,6 +104,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | — | — | — | — | — |
 | `v8_age_regression` | **1.056** | +0.054 | **-1.029** | **1.521** | 24 |
 | `v9_pos_specific` | **1.056** | +0.054 | **-1.029** | **1.521** | 24 |
+| `v10_stat_efficiency_v2` | **1.056** | +0.054 | **-1.029** | **1.521** | 24 |
+| `v11_team_context_v2` | **1.056** | +0.054 | **-1.029** | **1.521** | 24 |
 | `external_fantasypros_v1` | — | — | — | — | — |
 
 ## Season 2023
@@ -111,6 +123,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | — | — | — | — | — |
 | `v8_age_regression` | **2.564** | +0.385 | **0.461** | **3.668** | 188 |
 | `v9_pos_specific` | **2.564** | +0.385 | **0.461** | **3.668** | 188 |
+| `v10_stat_efficiency_v2` | **2.546** | +0.399 | **0.466** | **3.653** | 188 |
+| `v11_team_context_v2` | **2.561** | +0.344 | **0.461** | **3.669** | 188 |
 | `external_fantasypros_v1` | **2.267** | +1.633 | **0.630** | **3.196** | 176 |
 
 ### QB
@@ -126,6 +140,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | — | — | — | — | — |
 | `v8_age_regression` | 3.852 | -0.333 | **0.207** | **5.175** | 39 |
 | `v9_pos_specific` | 3.852 | -0.333 | **0.207** | **5.175** | 39 |
+| `v10_stat_efficiency_v2` | **3.833** | -0.296 | **0.210** | **5.162** | 39 |
+| `v11_team_context_v2` | 3.934 | -0.406 | **0.191** | **5.226** | 39 |
 | `external_fantasypros_v1` | **3.640** | +2.361 | 0.166 | **4.770** | 40 |
 
 ### RB
@@ -141,6 +157,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | — | — | — | — | — |
 | `v8_age_regression` | **3.306** | +1.328 | **-0.192** | **4.641** | 37 |
 | `v9_pos_specific` | **3.306** | +1.328 | **-0.192** | **4.641** | 37 |
+| `v10_stat_efficiency_v2` | **3.243** | +1.360 | **-0.169** | **4.595** | 37 |
+| `v11_team_context_v2` | **3.291** | +1.260 | **-0.205** | **4.666** | 37 |
 | `external_fantasypros_v1` | **2.548** | +2.210 | **0.466** | **3.472** | 40 |
 
 ### WR
@@ -156,6 +174,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | — | — | — | — | — |
 | `v8_age_regression` | 2.696 | +0.721 | 0.361 | 3.301 | 44 |
 | `v9_pos_specific` | 2.696 | +0.721 | 0.361 | 3.301 | 44 |
+| `v10_stat_efficiency_v2` | 2.685 | +0.718 | 0.364 | 3.293 | 44 |
+| `v11_team_context_v2` | 2.614 | +0.688 | 0.393 | 3.216 | 44 |
 | `external_fantasypros_v1` | **1.903** | +1.239 | **0.602** | **2.450** | 49 |
 
 ### TE
@@ -171,6 +191,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | — | — | — | — | — |
 | `v8_age_regression` | **1.526** | +0.121 | **0.529** | **1.982** | 44 |
 | `v9_pos_specific` | **1.526** | +0.121 | **0.529** | **1.982** | 44 |
+| `v10_stat_efficiency_v2` | **1.530** | +0.127 | **0.522** | **1.995** | 44 |
+| `v11_team_context_v2` | **1.535** | +0.102 | **0.537** | **1.964** | 44 |
 | `external_fantasypros_v1` | **1.237** | +0.931 | **0.743** | **1.535** | 47 |
 
 ### K
@@ -186,6 +208,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | — | — | — | — | — |
 | `v8_age_regression` | **0.988** | -0.036 | **-0.404** | **1.219** | 24 |
 | `v9_pos_specific` | **0.988** | -0.036 | **-0.404** | **1.219** | 24 |
+| `v10_stat_efficiency_v2` | **0.988** | -0.036 | **-0.404** | **1.219** | 24 |
+| `v11_team_context_v2` | **0.988** | -0.036 | **-0.404** | **1.219** | 24 |
 | `external_fantasypros_v1` | — | — | — | — | — |
 
 ## Season 2024
@@ -203,6 +227,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | 3.703 | -0.681 | -0.095 | 5.115 | 241 |
 | `v8_age_regression` | **2.625** | +0.431 | **0.489** | **3.494** | 241 |
 | `v9_pos_specific` | **2.625** | +0.431 | **0.489** | **3.494** | 241 |
+| `v10_stat_efficiency_v2` | **2.629** | +0.411 | **0.488** | **3.498** | 241 |
+| `v11_team_context_v2` | **2.632** | +0.400 | **0.487** | **3.501** | 241 |
 | `external_fantasypros_v1` | 2.782 | +1.531 | **0.543** | **3.602** | 211 |
 
 ### QB
@@ -218,6 +244,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | 4.223 | -0.015 | 0.300 | 5.457 | 49 |
 | `v8_age_regression` | **3.825** | -0.883 | **0.416** | **4.983** | 49 |
 | `v9_pos_specific` | **3.825** | -0.883 | **0.416** | **4.983** | 49 |
+| `v10_stat_efficiency_v2` | **3.838** | -0.898 | **0.414** | **4.991** | 49 |
+| `v11_team_context_v2` | **3.835** | -0.971 | **0.417** | **4.982** | 49 |
 | `external_fantasypros_v1` | 4.015 | +2.650 | 0.313 | **5.163** | 47 |
 
 ### RB
@@ -233,6 +261,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | 3.736 | +0.589 | -0.185 | 4.835 | 49 |
 | `v8_age_regression` | 3.063 | +1.098 | **0.244** | **3.861** | 49 |
 | `v9_pos_specific` | 3.063 | +1.098 | **0.244** | **3.861** | 49 |
+| `v10_stat_efficiency_v2` | 3.065 | +1.053 | **0.243** | **3.865** | 49 |
+| `v11_team_context_v2` | 3.034 | +1.138 | **0.246** | **3.856** | 49 |
 | `external_fantasypros_v1` | 3.281 | +1.622 | **0.409** | **3.898** | 51 |
 
 ### WR
@@ -248,6 +278,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | 4.485 | -1.676 | -3.836 | 6.743 | 55 |
 | `v8_age_regression` | **2.643** | +1.082 | **-0.105** | **3.223** | 55 |
 | `v9_pos_specific` | **2.643** | +1.082 | **-0.105** | **3.223** | 55 |
+| `v10_stat_efficiency_v2` | **2.654** | +1.059 | **-0.109** | **3.230** | 55 |
+| `v11_team_context_v2` | **2.647** | +1.008 | **-0.109** | **3.229** | 55 |
 | `external_fantasypros_v1` | **2.353** | +1.365 | **0.187** | **2.832** | 58 |
 
 ### TE
@@ -263,6 +295,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | 3.215 | -1.358 | -0.845 | 4.092 | 56 |
 | `v8_age_regression` | 1.859 | +0.383 | 0.411 | 2.311 | 56 |
 | `v9_pos_specific` | 1.859 | +0.383 | 0.411 | 2.311 | 56 |
+| `v10_stat_efficiency_v2` | 1.854 | +0.371 | 0.416 | 2.302 | 56 |
+| `v11_team_context_v2` | 1.902 | +0.364 | 0.388 | 2.357 | 56 |
 | `external_fantasypros_v1` | **1.719** | +0.666 | **0.486** | **2.106** | 55 |
 
 ### K
@@ -278,6 +312,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | 2.369 | -0.747 | -1.792 | 2.868 | 32 |
 | `v8_age_regression` | **1.424** | +0.385 | **-0.328** | **1.978** | 32 |
 | `v9_pos_specific` | **1.424** | +0.385 | **-0.328** | **1.978** | 32 |
+| `v10_stat_efficiency_v2` | **1.424** | +0.385 | **-0.328** | **1.978** | 32 |
+| `v11_team_context_v2` | **1.424** | +0.385 | **-0.328** | **1.978** | 32 |
 | `external_fantasypros_v1` | — | — | — | — | — |
 
 ## Season 2025
@@ -295,6 +331,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | 3.902 | -1.299 | -0.029 | 5.202 | 261 |
 | `v8_age_regression` | **2.637** | -0.710 | **0.512** | **3.583** | 261 |
 | `v9_pos_specific` | **2.637** | -0.710 | **0.512** | **3.583** | 261 |
+| `v10_stat_efficiency_v2` | **2.639** | -0.705 | **0.512** | **3.581** | 261 |
+| `v11_team_context_v2` | **2.637** | -0.744 | **0.516** | **3.570** | 261 |
 | `external_fantasypros_v1` | **2.613** | +0.721 | **0.538** | **3.637** | 246 |
 
 ### QB
@@ -310,6 +348,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | 4.857 | -0.624 | 0.075 | 6.175 | 53 |
 | `v8_age_regression` | **4.116** | -1.596 | **0.242** | **5.590** | 53 |
 | `v9_pos_specific` | **4.116** | -1.596 | **0.242** | **5.590** | 53 |
+| `v10_stat_efficiency_v2` | **4.134** | -1.552 | **0.239** | **5.599** | 53 |
+| `v11_team_context_v2` | **4.134** | -1.602 | **0.256** | **5.539** | 53 |
 | `external_fantasypros_v1` | **4.124** | +2.526 | **0.202** | **5.673** | 52 |
 
 ### RB
@@ -325,6 +365,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | 4.663 | -1.401 | -0.312 | 6.184 | 54 |
 | `v8_age_regression` | **2.705** | -0.431 | **0.635** | **3.262** | 54 |
 | `v9_pos_specific` | **2.705** | -0.431 | **0.635** | **3.262** | 54 |
+| `v10_stat_efficiency_v2` | **2.670** | -0.417 | **0.644** | **3.223** | 54 |
+| `v11_team_context_v2` | **2.646** | -0.518 | **0.640** | **3.239** | 54 |
 | `external_fantasypros_v1` | **2.584** | +0.361 | **0.628** | **3.252** | 64 |
 
 ### WR
@@ -340,6 +382,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | 4.062 | -2.016 | -1.318 | 5.371 | 62 |
 | `v8_age_regression` | **2.415** | -0.878 | **0.207** | **3.142** | 62 |
 | `v9_pos_specific` | **2.415** | -0.878 | **0.207** | **3.142** | 62 |
+| `v10_stat_efficiency_v2` | **2.433** | -0.899 | **0.201** | **3.153** | 62 |
+| `v11_team_context_v2` | **2.453** | -0.921 | **0.187** | **3.180** | 62 |
 | `external_fantasypros_v1` | **2.398** | -0.494 | **0.333** | **3.004** | 66 |
 
 ### TE
@@ -355,6 +399,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | 2.911 | -1.270 | -0.206 | 3.848 | 62 |
 | `v8_age_regression` | **1.912** | -0.257 | **0.553** | **2.342** | 62 |
 | `v9_pos_specific` | **1.912** | -0.257 | **0.553** | **2.342** | 62 |
+| `v10_stat_efficiency_v2` | **1.917** | -0.265 | **0.551** | **2.346** | 62 |
+| `v11_team_context_v2` | **1.911** | -0.279 | **0.554** | **2.338** | 62 |
 | `external_fantasypros_v1` | **1.637** | +0.867 | **0.604** | **2.192** | 64 |
 
 ### K
@@ -370,6 +416,8 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v7_regression_to_mean` | 2.561 | -0.889 | -1.784 | 3.005 | 30 |
 | `v8_age_regression` | **1.856** | -0.232 | **-0.721** | **2.363** | 30 |
 | `v9_pos_specific` | **1.856** | -0.232 | **-0.721** | **2.363** | 30 |
+| `v10_stat_efficiency_v2` | **1.856** | -0.232 | **-0.721** | **2.363** | 30 |
+| `v11_team_context_v2` | **1.856** | -0.232 | **-0.721** | **2.363** | 30 |
 | `external_fantasypros_v1` | — | — | — | — | — |
 
 ## All Seasons Combined
@@ -389,6 +437,8 @@ _Weighted averages across all seasons (weighted by player count N). RMSE is appr
 | `v7_regression_to_mean` | 3.807 | -1.002 | -0.060 | 5.161 | 502 |
 | `v8_age_regression` | **2.530** | +0.075 | **0.522** | **3.454** | 844 |
 | `v9_pos_specific` | **2.530** | +0.075 | **0.522** | **3.454** | 844 |
+| `v10_stat_efficiency_v2` | **2.525** | +0.076 | **0.523** | **3.449** | 844 |
+| `v11_team_context_v2` | **2.535** | +0.039 | **0.522** | **3.453** | 844 |
 | `external_fantasypros_v1` | **2.607** | +1.317 | **0.561** | **3.536** | 766 |
 
 ### QB
@@ -404,6 +454,8 @@ _Weighted averages across all seasons (weighted by player count N). RMSE is appr
 | `v7_regression_to_mean` | 4.553 | -0.331 | 0.183 | 5.841 | 102 |
 | `v8_age_regression` | **3.845** | -0.737 | **0.293** | **5.092** | 177 |
 | `v9_pos_specific` | **3.845** | -0.737 | **0.293** | **5.092** | 177 |
+| `v10_stat_efficiency_v2` | **3.843** | -0.712 | **0.293** | **5.092** | 177 |
+| `v11_team_context_v2` | **3.882** | -0.789 | **0.292** | **5.091** | 177 |
 | `external_fantasypros_v1` | 4.083 | +2.628 | 0.176 | 5.365 | 171 |
 
 ### RB
@@ -419,6 +471,8 @@ _Weighted averages across all seasons (weighted by player count N). RMSE is appr
 | `v7_regression_to_mean` | 4.222 | -0.454 | -0.252 | 5.583 | 103 |
 | `v8_age_regression` | **2.916** | +0.474 | **0.322** | **3.762** | 165 |
 | `v9_pos_specific` | **2.916** | +0.474 | **0.322** | **3.762** | 165 |
+| `v10_stat_efficiency_v2` | **2.884** | +0.476 | **0.331** | **3.735** | 165 |
+| `v11_team_context_v2` | **2.894** | +0.435 | **0.318** | **3.769** | 165 |
 | `external_fantasypros_v1` | **2.778** | +1.246 | **0.525** | **3.478** | 185 |
 
 ### WR
@@ -434,6 +488,8 @@ _Weighted averages across all seasons (weighted by player count N). RMSE is appr
 | `v7_regression_to_mean` | 4.261 | -1.856 | -2.502 | 6.055 | 117 |
 | `v8_age_regression` | **2.461** | +0.387 | **0.223** | **3.070** | 194 |
 | `v9_pos_specific` | **2.461** | +0.387 | **0.223** | **3.070** | 194 |
+| `v10_stat_efficiency_v2` | **2.466** | +0.369 | **0.221** | **3.073** | 194 |
+| `v11_team_context_v2` | **2.456** | +0.338 | **0.224** | **3.060** | 194 |
 | `external_fantasypros_v1` | **2.189** | +0.737 | **0.405** | **2.734** | 209 |
 
 ### TE
@@ -449,6 +505,8 @@ _Weighted averages across all seasons (weighted by player count N). RMSE is appr
 | `v7_regression_to_mean` | 3.055 | -1.312 | -0.509 | 3.965 | 118 |
 | `v8_age_regression` | **1.747** | +0.173 | **0.515** | **2.169** | 198 |
 | `v9_pos_specific` | **1.747** | +0.173 | **0.515** | **2.169** | 198 |
+| `v10_stat_efficiency_v2` | **1.747** | +0.171 | **0.514** | **2.170** | 198 |
+| `v11_team_context_v2` | **1.757** | +0.149 | **0.514** | **2.172** | 198 |
 | `external_fantasypros_v1` | **1.630** | +0.871 | **0.563** | **2.062** | 201 |
 
 ### K
@@ -464,4 +522,6 @@ _Weighted averages across all seasons (weighted by player count N). RMSE is appr
 | `v7_regression_to_mean` | 2.462 | -0.816 | -1.788 | 2.935 | 62 |
 | `v8_age_regression` | **1.366** | +0.053 | **-0.605** | **1.868** | 110 |
 | `v9_pos_specific` | **1.366** | +0.053 | **-0.605** | **1.868** | 110 |
+| `v10_stat_efficiency_v2` | **1.366** | +0.053 | **-0.605** | **1.868** | 110 |
+| `v11_team_context_v2` | **1.366** | +0.053 | **-0.605** | **1.868** | 110 |
 | `external_fantasypros_v1` | — | — | — | — | — |

--- a/migrations/018_add_nfl_stats_recent_team.sql
+++ b/migrations/018_add_nfl_stats_recent_team.sql
@@ -1,0 +1,6 @@
+-- Add recent_team column to nfl_stats for historical team tracking.
+-- This enables the team_context projection feature to correctly handle
+-- players who changed teams between seasons.
+alter table nfl_stats add column if not exists recent_team text;
+alter table nfl_stats add column if not exists passing_attempts integer;
+alter table nfl_stats add column if not exists completions integer;

--- a/schema.sql
+++ b/schema.sql
@@ -118,6 +118,9 @@ create table nfl_stats (
   total_snaps integer,
   total_points numeric,
   ppg numeric,
+  recent_team text,
+  passing_attempts integer,
+  completions integer,
   created_at timestamp with time zone default timezone('utc'::text, now()) not null,
   updated_at timestamp with time zone default timezone('utc'::text, now()) not null,
   unique(player_id, season)

--- a/scripts/backfill_nfl_stats.py
+++ b/scripts/backfill_nfl_stats.py
@@ -192,6 +192,11 @@ def process_stats(combined: pd.DataFrame) -> pd.DataFrame:
     if "player_id" in combined.columns:
         agg_cols["player_id"] = "first"
 
+    # Preserve recent_team: for traded players, keep the team where they
+    # played the most games (last row after sort is a reasonable proxy)
+    if "recent_team" in combined.columns:
+        agg_cols["recent_team"] = "last"
+
     combined = (
         combined
         .groupby(["player_display_name", "season"], as_index=False)
@@ -436,6 +441,11 @@ def backfill_seasons(
             "passing_attempts": _safe_int(getattr(row, "passing_attempts", None)),
             "completions": _safe_int(getattr(row, "completions", None)),
         }
+
+        # Preserve recent_team for historical team tracking
+        recent_team = getattr(row, "recent_team", None)
+        if recent_team and pd.notna(recent_team):
+            stat_row["recent_team"] = str(recent_team)
 
         # Calculate fantasy points
         stat_row["total_points"] = round(calc_half_ppr_points(stat_row), 2)

--- a/scripts/feature_projections/backtest.py
+++ b/scripts/feature_projections/backtest.py
@@ -160,20 +160,10 @@ def backtest_model(
             })
 
         if records:
-            # Use a workaround for NULL position in unique constraint:
-            # delete existing then insert
-            for rec in records:
-                q = (
-                    supabase.table("backtest_results")
-                    .delete()
-                    .eq("model_id", model_id)
-                    .eq("season", season)
-                )
-                if rec["position"] is None:
-                    q = q.is_("position", "null")
-                else:
-                    q = q.eq("position", rec["position"])
-                q.execute()
+            # Delete all existing results for this model/season, then insert fresh
+            supabase.table("backtest_results").delete().eq(
+                "model_id", model_id
+            ).eq("season", season).execute()
 
             supabase.table("backtest_results").insert(records).execute()
             print(f"  Stored {len(records)} backtest results")

--- a/scripts/feature_projections/features/team_context.py
+++ b/scripts/feature_projections/features/team_context.py
@@ -1,4 +1,13 @@
-"""Team context feature — adjust projections based on team offensive quality."""
+"""Team context feature — adjust projections based on team offensive quality.
+
+v2: Position-specific scaling, kicker exclusion, team-change handling.
+Fixes from issue #279:
+- Excludes kickers (team offense is irrelevant for K)
+- Uses per-season team history when available (not just current team)
+- Position-specific scaling (QB most affected, TE least)
+- Reduced scaling from 0.10 to 0.02-0.05 range
+- Dampens adjustment for players who changed teams (more uncertainty)
+"""
 
 from __future__ import annotations
 
@@ -12,15 +21,25 @@ from scripts.feature_projections.features.base import ProjectionFeature
 class TeamContextFeature(ProjectionFeature):
     """Adjusts projection based on team offensive environment quality.
 
-    Computes a team's offensive PPG relative to league average from nfl_stats,
-    then applies a scaled adjustment to the player's projection.
-
-    Players on high-scoring offenses get a boost; players on low-scoring
-    offenses get penalized.
+    Uses historical per-season team data when available to compute the
+    offense rating for the team the player actually played on, not just
+    their current team. Applies position-specific scaling and dampens
+    the adjustment for players who recently changed teams.
     """
 
-    # How much of the team-level deviation to apply to individual players
-    SCALING_FACTOR = 0.10
+    # Position-specific scaling factors: how much team quality affects
+    # individual production. QBs are most coupled to team offense,
+    # TEs are least affected.
+    POSITION_SCALING: dict[str, float] = {
+        "QB": 0.05,
+        "RB": 0.04,
+        "WR": 0.03,
+        "TE": 0.02,
+    }
+
+    # Dampen factor for players who changed teams — new team = more
+    # uncertainty about how the player fits the offense
+    TEAM_CHANGE_DAMPEN = 0.5
 
     @property
     def name(self) -> str:
@@ -34,13 +53,58 @@ class TeamContextFeature(ProjectionFeature):
         nfl_stats_df: pd.DataFrame,
         context: dict[str, Any],
     ) -> Optional[float]:
-        team_offense_rating = context.get("team_offense_rating")
-        if team_offense_rating is None:
+        # Kickers are not meaningfully affected by team offensive quality
+        if position == "K":
             return None
 
         base_ppg = context.get("base_ppg")
         if not base_ppg or base_ppg <= 0:
             return None
 
-        # team_offense_rating is deviation from league average (e.g., +2.5 or -1.3)
-        return team_offense_rating * self.SCALING_FACTOR
+        scaling = self.POSITION_SCALING.get(position)
+        if scaling is None:
+            return None
+
+        target_season = context.get("target_season")
+        team_history: dict[int, str] = context.get("team_history", {})
+        all_team_ratings: dict[str, float] = context.get("all_team_ratings", {})
+        current_team: str | None = context.get("nfl_team")
+
+        # Determine the effective team and whether the player changed teams
+        team_changed = False
+        effective_team = current_team
+
+        if team_history and target_season:
+            # Find the most recent historical team
+            historical_seasons = sorted(
+                [s for s in team_history if s < target_season], reverse=True
+            )
+            if historical_seasons:
+                most_recent_team = team_history[historical_seasons[0]]
+                effective_team = most_recent_team
+
+                # Detect team change: current team differs from most recent historical team
+                if current_team and current_team != most_recent_team:
+                    team_changed = True
+
+                # Check if player was on this team for the historical period used
+                # If they were on different teams across history, use the most recent
+                # season's team rating (most predictive of next season)
+
+        # Get the offense rating for the effective team
+        if not effective_team or effective_team not in all_team_ratings:
+            # Fall back to context-level rating (current team)
+            offense_rating = context.get("team_offense_rating")
+            if offense_rating is None:
+                return None
+        else:
+            offense_rating = all_team_ratings[effective_team]
+
+        # Apply position-specific scaling
+        adjustment = offense_rating * scaling
+
+        # Dampen for team changers — new team context is less predictive
+        if team_changed:
+            adjustment *= self.TEAM_CHANGE_DAMPEN
+
+        return adjustment

--- a/scripts/feature_projections/model_config.py
+++ b/scripts/feature_projections/model_config.py
@@ -114,6 +114,16 @@ MODELS: dict[str, ModelDefinition] = {
         description="v8 (age_curve + regression_to_mean) + rewritten stat_efficiency v2 with rate-based efficiency deltas.",
         features=["weighted_ppg", "age_curve", "regression_to_mean", "stat_efficiency"],
     ),
+    "v11_team_context_v2": ModelDefinition(
+        name="v11_team_context_v2",
+        version=1,
+        description=(
+            "v8 (age_curve + regression_to_mean) + fixed team_context v2: "
+            "position-specific scaling (0.02-0.05), kicker exclusion, "
+            "historical team tracking, team-change dampening."
+        ),
+        features=["weighted_ppg", "age_curve", "regression_to_mean", "team_context"],
+    ),
     "external_fantasypros_v1": ModelDefinition(
         name="external_fantasypros_v1",
         version=1,

--- a/scripts/feature_projections/runner.py
+++ b/scripts/feature_projections/runner.py
@@ -105,6 +105,31 @@ def _compute_positional_mean_ppg(
     return {str(pos): float(val) for pos, val in pos_means.items()}
 
 
+def _build_player_team_history(
+    player_id: str,
+    nfl_stats_all: pd.DataFrame,
+) -> dict[int, str]:
+    """Build a mapping of season -> team for a player from nfl_stats.recent_team.
+
+    Returns dict like {2022: "KC", 2023: "KC", 2024: "NYJ"}.
+    """
+    if nfl_stats_all.empty or "recent_team" not in nfl_stats_all.columns:
+        return {}
+
+    player_rows = nfl_stats_all[nfl_stats_all["player_id"] == player_id]
+    if player_rows.empty:
+        return {}
+
+    team_history: dict[int, str] = {}
+    for _, row in player_rows.iterrows():
+        season = int(row["season"]) if pd.notna(row.get("season")) else None
+        team = row.get("recent_team")
+        if season and team and pd.notna(team):
+            team_history[season] = str(team)
+
+    return team_history
+
+
 def _build_context(
     player_id: str,
     position: str,
@@ -124,12 +149,24 @@ def _build_context(
         if pd.notna(bd):
             context["birth_date"] = bd
 
-    # Team offense rating and usage
+    # Current team and team offense rating
     nfl_team = player_row.iloc[0].get("nfl_team") if not player_row.empty else None
+    context["nfl_team"] = nfl_team
+
     if nfl_team and nfl_team in team_aggregates:
         team_data = team_aggregates[nfl_team]
         context["team_offense_rating"] = team_data.get("offense_rating", 0.0)
         context["team_usage"] = team_data.get("usage_by_season", {})
+
+    # Per-season team history for team_context feature
+    team_history = _build_player_team_history(player_id, nfl_stats_all)
+    context["team_history"] = team_history
+
+    # Per-team offense ratings (all teams) for historical lookups
+    context["all_team_ratings"] = {
+        team: data.get("offense_rating", 0.0)
+        for team, data in team_aggregates.items()
+    }
 
     # Positional mean PPG for regression-to-mean feature
     if positional_means and position in positional_means:
@@ -141,22 +178,35 @@ def _build_context(
 def _compute_team_aggregates(
     nfl_stats_all: pd.DataFrame, players_df: pd.DataFrame
 ) -> dict[str, Any]:
-    """Compute team-level aggregates from nfl_stats for team_context and usage_share."""
+    """Compute team-level aggregates from nfl_stats for team_context and usage_share.
+
+    Prefers nfl_stats.recent_team (historical per-season team) when available,
+    falling back to players.nfl_team (current team) for backward compatibility.
+    """
     if nfl_stats_all.empty or players_df.empty:
         return {}
 
-    # Join nfl_stats with players to get nfl_team
-    merged = nfl_stats_all.merge(
-        players_df[["player_id_ref", "nfl_team"]],
-        left_on="player_id",
-        right_on="player_id_ref",
-        how="left",
-    )
+    # Use recent_team from nfl_stats if available, otherwise fall back to players.nfl_team
+    has_recent_team = "recent_team" in nfl_stats_all.columns and nfl_stats_all["recent_team"].notna().any()
+
+    if has_recent_team:
+        # Use the historical team directly from nfl_stats
+        merged = nfl_stats_all.copy()
+        merged["team_for_agg"] = merged["recent_team"]
+    else:
+        # Fall back to joining with players table (current team — legacy behavior)
+        merged = nfl_stats_all.merge(
+            players_df[["player_id_ref", "nfl_team"]],
+            left_on="player_id",
+            right_on="player_id_ref",
+            how="left",
+        )
+        merged["team_for_agg"] = merged["nfl_team"]
 
     team_aggregates: dict[str, Any] = {}
 
-    for nfl_team, team_df in merged.groupby("nfl_team"):
-        if not nfl_team or pd.isna(nfl_team):
+    for team, team_df in merged.groupby("team_for_agg"):
+        if not team or pd.isna(team):
             continue
 
         # Team total points per season
@@ -169,8 +219,6 @@ def _compute_team_aggregates(
             season_ppg[season] = float(total_points) / 17.0  # approximate team PPG
 
             # Aggregate usage stats per team/season
-            # Note: passing_attempts is available in nfl_stats but not used here
-            # yet — see docs/exec-plans/qb-usage-share.md for why and next steps
             usage_by_season[season] = {
                 "targets": float(season_df["targets"].fillna(0).sum()),
                 "rushing_attempts": float(season_df["rushing_attempts"].fillna(0).sum()),
@@ -179,8 +227,7 @@ def _compute_team_aggregates(
         # Compute offense rating: recency-weighted deviation from league average
         if season_ppg:
             avg_team_ppg = sum(season_ppg.values()) / len(season_ppg)
-            # Simple deviation (will be compared to league-wide average in context)
-            team_aggregates[str(nfl_team)] = {
+            team_aggregates[str(team)] = {
                 "avg_ppg": avg_team_ppg,
                 "offense_rating": 0.0,  # will be set after league average is computed
                 "usage_by_season": usage_by_season,
@@ -258,7 +305,7 @@ def run_model(
         for col in ["total_points", "games_played", "targets", "rushing_attempts",
                      "passing_yards", "passing_tds", "interceptions", "rushing_yards",
                      "rushing_tds", "receptions", "receiving_yards", "receiving_tds",
-                     "offense_snaps"]:
+                     "offense_snaps", "passing_attempts", "completions"]:
             if col in nfl_stats_all.columns:
                 nfl_stats_all[col] = pd.to_numeric(nfl_stats_all[col], errors="coerce").fillna(0)
         if "season" in nfl_stats_all.columns:

--- a/scripts/tests/test_feature_projections.py
+++ b/scripts/tests/test_feature_projections.py
@@ -302,14 +302,32 @@ class TestTeamContextFeature:
     def setup_method(self):
         self.feature = TeamContextFeature()
 
+    def _make_ctx(self, **overrides):
+        """Build a context dict with sensible defaults for team_context."""
+        ctx = {
+            "base_ppg": 15.0,
+            "target_season": 2025,
+            "nfl_team": "KC",
+            "team_offense_rating": 5.0,
+            "all_team_ratings": {"KC": 5.0, "NYJ": -2.0},
+            "team_history": {2023: "KC", 2024: "KC"},
+        }
+        ctx.update(overrides)
+        return ctx
+
     def test_positive_rating_gives_boost(self):
-        ctx = {"team_offense_rating": 5.0, "base_ppg": 15.0}
+        ctx = self._make_ctx(all_team_ratings={"KC": 5.0})
         result = self.feature.compute("p1", "QB", pd.DataFrame(), pd.DataFrame(), ctx)
         assert result is not None
         assert result > 0
 
     def test_negative_rating_gives_penalty(self):
-        ctx = {"team_offense_rating": -3.0, "base_ppg": 15.0}
+        ctx = self._make_ctx(
+            nfl_team="NYJ",
+            team_offense_rating=-3.0,
+            all_team_ratings={"NYJ": -3.0},
+            team_history={2023: "NYJ", 2024: "NYJ"},
+        )
         result = self.feature.compute("p1", "QB", pd.DataFrame(), pd.DataFrame(), ctx)
         assert result is not None
         assert result < 0
@@ -317,6 +335,49 @@ class TestTeamContextFeature:
     def test_no_rating_returns_none(self):
         result = self.feature.compute("p1", "QB", pd.DataFrame(), pd.DataFrame(), {})
         assert result is None
+
+    def test_kicker_excluded(self):
+        ctx = self._make_ctx()
+        result = self.feature.compute("p1", "K", pd.DataFrame(), pd.DataFrame(), ctx)
+        assert result is None
+
+    def test_position_specific_scaling(self):
+        """QB should get a larger adjustment than TE for the same team rating."""
+        ctx = self._make_ctx()
+        qb_result = self.feature.compute("p1", "QB", pd.DataFrame(), pd.DataFrame(), ctx)
+        te_result = self.feature.compute("p1", "TE", pd.DataFrame(), pd.DataFrame(), ctx)
+        assert qb_result is not None and te_result is not None
+        assert abs(qb_result) > abs(te_result)
+
+    def test_team_change_dampens_adjustment(self):
+        """Player who changed teams should get a smaller adjustment."""
+        # Same team throughout
+        ctx_same = self._make_ctx(
+            nfl_team="KC",
+            team_history={2023: "KC", 2024: "KC"},
+        )
+        result_same = self.feature.compute("p1", "QB", pd.DataFrame(), pd.DataFrame(), ctx_same)
+
+        # Changed teams (was NYJ, now KC)
+        ctx_changed = self._make_ctx(
+            nfl_team="KC",
+            team_history={2023: "NYJ", 2024: "NYJ"},
+            all_team_ratings={"KC": 5.0, "NYJ": -2.0},
+        )
+        result_changed = self.feature.compute("p1", "QB", pd.DataFrame(), pd.DataFrame(), ctx_changed)
+
+        assert result_same is not None and result_changed is not None
+        # Changed player uses historical team (NYJ: -2.0) with dampen,
+        # while same-team player uses KC (5.0) without dampen
+        assert abs(result_same) > abs(result_changed)
+
+    def test_reduced_scaling(self):
+        """Scaling should be much smaller than old 0.10 factor."""
+        ctx = self._make_ctx(all_team_ratings={"KC": 5.0})
+        result = self.feature.compute("p1", "QB", pd.DataFrame(), pd.DataFrame(), ctx)
+        assert result is not None
+        # Old scaling: 5.0 * 0.10 = 0.50. New QB scaling: 5.0 * 0.05 = 0.25
+        assert result == pytest.approx(0.25, abs=0.01)
 
 
 # ---------------------------------------------------------------------------
@@ -448,7 +509,13 @@ class TestCombiner:
             {"season": 2023, "ppg": 10.0, "games_played": 17},
             {"season": 2024, "ppg": 20.0, "games_played": 17},
         ])
-        ctx = {"team_offense_rating": 5.0}
+        ctx = {
+            "team_offense_rating": 5.0,
+            "target_season": 2025,
+            "nfl_team": "KC",
+            "all_team_ratings": {"KC": 5.0},
+            "team_history": {2023: "KC", 2024: "KC"},
+        }
         result, values = combine_features(
             [base, team], "p1", "QB", df, pd.DataFrame(), ctx
         )


### PR DESCRIPTION
## Summary
Fixes #279 — the team_context feature (v5) was adding +0.47 MAE because it used the player's *current* team with *historical* ratings (wrong for team-changers) and applied to kickers where team offense is irrelevant.

- **Exclude kickers** — return `None` for K position
- **Position-specific scaling** — QB (0.05), RB (0.04), WR (0.03), TE (0.02), down from flat 0.10
- **Historical team tracking** — added `recent_team` column to `nfl_stats`, backfilled from nflverse (2019-2025). Runner now builds per-season team history and passes it to the feature
- **Team-change dampening** — 50% dampen for players whose current team differs from most recent historical team
- **v11_team_context_v2** — new model definition for testing

### Accuracy Results (All Seasons Combined, ALL positions)

| Model | MAE | R² | Bias |
|-------|-----|-----|------|
| v2_age_adjusted | 2.584 | 0.499 | -0.120 |
| **v5_team_context (old)** | **3.424** | **0.190** | **-0.618** |
| v8_age_regression | 2.530 | 0.522 | +0.075 |
| **v11_team_context_v2 (new)** | **2.535** | **0.522** | **+0.039** |

The old team_context degraded MAE by +0.84 over v2. The new version is essentially neutral vs v8 (+0.005 MAE), with slightly better bias.

## Changes
- `migrations/018_add_nfl_stats_recent_team.sql` — add `recent_team` column
- `schema.sql` — canonical schema updated
- `scripts/feature_projections/features/team_context.py` — full rewrite
- `scripts/feature_projections/runner.py` — historical team context building
- `scripts/feature_projections/model_config.py` — v11 model definition
- `scripts/backfill_nfl_stats.py` — preserve `recent_team` from nflverse
- `scripts/feature_projections/backtest.py` — fix delete-then-insert race condition
- Tests and docs updated

## Test plan
- [x] All 70 unit tests pass (`pytest scripts/tests/test_feature_projections.py`)
- [x] Backtest run across 2022-2025: v11 does not degrade v8
- [x] Kickers correctly excluded (K results identical to v8)
- [x] Migration applied to production Supabase
- [x] `recent_team` backfilled for 2,428 player-season rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)