### PR TITLE
retro: document worktree build prerequisites, clarify projection comments

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -11,6 +11,9 @@ npm test             # Jest tests
 npm start            # Production server
 ```
 
+> **Worktree note:** Git worktrees share source files but not `node_modules/` or gitignored files.
+> Before building in a worktree, run `npm install` in `web/` and copy `config.json` from the main repo root.
+
 ## Backend (run from project root, venv must be active)
 
 All Python commands below assume the venv is activated. If running without activation, use `venv/bin/python` instead of `python`.

--- a/web/app/arb-progress/page.tsx
+++ b/web/app/arb-progress/page.tsx
@@ -85,7 +85,11 @@ export default async function ArbProgressPage() {
 
   // Compute projected raises: extrapolate based on how many eligible teams have completed.
   // Each player can be raised by 11 teams (all except their owner).
-  // If the owner's team is among the complete teams, subtract 1 from eligible complete count.
+  // If the owner's team is among the complete teams, subtract 1 from eligible complete count
+  // because the owner is complete but wasn't eligible to allocate to their own player.
+  // Example with 6 of 12 complete:
+  //   Player on complete team → 5 of 11 eligible have weighed in → factor 11/5 = 2.2x
+  //   Player on incomplete team → 6 of 11 eligible have weighed in → factor 11/6 = 1.83x
   const ELIGIBLE_TEAMS = NUM_TEAMS - 1; // 11 teams can raise any given player
   for (const a of allocations) {
     const ownerIsComplete = a.team_name ? completeTeamNames.has(a.team_name) : false;


### PR DESCRIPTION
## Summary
Retrospective from the arb-progress projected salaries task (#323).

| # | What happened | Category | Root cause | Proposed fix |
|---|--------------|----------|------------|--------------|
| 1 | `npm run build` failed — `config.json` missing in worktree | missing-docs | Worktree doesn't copy gitignored files | Document in COMMANDS.md |
| 2 | `npm run build` failed — `node_modules` missing in worktree | missing-docs | Worktree doesn't share node_modules | Document in COMMANDS.md |
| 3 | User asked if owner-complete asymmetry was handled | missing-guardrail | Code comment didn't show concrete example | Add example to comment |

## Changes
- **docs/COMMANDS.md** — Added worktree note about `npm install` and `config.json` prerequisites
- **web/app/arb-progress/page.tsx** — Expanded projection comment with concrete example showing the factor difference between players on complete vs incomplete teams