### PR TITLE
retro: document QB trajectory intent, backtest season gap, Supabase pagination

### DIFF
--- a/.claude/commands/projection-accuracy.md
+++ b/.claude/commands/projection-accuracy.md
@@ -4,11 +4,17 @@ description: Run projection accuracy comparison across all models and generate a
 Follow these steps to generate a projection accuracy comparison table:
 
 // turbo
-1. Activate the virtual environment and run backtests for all models, then generate the report
+1. **If a new model was just added**, first run it for ALL backtest seasons before running the report.
+   Missing seasons show as `—` in the table and corrupt the combined averages.
+   ```
+   source venv/bin/activate && python scripts/feature_projections/cli.py run --model <new_model> --seasons 2022,2023,2024,2025
+   ```
+
+2. Activate the virtual environment and run backtests for all models, then generate the report
 `source venv/bin/activate && python scripts/feature_projections/accuracy_report.py --run-backtest --seasons 2022,2023,2024,2025`
 
-2. The report is saved to `docs/generated/projection-accuracy.md` and printed to stdout.
+3. The report is saved to `docs/generated/projection-accuracy.md` and printed to stdout.
    Include the full markdown table in any task output or PR description when this relates to a projection model change.
 
-3. When comparing a specific pair of models (e.g., after adding a new model), you can also run:
+4. When comparing a specific pair of models (e.g., after adding a new model), you can also run:
 `source venv/bin/activate && python scripts/feature_projections/cli.py compare --models v1_baseline_weighted_ppg,<new_model> --season 2024`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,13 +77,32 @@ Run `make check-arch` to validate these rules locally.
 
 When any task modifies the projection system — including `scripts/feature_projections/`, `scripts/projection_methods.py`, `scripts/update_projections.py`, or `model_config.py` — you MUST:
 
-1. **Recompute the accuracy comparison table** by running:
+1. **Run the new model for ALL backtest seasons before calling `--run-backtest`.**
+   The accuracy report covers seasons 2022–2025. If a new model is missing any of those seasons in `model_projections`, that season will show `—` in the table and the combined averages will be wrong. Run:
    ```
-   source venv/bin/activate && python scripts/feature_projections/accuracy_report.py --run-backtest --seasons 2024,2025
+   source venv/bin/activate && python scripts/feature_projections/cli.py run --model <name> --seasons 2022,2023,2024,2025
+   ```
+   Then run the full report:
+   ```
+   source venv/bin/activate && python scripts/feature_projections/accuracy_report.py --run-backtest --seasons 2022,2023,2024,2025
    ```
 2. **Include the full markdown table** (from `docs/generated/projection-accuracy.md`) in:
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
+4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
 
 This ensures every projection change is empirically validated before merge.
+
+### Rookie snap trajectory (weighted_ppg feature)
+
+The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year players (`_rookie_trajectory`). This is appropriate for skill positions (WR/RB/TE) where rising snap share signals growing role. It is **not** appropriate for:
+
+- **QB**: A starting QB already receives all offensive snaps. A high H2/H1 ratio simply means they took over mid-season, not that they'll be better next year.
+- **K**: Snap counts are irrelevant to kicker scoring.
+
+`v12_no_qb_trajectory` (current active model) disables the trajectory for QB and K via `WeightedPPGNoQBTrajectoryFeature`. Do not re-enable it for those positions.
+
+### Supabase pagination
+
+Supabase's Python client defaults to a **1000-row limit** on `.execute()` calls. Any query that may return more than 1000 rows must use paginated `.range(offset, offset + page_size - 1)` fetching in a loop. This has already caused a silent bug in `promote.py` (now fixed). Apply the same pattern in any new bulk-fetch code.

--- a/docs/exec-plans/projection-accuracy-improvement.md
+++ b/docs/exec-plans/projection-accuracy-improvement.md
@@ -26,9 +26,11 @@ The combiner stacks features additively. When a feature adds noise (even small),
 | Model | MAE | R² | Bias |
 |-------|-----|-----|------|
 | `v1_baseline` | 2.666 | 0.472 | -0.389 |
-| **`v2_age_adjusted`** | **2.584** | **0.499** | -0.120 |
+| `v2_age_adjusted` | 2.584 | 0.499 | -0.120 |
 | v3-v6 | 2.95–4.01 | degrades | — |
-| **FantasyPros** | **2.607** | **0.561** | +1.317 |
+| `v8_age_regression` | 2.530 | 0.522 | +0.075 |
+| **`v12_no_qb_trajectory`** | **2.525** | **0.526** | **+0.103** |
+| FantasyPros | 2.607 | 0.561 | +1.317 |
 
 ---
 
@@ -56,7 +58,7 @@ Repair v3-v6 features so they contribute positively.
 - [#278](https://github.com/alex-monroe/ottoneu-db/issues/278) — ~~Fix stat_efficiency~~ ✅ (v10: rate-based efficiency deltas)
 - [#279](https://github.com/alex-monroe/ottoneu-db/issues/279) — ~~Fix team_context~~ ✅ (v11: K exclusion, position-specific scaling 0.02-0.05, historical team tracking via `nfl_stats.recent_team`, team-change dampening. Neutral to v8: MAE 2.535 vs 2.530)
 - [#280](https://github.com/alex-monroe/ottoneu-db/issues/280) — Test snap_trend feature
-- [#281](https://github.com/alex-monroe/ottoneu-db/issues/281) — Improve rookie projection
+- [#281](https://github.com/alex-monroe/ottoneu-db/issues/281) — ~~Improve rookie projection~~ ✅ (v12: disabled H2/H1 snap trajectory for QB and K. A first-year QB taking over mid-season has an inflated H2/H1 snap ratio that reflects role acquisition, not future performance signal. First-year QBs/Ks now use raw season PPG. MAE 2.530→2.525, R² 0.522→0.526; K improves meaningfully, QB neutral)
 
 ### Phase 4: New Data & ML
 


### PR DESCRIPTION
## Summary

Retrospective on the v12 no-QB-trajectory task. Three friction points surfaced that warranted documentation:

## Friction points

| # | What happened | Category | Proposed fix |
|---|--------------|----------|--------------|
| 1 | Re-ran projections assuming stale data; Shough's 20 PPG was intentional v8 snap trajectory behavior, not a bug | `agent-error` | Exec plan #281 now explains the snap trajectory issue and documents v12's fix |
| 2 | User had to correct that snap trajectory should be removed for QBs — not recorded anywhere | `user-correction` | AGENTS.md now documents the QB/K trajectory intent and warns against re-enabling |
| 3 | New model run for 2023–2025 only; accuracy report needed 2022 too — caused 3 separate report runs | `agent-error` | Skill and AGENTS.md now require all backtest seasons before `--run-backtest` |
| 4 | UI methodology text described v1 baseline; no rule to keep it in sync with active model | `missing-guardrail` | AGENTS.md now requires updating UI text when changing ACTIVE_MODEL |
| 5 | `promote.py` had silent 1000-row Supabase truncation — 2026 projections were dropped | `missing-guardrail` | Fixed in code (PR #310); AGENTS.md now documents the pagination pattern |

## Files changed

- **`AGENTS.md`** — Added to Projection Model Update Requirements: (1) run new model for all backtest seasons first, (2) update UI methodology text when changing ACTIVE_MODEL, (3) QB/K snap trajectory intent, (4) Supabase 1000-row pagination warning
- **`.claude/commands/projection-accuracy.md`** — Added step 1 callout for new models requiring all-season run before the report
- **`docs/exec-plans/projection-accuracy-improvement.md`** — Marked #281 complete with v12 description; updated current accuracy table to include v8 and v12

🤖 Generated with [Claude Code](https://claude.com/claude-code)