### PR TITLE
feat: improve rookie projection with growth curves and small-sample blending

### DIFF
--- a/docs/exec-plans/projection-accuracy-improvement.md
+++ b/docs/exec-plans/projection-accuracy-improvement.md
@@ -58,7 +58,7 @@ Repair v3-v6 features so they contribute positively.
 - [#278](https://github.com/alex-monroe/ottoneu-db/issues/278) — ~~Fix stat_efficiency~~ ✅ (v10: rate-based efficiency deltas)
 - [#279](https://github.com/alex-monroe/ottoneu-db/issues/279) — ~~Fix team_context~~ ✅ (v11: K exclusion, position-specific scaling 0.02-0.05, historical team tracking via `nfl_stats.recent_team`, team-change dampening. Neutral to v8: MAE 2.535 vs 2.530)
 - [#280](https://github.com/alex-monroe/ottoneu-db/issues/280) — Test snap_trend feature
-- [#281](https://github.com/alex-monroe/ottoneu-db/issues/281) — ~~Improve rookie projection~~ ✅ (v12: disabled H2/H1 snap trajectory for QB and K. A first-year QB taking over mid-season has an inflated H2/H1 snap ratio that reflects role acquisition, not future performance signal. First-year QBs/Ks now use raw season PPG. MAE 2.530→2.525, R² 0.522→0.526; K improves meaningfully, QB neutral)
+- [#281](https://github.com/alex-monroe/ottoneu-db/issues/281) — ~~Improve rookie projection~~ ✅ (v12: disabled H2/H1 snap trajectory for QB and K. v17: added position-specific rookie growth curves computed from 2018-2025 data (WR 1.04, RB 1.047, TE 1.051, QB 0.95) and small-sample blending for <4 game rookies. Growth delta applied only when snap data absent; dampened 50%. Neutral to v14 overall (ALL MAE 2.516 vs 2.515); existing age_curve + regression_to_mean already capture most rookie growth signal. Analysis script `analyze_rookie_growth.py` added for future tuning. Draft capital deferred — no data source.)
 
 ### Phase 4: New Data & ML
 

--- a/docs/generated/projection-accuracy.md
+++ b/docs/generated/projection-accuracy.md
@@ -1,6 +1,6 @@
 # Projection Model Accuracy Report
 
-_Generated: 2026-03-28 12:45_
+_Generated: 2026-03-28 14:59_
 
 Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed error (positive = under-projection), **R²** = Goodness of fit (higher is better), **RMSE** = Root mean square error, **N** = player sample size.
 
@@ -26,6 +26,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **2.165** | +0.524 | **0.667** | **2.826** | 154 |
 | `v15_snap_trend` | **2.187** | +0.102 | **0.640** | **2.937** | 154 |
 | `v16_snap_trend_full` | **2.142** | +0.496 | **0.670** | **2.811** | 154 |
+| `v17_rookie_growth` | **2.165** | +0.505 | **0.666** | **2.827** | 154 |
 | `external_fantasypros_v1` | 2.768 | +1.662 | 0.540 | 3.668 | 133 |
 
 ### QB
@@ -48,6 +49,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **3.488** | +0.530 | **0.310** | **4.271** | 36 |
 | `v15_snap_trend` | 3.647 | +0.170 | **0.224** | **4.527** | 36 |
 | `v16_snap_trend_full` | **3.509** | +0.643 | **0.308** | **4.276** | 36 |
+| `v17_rookie_growth` | **3.488** | +0.530 | **0.310** | **4.271** | 36 |
 | `external_fantasypros_v1` | 4.669 | +3.096 | -0.055 | 5.825 | 32 |
 
 ### RB
@@ -70,6 +72,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **2.506** | -0.059 | **0.558** | **3.059** | 25 |
 | `v15_snap_trend` | 2.780 | -0.949 | 0.479 | 3.319 | 25 |
 | `v16_snap_trend_full` | **2.420** | -0.246 | **0.561** | **3.047** | 25 |
+| `v17_rookie_growth` | **2.535** | -0.104 | **0.553** | **3.074** | 25 |
 | `external_fantasypros_v1` | **2.643** | +1.210 | **0.579** | **3.179** | 30 |
 
 ### WR
@@ -92,6 +95,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | 1.930 | +1.161 | 0.615 | 2.235 | 33 |
 | `v15_snap_trend` | **1.542** | +0.496 | **0.727** | **1.879** | 33 |
 | `v16_snap_trend_full` | **1.851** | +1.058 | **0.656** | **2.112** | 33 |
+| `v17_rookie_growth` | 1.906 | +1.125 | 0.619 | 2.221 | 33 |
 | `external_fantasypros_v1` | 1.927 | +1.295 | 0.623 | 2.401 | 36 |
 
 ### TE
@@ -114,6 +118,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | 1.560 | +0.651 | **0.592** | **1.821** | 36 |
 | `v15_snap_trend` | 1.635 | +0.416 | 0.527 | 1.961 | 36 |
 | `v16_snap_trend_full` | 1.599 | +0.588 | 0.568 | 1.875 | 36 |
+| `v17_rookie_growth` | 1.562 | +0.635 | **0.590** | **1.826** | 36 |
 | `external_fantasypros_v1` | 2.001 | +1.117 | 0.368 | 2.346 | 35 |
 
 ### K
@@ -136,6 +141,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **1.056** | +0.054 | **-1.029** | **1.521** | 24 |
 | `v15_snap_trend` | **1.094** | +0.081 | **-1.181** | **1.577** | 24 |
 | `v16_snap_trend_full` | **1.014** | +0.141 | **-0.940** | **1.487** | 24 |
+| `v17_rookie_growth` | **1.056** | +0.054 | **-1.029** | **1.521** | 24 |
 | `external_fantasypros_v1` | — | — | — | — | — |
 
 ## Season 2023
@@ -160,6 +166,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **2.614** | +0.468 | 0.441 | 3.738 | 188 |
 | `v15_snap_trend` | 2.700 | +0.081 | 0.414 | 3.825 | 188 |
 | `v16_snap_trend_full` | 2.658 | +0.443 | 0.425 | 3.791 | 188 |
+| `v17_rookie_growth` | **2.616** | +0.452 | 0.440 | 3.738 | 188 |
 | `external_fantasypros_v1` | **2.267** | +1.633 | **0.630** | **3.196** | 176 |
 
 ### QB
@@ -182,6 +189,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | 4.097 | +0.070 | 0.133 | 5.411 | 39 |
 | `v15_snap_trend` | 4.018 | -0.711 | 0.129 | 5.421 | 39 |
 | `v16_snap_trend_full` | 4.138 | -0.082 | 0.111 | 5.479 | 39 |
+| `v17_rookie_growth` | 4.097 | +0.070 | 0.133 | 5.411 | 39 |
 | `external_fantasypros_v1` | **3.640** | +2.361 | 0.166 | **4.770** | 40 |
 
 ### RB
@@ -204,6 +212,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **3.306** | +1.328 | **-0.192** | **4.641** | 37 |
 | `v15_snap_trend` | 3.593 | +0.842 | -0.345 | 4.929 | 37 |
 | `v16_snap_trend_full` | **3.386** | +1.280 | **-0.243** | **4.738** | 37 |
+| `v17_rookie_growth` | **3.306** | +1.328 | **-0.192** | **4.641** | 37 |
 | `external_fantasypros_v1` | **2.548** | +2.210 | **0.466** | **3.472** | 40 |
 
 ### WR
@@ -226,6 +235,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | 2.696 | +0.721 | 0.361 | 3.301 | 44 |
 | `v15_snap_trend` | 2.767 | +0.276 | 0.368 | 3.282 | 44 |
 | `v16_snap_trend_full` | 2.763 | +0.722 | 0.355 | 3.317 | 44 |
+| `v17_rookie_growth` | 2.695 | +0.720 | 0.361 | 3.301 | 44 |
 | `external_fantasypros_v1` | **1.903** | +1.239 | **0.602** | **2.450** | 49 |
 
 ### TE
@@ -248,6 +258,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **1.526** | +0.121 | **0.529** | **1.982** | 44 |
 | `v15_snap_trend` | **1.633** | -0.019 | **0.483** | **2.076** | 44 |
 | `v16_snap_trend_full` | **1.536** | +0.125 | **0.520** | **2.000** | 44 |
+| `v17_rookie_growth` | **1.533** | +0.053 | **0.527** | **1.986** | 44 |
 | `external_fantasypros_v1` | **1.237** | +0.931 | **0.743** | **1.535** | 47 |
 
 ### K
@@ -270,6 +281,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **0.984** | -0.041 | **-0.403** | **1.219** | 24 |
 | `v15_snap_trend` | **1.015** | +0.022 | -0.669 | 1.329 | 24 |
 | `v16_snap_trend_full` | **0.995** | +0.080 | -0.568 | 1.289 | 24 |
+| `v17_rookie_growth` | **0.984** | -0.041 | **-0.403** | **1.219** | 24 |
 | `external_fantasypros_v1` | — | — | — | — | — |
 
 ## Season 2024
@@ -294,6 +306,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **2.599** | +0.520 | **0.520** | **3.386** | 241 |
 | `v15_snap_trend` | **2.704** | +0.236 | **0.465** | **3.575** | 241 |
 | `v16_snap_trend_full` | **2.609** | +0.512 | **0.516** | **3.401** | 241 |
+| `v17_rookie_growth` | **2.599** | +0.520 | **0.520** | **3.386** | 241 |
 | `external_fantasypros_v1` | 2.782 | +1.531 | **0.543** | **3.602** | 211 |
 
 ### QB
@@ -316,6 +329,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **3.680** | -0.490 | **0.503** | **4.600** | 49 |
 | `v15_snap_trend` | **3.884** | -1.024 | **0.402** | **5.043** | 49 |
 | `v16_snap_trend_full` | **3.645** | -0.525 | **0.507** | **4.578** | 49 |
+| `v17_rookie_growth` | **3.680** | -0.490 | **0.503** | **4.600** | 49 |
 | `external_fantasypros_v1` | 4.015 | +2.650 | 0.313 | **5.163** | 47 |
 
 ### RB
@@ -338,6 +352,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | 3.063 | +1.098 | **0.244** | **3.861** | 49 |
 | `v15_snap_trend` | 3.185 | +0.865 | **0.180** | **4.022** | 49 |
 | `v16_snap_trend_full` | 3.174 | +1.131 | **0.200** | **3.972** | 49 |
+| `v17_rookie_growth` | 3.063 | +1.098 | **0.244** | **3.861** | 49 |
 | `external_fantasypros_v1` | 3.281 | +1.622 | **0.409** | **3.898** | 51 |
 
 ### WR
@@ -360,6 +375,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **2.643** | +1.082 | **-0.105** | **3.223** | 55 |
 | `v15_snap_trend` | **2.731** | +0.658 | **-0.136** | **3.268** | 55 |
 | `v16_snap_trend_full` | **2.608** | +1.026 | **-0.073** | **3.176** | 55 |
+| `v17_rookie_growth` | **2.643** | +1.082 | **-0.105** | **3.223** | 55 |
 | `external_fantasypros_v1` | **2.353** | +1.365 | **0.187** | **2.832** | 58 |
 
 ### TE
@@ -382,6 +398,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | 1.859 | +0.383 | 0.411 | 2.311 | 56 |
 | `v15_snap_trend` | 1.934 | +0.314 | 0.370 | 2.392 | 56 |
 | `v16_snap_trend_full` | 1.867 | +0.403 | 0.395 | 2.345 | 56 |
+| `v17_rookie_growth` | 1.860 | +0.382 | 0.411 | 2.312 | 56 |
 | `external_fantasypros_v1` | **1.719** | +0.666 | **0.486** | **2.106** | 55 |
 
 ### K
@@ -404,6 +421,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **1.455** | +0.456 | **-0.329** | **1.979** | 32 |
 | `v15_snap_trend` | **1.466** | +0.340 | **-0.415** | **2.041** | 32 |
 | `v16_snap_trend_full` | **1.455** | +0.456 | **-0.329** | **1.979** | 32 |
+| `v17_rookie_growth` | **1.455** | +0.456 | **-0.329** | **1.979** | 32 |
 | `external_fantasypros_v1` | — | — | — | — | — |
 
 ## Season 2025
@@ -428,6 +446,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **2.573** | -0.578 | **0.560** | **3.402** | 261 |
 | `v15_snap_trend` | **2.695** | -0.807 | **0.484** | **3.684** | 261 |
 | `v16_snap_trend_full` | **2.574** | -0.620 | **0.554** | **3.423** | 261 |
+| `v17_rookie_growth` | **2.573** | -0.577 | **0.560** | **3.402** | 261 |
 | `external_fantasypros_v1` | **2.613** | +0.721 | **0.538** | **3.637** | 246 |
 
 ### QB
@@ -450,6 +469,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **3.907** | -0.990 | **0.378** | **5.065** | 53 |
 | `v15_snap_trend` | **4.288** | -1.790 | **0.184** | **5.799** | 53 |
 | `v16_snap_trend_full` | **3.928** | -1.022 | **0.368** | **5.104** | 53 |
+| `v17_rookie_growth` | **3.907** | -0.990 | **0.378** | **5.065** | 53 |
 | `external_fantasypros_v1` | **4.124** | +2.526 | **0.202** | **5.673** | 52 |
 
 ### RB
@@ -472,6 +492,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **2.705** | -0.431 | **0.635** | **3.262** | 54 |
 | `v15_snap_trend` | **2.642** | -0.579 | **0.644** | **3.221** | 54 |
 | `v16_snap_trend_full` | **2.665** | -0.552 | **0.637** | **3.252** | 54 |
+| `v17_rookie_growth` | **2.705** | -0.431 | **0.635** | **3.262** | 54 |
 | `external_fantasypros_v1` | **2.584** | +0.361 | **0.628** | **3.252** | 64 |
 
 ### WR
@@ -494,6 +515,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **2.415** | -0.878 | **0.207** | **3.142** | 62 |
 | `v15_snap_trend` | **2.508** | -0.956 | **0.146** | **3.260** | 62 |
 | `v16_snap_trend_full` | **2.385** | -0.919 | **0.201** | **3.154** | 62 |
+| `v17_rookie_growth` | **2.415** | -0.878 | **0.207** | **3.142** | 62 |
 | `external_fantasypros_v1` | **2.398** | -0.494 | **0.333** | **3.004** | 66 |
 
 ### TE
@@ -516,6 +538,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **1.912** | -0.257 | **0.553** | **2.342** | 62 |
 | `v15_snap_trend` | **1.920** | -0.296 | **0.531** | **2.398** | 62 |
 | `v16_snap_trend_full` | **1.964** | -0.259 | **0.532** | **2.395** | 62 |
+| `v17_rookie_growth` | **1.910** | -0.254 | **0.555** | **2.338** | 62 |
 | `external_fantasypros_v1` | **1.637** | +0.867 | **0.604** | **2.192** | 64 |
 
 ### K
@@ -538,6 +561,7 @@ Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed
 | `v14_qb_starter` | **1.671** | -0.156 | **-0.385** | **2.120** | 30 |
 | `v15_snap_trend` | 1.959 | -0.233 | -0.896 | 2.481 | 30 |
 | `v16_snap_trend_full` | **1.671** | -0.156 | **-0.385** | **2.120** | 30 |
+| `v17_rookie_growth` | **1.671** | -0.156 | **-0.385** | **2.120** | 30 |
 | `external_fantasypros_v1` | — | — | — | — | — |
 
 ## All Seasons Combined
@@ -564,6 +588,7 @@ _Weighted averages across all seasons (weighted by player count N). RMSE is appr
 | `v14_qb_starter` | **2.515** | +0.170 | **0.542** | **3.380** | 844 |
 | `v15_snap_trend` | **2.606** | -0.146 | **0.492** | **3.561** | 844 |
 | `v16_snap_trend_full` | **2.524** | +0.144 | **0.536** | **3.401** | 844 |
+| `v17_rookie_growth` | **2.516** | +0.163 | **0.542** | **3.380** | 844 |
 | `external_fantasypros_v1` | **2.607** | +1.317 | **0.561** | **3.536** | 766 |
 
 ### QB
@@ -586,6 +611,7 @@ _Weighted averages across all seasons (weighted by player count N). RMSE is appr
 | `v14_qb_starter` | **3.801** | -0.309 | **0.344** | **4.868** | 177 |
 | `v15_snap_trend` | **3.986** | -0.942 | **0.241** | **5.268** | 177 |
 | `v16_snap_trend_full` | **3.810** | -0.339 | **0.338** | **4.892** | 177 |
+| `v17_rookie_growth` | **3.801** | -0.309 | **0.344** | **4.868** | 177 |
 | `external_fantasypros_v1` | 4.083 | +2.628 | 0.176 | 5.365 | 171 |
 
 ### RB
@@ -608,6 +634,7 @@ _Weighted averages across all seasons (weighted by player count N). RMSE is appr
 | `v14_qb_starter` | **2.916** | +0.474 | **0.322** | **3.762** | 165 |
 | `v15_snap_trend` | **3.037** | +0.112 | **0.259** | **3.914** | 165 |
 | `v16_snap_trend_full` | **2.941** | +0.405 | **0.298** | **3.819** | 165 |
+| `v17_rookie_growth` | **2.920** | +0.467 | **0.321** | **3.764** | 165 |
 | `external_fantasypros_v1` | **2.778** | +1.246 | **0.525** | **3.478** | 185 |
 
 ### WR
@@ -630,6 +657,7 @@ _Weighted averages across all seasons (weighted by player count N). RMSE is appr
 | `v14_qb_starter` | **2.461** | +0.387 | **0.223** | **3.070** | 194 |
 | `v15_snap_trend` | **2.465** | +0.028 | **0.215** | **3.077** | 194 |
 | `v16_snap_trend_full` | **2.443** | +0.341 | **0.236** | **3.048** | 194 |
+| `v17_rookie_growth` | **2.456** | +0.381 | **0.224** | **3.068** | 194 |
 | `external_fantasypros_v1` | **2.189** | +0.737 | **0.405** | **2.734** | 209 |
 
 ### TE
@@ -652,6 +680,7 @@ _Weighted averages across all seasons (weighted by player count N). RMSE is appr
 | `v14_qb_starter` | **1.747** | +0.173 | **0.515** | **2.169** | 198 |
 | `v15_snap_trend` | **1.808** | +0.067 | **0.474** | **2.253** | 198 |
 | `v16_snap_trend_full` | **1.775** | +0.168 | **0.497** | **2.209** | 198 |
+| `v17_rookie_growth` | **1.749** | +0.156 | **0.514** | **2.169** | 198 |
 | `external_fantasypros_v1` | **1.630** | +0.871 | **0.563** | **2.062** | 201 |
 
 ### K
@@ -674,4 +703,5 @@ _Weighted averages across all seasons (weighted by player count N). RMSE is appr
 | `v14_qb_starter` | **1.324** | +0.093 | **-0.513** | **1.787** | 110 |
 | `v15_snap_trend` | **1.421** | +0.058 | **-0.769** | **1.954** | 110 |
 | `v16_snap_trend_full` | **1.317** | +0.138 | **-0.530** | **1.791** | 110 |
+| `v17_rookie_growth` | **1.324** | +0.093 | **-0.513** | **1.787** | 110 |
 | `external_fantasypros_v1` | — | — | — | — | — |

--- a/docs/generated/segment-analysis.md
+++ b/docs/generated/segment-analysis.md
@@ -1,8 +1,8 @@
 # Segmented Projection Accuracy Analysis
 
-_Generated: 2026-03-18 20:01_
+_Generated: 2026-03-28 14:57_
 
-**Models:** `v1_baseline_weighted_ppg`, `v8_age_regression`, `external_fantasypros_v1`  
+**Models:** `v14_qb_starter`, `v17_rookie_growth`  
 **Seasons:** 2022, 2023, 2024, 2025  
 **Min games:** 4
 
@@ -10,26 +10,9 @@ _Generated: 2026-03-18 20:01_
 
 | Segment | Model | MAE | Bias | R² | N |
 | --- | --- | ---: | ---: | ---: | ---: |
-| rookie | `external_fantasypros_v1` | 2.558 | +1.328 | 0.505 | 288 |
-| rookie | `v1_baseline_weighted_ppg` | 2.773 | -0.175 | 0.324 | 180 |
-| rookie | `v8_age_regression` | 2.630 | -0.375 | 0.377 | 180 |
-| veteran | `external_fantasypros_v1` | 2.480 | +1.382 | 0.618 | 139 |
-| veteran | `v1_baseline_weighted_ppg` | 2.454 | -0.668 | 0.534 | 214 |
-| veteran | `v8_age_regression` | 2.441 | +0.435 | 0.549 | 214 |
-| young | `external_fantasypros_v1` | 2.701 | +1.281 | 0.548 | 339 |
-| young | `v1_baseline_weighted_ppg` | 2.724 | -0.341 | 0.502 | 450 |
-| young | `v8_age_regression` | 2.532 | +0.083 | 0.567 | 450 |
-
-## Player Age At Season Start
-
-| Segment | Model | MAE | Bias | R² | N |
-| --- | --- | ---: | ---: | ---: | ---: |
-| aging | `external_fantasypros_v1` | 3.353 | +1.627 | 0.269 | 66 |
-| aging | `v1_baseline_weighted_ppg` | 2.884 | -1.388 | 0.259 | 161 |
-| aging | `v8_age_regression` | 2.607 | +0.204 | 0.382 | 161 |
-| prime | `external_fantasypros_v1` | 2.646 | +1.354 | 0.571 | 343 |
-| prime | `v1_baseline_weighted_ppg` | 2.560 | -0.514 | 0.554 | 449 |
-| prime | `v8_age_regression` | 2.462 | -0.042 | 0.585 | 449 |
-| young | `external_fantasypros_v1` | 2.432 | +1.225 | 0.609 | 357 |
-| young | `v1_baseline_weighted_ppg` | 2.719 | +0.539 | 0.465 | 234 |
-| young | `v8_age_regression` | 2.606 | +0.209 | 0.508 | 234 |
+| rookie | `v14_qb_starter` | 2.567 | -0.168 | 0.446 | 180 |
+| rookie | `v17_rookie_growth` | 2.568 | -0.201 | 0.446 | 180 |
+| veteran | `v14_qb_starter` | 2.456 | +0.481 | 0.545 | 214 |
+| veteran | `v17_rookie_growth` | 2.456 | +0.481 | 0.545 | 214 |
+| young | `v14_qb_starter` | 2.523 | +0.157 | 0.581 | 450 |
+| young | `v17_rookie_growth` | 2.523 | +0.157 | 0.581 | 450 |

--- a/scripts/feature_projections/analyze_rookie_growth.py
+++ b/scripts/feature_projections/analyze_rookie_growth.py
@@ -1,0 +1,192 @@
+"""Compute position-specific rookie growth constants from historical data.
+
+Identifies rookies (players with exactly 1 season at time T), pairs their
+year-1 PPG with year-2 PPG, and computes per-position growth ratios and
+mean rookie PPG for small-sample blending.
+
+Usage:
+    venv/bin/python scripts/feature_projections/analyze_rookie_growth.py [--seasons 2019,2020,2021,2022,2023,2024,2025]
+    venv/bin/python scripts/feature_projections/analyze_rookie_growth.py --positions QB,WR,RB,TE
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import sys
+from collections import defaultdict
+
+# Setup paths
+script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+repo_root = os.path.dirname(script_dir)
+if script_dir not in sys.path:
+    sys.path.insert(0, script_dir)
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+
+from config import get_supabase_client, MIN_GAMES
+
+
+def compute_rookie_growth_ratios(
+    seasons: list[int],
+    min_games: int = MIN_GAMES,
+    positions: list[str] | None = None,
+) -> dict[str, dict[str, float]]:
+    """Compute rookie-to-year-2 growth ratios by position.
+
+    For each target season T in `seasons`:
+    - A "rookie" is a player whose first appearance in player_stats is season T-1
+      (i.e., they have exactly 1 season of history at projection time T).
+    - We pair their year-1 PPG (season T-1) with year-2 PPG (season T).
+    - Both seasons must have >= min_games.
+
+    Returns: {position: {"growth_ratio": median, "mean_ratio": mean,
+                          "rookie_mean_ppg": mean year-1 PPG, "n": count}}
+    """
+    supabase = get_supabase_client()
+
+    # Fetch all player_stats
+    all_seasons = list(range(min(seasons) - 1, max(seasons) + 1))
+    print(f"Fetching player_stats for seasons {all_seasons[0]}-{all_seasons[-1]}...")
+
+    stats_res = (
+        supabase.table("player_stats")
+        .select("player_id, season, ppg, games_played")
+        .gte("season", all_seasons[0])
+        .lte("season", all_seasons[-1])
+        .execute()
+    )
+
+    # Fetch player positions
+    players_res = supabase.table("players").select("id, position").execute()
+    pos_map = {row["id"]: row["position"] for row in (players_res.data or [])}
+
+    # Organize stats by player
+    player_seasons: dict[str, dict[int, dict]] = defaultdict(dict)
+    for row in (stats_res.data or []):
+        pid = row["player_id"]
+        season = int(row["season"])
+        player_seasons[pid][season] = row
+
+    # Find rookie pairs: for each target season T, find players whose
+    # first season in player_stats is T-1 (making them a "rookie" at time T)
+    pairs: dict[str, list[tuple[float, float]]] = defaultdict(list)  # position -> [(y1_ppg, y2_ppg)]
+    rookie_ppgs: dict[str, list[float]] = defaultdict(list)  # position -> [y1_ppg]
+
+    for target_season in seasons:
+        rookie_season = target_season - 1
+
+        for pid, seasons_data in player_seasons.items():
+            position = pos_map.get(pid)
+            if not position:
+                continue
+            if positions and position not in positions:
+                continue
+
+            # Check if rookie_season is their first season
+            player_season_list = sorted(seasons_data.keys())
+            if not player_season_list or player_season_list[0] != rookie_season:
+                continue
+            # Must have exactly 1 season before target_season
+            seasons_before_target = [s for s in player_season_list if s < target_season]
+            if len(seasons_before_target) != 1:
+                continue
+
+            y1_data = seasons_data.get(rookie_season)
+            y2_data = seasons_data.get(target_season)
+
+            if not y1_data or not y2_data:
+                continue
+
+            y1_games = int(y1_data.get("games_played", 0) or 0)
+            y2_games = int(y2_data.get("games_played", 0) or 0)
+
+            if y1_games < min_games or y2_games < min_games:
+                continue
+
+            y1_ppg = float(y1_data["ppg"])
+            y2_ppg = float(y2_data["ppg"])
+
+            if y1_ppg <= 0:
+                continue
+
+            ratio = y2_ppg / y1_ppg
+            pairs[position].append((y1_ppg, y2_ppg))
+            rookie_ppgs[position].append(y1_ppg)
+
+    # Compute per-position stats
+    results: dict[str, dict[str, float]] = {}
+    for position in sorted(pairs.keys()):
+        position_pairs = pairs[position]
+        ratios = [y2 / y1 for y1, y2 in position_pairs]
+        y1_ppgs = rookie_ppgs[position]
+
+        results[position] = {
+            "growth_ratio": round(statistics.median(ratios), 3),
+            "mean_ratio": round(statistics.mean(ratios), 3),
+            "rookie_mean_ppg": round(statistics.mean(y1_ppgs), 2),
+            "rookie_median_ppg": round(statistics.median(y1_ppgs), 2),
+            "n": len(position_pairs),
+        }
+
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compute rookie growth constants by position")
+    parser.add_argument(
+        "--seasons",
+        default="2019,2020,2021,2022,2023,2024,2025",
+        help="Comma-separated target seasons (default: 2019-2025)",
+    )
+    parser.add_argument(
+        "--positions",
+        default=None,
+        help="Comma-separated positions to analyze (default: all)",
+    )
+    parser.add_argument(
+        "--min-games",
+        type=int,
+        default=MIN_GAMES,
+        help=f"Minimum games played in both seasons (default: {MIN_GAMES})",
+    )
+    args = parser.parse_args()
+
+    seasons = [int(s.strip()) for s in args.seasons.split(",")]
+    positions = [p.strip().upper() for p in args.positions.split(",")] if args.positions else None
+
+    print(f"Computing rookie growth ratios")
+    print(f"Target seasons: {seasons}")
+    print(f"Positions: {positions or 'all'}")
+    print(f"Min games: {args.min_games}")
+    print()
+
+    results = compute_rookie_growth_ratios(seasons, args.min_games, positions)
+
+    if not results:
+        print("No rookie pairs found!")
+        return
+
+    # Display results table
+    print(f"\n{'Position':<6} {'N':>5} {'Median Ratio':>13} {'Mean Ratio':>11} "
+          f"{'Mean Y1 PPG':>12} {'Median Y1 PPG':>14}")
+    print("-" * 70)
+
+    for position, stats in results.items():
+        print(f"{position:<6} {stats['n']:>5} {stats['growth_ratio']:>13.3f} "
+              f"{stats['mean_ratio']:>11.3f} {stats['rookie_mean_ppg']:>12.2f} "
+              f"{stats['rookie_median_ppg']:>14.2f}")
+
+    # Print code snippet
+    print("\n\nSuggested ROOKIE_GROWTH_CURVES for weighted_ppg.py:")
+    print("-" * 60)
+    print("ROOKIE_GROWTH_CURVES = {")
+    for position, stats in results.items():
+        print(f'    "{position}": {{"growth_ratio": {stats["growth_ratio"]}, '
+              f'"rookie_mean_ppg": {stats["rookie_mean_ppg"]}}},')
+    print("}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/feature_projections/features/__init__.py
+++ b/scripts/feature_projections/features/__init__.py
@@ -3,7 +3,12 @@
 All features register themselves here. The registry maps feature name -> class.
 """
 
-from scripts.feature_projections.features.weighted_ppg import WeightedPPGFeature, WeightedPPGNoQBTrajectoryFeature
+from scripts.feature_projections.features.weighted_ppg import (
+    WeightedPPGFeature,
+    WeightedPPGNoQBTrajectoryFeature,
+    WeightedPPGRookieGrowthFeature,
+    WeightedPPGRookieGrowthNoQBFeature,
+)
 from scripts.feature_projections.features.age_curve import AgeCurveFeature
 from scripts.feature_projections.features.stat_efficiency import StatEfficiencyFeature
 from scripts.feature_projections.features.games_played import GamesPlayedFeature
@@ -28,4 +33,6 @@ FEATURE_REGISTRY: dict[str, type] = {
     "snap_trend": SnapTrendFeature,
     "qb_starter_usage": QBStarterUsageFeature,
     "qb_backup_penalty": QBStarterBackupPenaltyFeature,
+    "weighted_ppg_rookie_growth": WeightedPPGRookieGrowthFeature,
+    "weighted_ppg_rookie_growth_no_qb": WeightedPPGRookieGrowthNoQBFeature,
 }

--- a/scripts/feature_projections/features/weighted_ppg.py
+++ b/scripts/feature_projections/features/weighted_ppg.py
@@ -9,6 +9,22 @@ import pandas as pd
 from scripts.feature_projections.features.base import ProjectionFeature
 
 
+# Position-specific rookie year-1 → year-2 growth ratios (median) and
+# mean rookie PPG for small-sample blending.
+# Computed from 2018-2025 player_stats via analyze_rookie_growth.py.
+ROOKIE_GROWTH_CURVES: dict[str, dict[str, float]] = {
+    "QB": {"growth_ratio": 0.95, "rookie_mean_ppg": 14.22},
+    "RB": {"growth_ratio": 1.047, "rookie_mean_ppg": 9.22},
+    "WR": {"growth_ratio": 1.04, "rookie_mean_ppg": 9.65},
+    "TE": {"growth_ratio": 1.051, "rookie_mean_ppg": 5.14},
+    "K":  {"growth_ratio": 1.022, "rookie_mean_ppg": 7.97},
+}
+
+# Rookies with fewer games than this threshold get PPG blended toward the
+# positional rookie mean to reduce small-sample noise.
+ROOKIE_MIN_GAMES_FULL_WEIGHT = 4
+
+
 class WeightedPPGFeature(ProjectionFeature):
     """Recency-weighted, games-scaled average PPG.
 
@@ -119,6 +135,103 @@ class WeightedPPGNoQBTrajectoryFeature(WeightedPPGFeature):
     @property
     def name(self) -> str:
         return "weighted_ppg_no_qb_trajectory"
+
+    @property
+    def is_base(self) -> bool:
+        return True
+
+
+class WeightedPPGRookieGrowthFeature(WeightedPPGFeature):
+    """WeightedPPG with position-specific rookie growth curves and small-sample blending.
+
+    Enhancements over base WeightedPPGFeature for rookies:
+    1. Small-sample blending: if games_played < ROOKIE_MIN_GAMES_FULL_WEIGHT,
+       PPG is blended toward the positional rookie mean.
+    2. Position-specific growth adjustment: applies historical year-1→year-2
+       median improvement as a dampened additive delta (not multiplicative,
+       to avoid compounding with the snap trajectory factor).
+
+    Formula: base_ppg * snap_factor + growth_delta
+    where growth_delta = base_ppg * (growth_ratio - 1.0) * GROWTH_DAMPING
+
+    Veteran path (2+ seasons) is unchanged.
+    """
+
+    # Scale factor for the positional growth adjustment. The growth delta is
+    # only applied when snap trajectory data is absent (snap_factor == 1.0),
+    # since the snap trajectory already captures within-season momentum.
+    GROWTH_DAMPING = 0.5
+
+    @property
+    def name(self) -> str:
+        return "weighted_ppg_rookie_growth"
+
+    @property
+    def is_base(self) -> bool:
+        return True
+
+    def _rookie_trajectory(self, row: pd.Series, position: str = "") -> Optional[float]:
+        """Rookie projection with growth curves and small-sample blending."""
+        ppg = float(row["ppg"]) if pd.notna(row.get("ppg")) else 0.0
+        if ppg == 0:
+            return None
+
+        # Positions that skip snap trajectory get plain PPG (no growth either,
+        # since the growth ratio is coupled to the trajectory logic).
+        if position in self.NO_TRAJECTORY_POSITIONS:
+            return ppg
+
+        curve = ROOKIE_GROWTH_CURVES.get(position)
+        if not curve:
+            # Unknown position — fall back to snap-only trajectory
+            return super()._rookie_trajectory(row, position)
+
+        games_played = int(row.get("games_played", 0) or 0) if pd.notna(row.get("games_played")) else 0
+
+        # Small-sample blending: blend toward positional rookie mean
+        if games_played < ROOKIE_MIN_GAMES_FULL_WEIGHT and games_played > 0:
+            blend_weight = games_played / ROOKIE_MIN_GAMES_FULL_WEIGHT
+            blended_ppg = ppg * blend_weight + curve["rookie_mean_ppg"] * (1 - blend_weight)
+        else:
+            blended_ppg = ppg
+
+        # Snap trajectory factor (existing logic)
+        h1_snaps = int(row.get("h1_snaps") or 0) if pd.notna(row.get("h1_snaps")) else 0
+        h1_games = max(int(row.get("h1_games") or 1) if pd.notna(row.get("h1_games")) else 1, 1)
+        h2_snaps = int(row.get("h2_snaps") or 0) if pd.notna(row.get("h2_snaps")) else 0
+        h2_games = max(int(row.get("h2_games") or 1) if pd.notna(row.get("h2_games")) else 1, 1)
+
+        h1_spg = h1_snaps / h1_games
+        h2_spg = h2_snaps / h2_games
+
+        if h1_spg == 0:
+            snap_factor = 1.0
+        else:
+            snap_factor = min(max(h2_spg / h1_spg, self.ROOKIE_MIN_FACTOR), self.ROOKIE_MAX_FACTOR)
+
+        # Position-specific growth: only applied when snap trajectory data is
+        # absent (snap_factor == 1.0). When snap data exists, the trajectory
+        # already captures within-season momentum and adding growth over-projects.
+        if snap_factor == 1.0:
+            growth_delta = blended_ppg * (curve["growth_ratio"] - 1.0) * self.GROWTH_DAMPING
+        else:
+            growth_delta = 0.0
+
+        return blended_ppg * snap_factor + growth_delta
+
+
+class WeightedPPGRookieGrowthNoQBFeature(WeightedPPGRookieGrowthFeature):
+    """Rookie growth curves + no QB/K snap trajectory.
+
+    Combines position-specific rookie growth with the QB/K trajectory
+    exclusion from WeightedPPGNoQBTrajectoryFeature.
+    """
+
+    NO_TRAJECTORY_POSITIONS: frozenset[str] = frozenset({"QB", "K"})
+
+    @property
+    def name(self) -> str:
+        return "weighted_ppg_rookie_growth_no_qb"
 
     @property
     def is_base(self) -> bool:

--- a/scripts/feature_projections/model_config.py
+++ b/scripts/feature_projections/model_config.py
@@ -178,6 +178,17 @@ MODELS: dict[str, ModelDefinition] = {
             "snap_trend",
         ],
     ),
+    "v17_rookie_growth": ModelDefinition(
+        name="v17_rookie_growth",
+        version=1,
+        description=(
+            "v14 + position-specific rookie growth curves and small-sample blending. "
+            "Small-sample rookies (<4 games) blend PPG toward positional rookie mean. "
+            "Dampened growth delta applied only when snap trajectory data is absent. "
+            "Neutral to v14 overall (ALL MAE 2.516 vs 2.515); WR MAE slightly improved."
+        ),
+        features=["weighted_ppg_rookie_growth_no_qb", "age_curve", "regression_to_mean", "qb_backup_penalty"],
+    ),
     "external_fantasypros_v1": ModelDefinition(
         name="external_fantasypros_v1",
         version=1,

--- a/scripts/tests/test_feature_projections.py
+++ b/scripts/tests/test_feature_projections.py
@@ -8,7 +8,13 @@ Pure functions with no DB or network dependencies.
 import pytest
 import pandas as pd
 
-from scripts.feature_projections.features.weighted_ppg import WeightedPPGFeature
+from scripts.feature_projections.features.weighted_ppg import (
+    WeightedPPGFeature,
+    WeightedPPGRookieGrowthFeature,
+    WeightedPPGRookieGrowthNoQBFeature,
+    ROOKIE_GROWTH_CURVES,
+    ROOKIE_MIN_GAMES_FULL_WEIGHT,
+)
 from scripts.feature_projections.features.age_curve import AgeCurveFeature
 from scripts.feature_projections.features.stat_efficiency import StatEfficiencyFeature
 from scripts.feature_projections.features.games_played import GamesPlayedFeature
@@ -718,6 +724,139 @@ class TestWeightedPPGVeteranCases:
     def test_empty_history_returns_none(self):
         result = self.feature.compute("test", "QB", pd.DataFrame(), pd.DataFrame(), {})
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# WeightedPPGRookieGrowthFeature
+# ---------------------------------------------------------------------------
+
+class TestWeightedPPGRookieGrowthFeature:
+    """Tests for position-specific rookie growth curves and small-sample blending."""
+
+    def setup_method(self):
+        self.feature = WeightedPPGRookieGrowthFeature()
+        self.no_qb_feature = WeightedPPGRookieGrowthNoQBFeature()
+
+    def _project(self, history_rows, position="WR"):
+        df = make_history_df(history_rows)
+        return self.feature.compute("test", position, df, pd.DataFrame(), {})
+
+    def test_name(self):
+        assert self.feature.name == "weighted_ppg_rookie_growth"
+        assert self.feature.is_base is True
+        assert self.no_qb_feature.name == "weighted_ppg_rookie_growth_no_qb"
+
+    def test_rookie_growth_wr_vs_rb(self):
+        """WR and RB with identical stats (no snap data) get different projections due to growth."""
+        history = [{
+            "season": 2024, "ppg": 10.0, "games_played": 17,
+        }]
+        wr_result = self._project(history, "WR")
+        rb_result = self._project(history, "RB")
+        assert wr_result is not None
+        assert rb_result is not None
+        # No snap data → growth applies. RB growth_ratio (1.047) > WR (1.04)
+        assert rb_result > wr_result
+
+    def test_rookie_small_sample_blending(self):
+        """Rookie with 2 games should blend PPG 50/50 with positional mean."""
+        history = [{
+            "season": 2024, "ppg": 20.0, "games_played": 2,
+        }]
+        result = self._project(history, "WR")
+        # blend_weight = 2/4 = 0.5
+        # blended_ppg = 20.0 * 0.5 + 9.65 * 0.5 = 14.825
+        # No snap data → snap_factor = 1.0
+        # growth_delta = 14.825 * (1.04 - 1.0) * 0.5 = 0.2965
+        # result = 14.825 * 1.0 + 0.2965 = 15.1215
+        wr_curve = ROOKIE_GROWTH_CURVES["WR"]
+        expected_blend = 20.0 * 0.5 + wr_curve["rookie_mean_ppg"] * 0.5
+        growth_delta = expected_blend * (wr_curve["growth_ratio"] - 1.0) * 0.5
+        expected = expected_blend * 1.0 + growth_delta
+        assert result == pytest.approx(expected)
+
+    def test_rookie_full_sample_no_blending(self):
+        """Rookie with 10+ games uses raw PPG — no blending."""
+        history = [{
+            "season": 2024, "ppg": 10.0, "games_played": 10,
+        }]
+        result = self._project(history, "WR")
+        # No snap data → snap_factor = 1.0
+        # growth_delta = 10.0 * (1.04 - 1.0) * 0.5 = 0.2
+        # result = 10.0 * 1.0 + 0.2 = 10.2
+        wr_curve = ROOKIE_GROWTH_CURVES["WR"]
+        growth_delta = 10.0 * (wr_curve["growth_ratio"] - 1.0) * 0.5
+        expected = 10.0 + growth_delta
+        assert result == pytest.approx(expected)
+
+    def test_rookie_growth_ratio_applied_per_position(self):
+        """Each position gets its own growth delta (additive, dampened)."""
+        history = [{"season": 2024, "ppg": 10.0, "games_played": 17}]
+        for position in ["RB", "WR", "TE"]:
+            result = self._project(history, position)
+            curve = ROOKIE_GROWTH_CURVES[position]
+            growth_delta = 10.0 * (curve["growth_ratio"] - 1.0) * 0.5
+            expected = 10.0 + growth_delta  # snap_factor = 1.0 (no snap data)
+            assert result == pytest.approx(expected), f"Failed for {position}"
+
+    def test_rookie_qb_no_trajectory_still_skipped(self):
+        """NoQB variant returns plain PPG for QB — no growth ratio, no snap factor."""
+        history = [{
+            "season": 2024, "ppg": 15.0, "games_played": 17,
+            "h1_snaps": 200, "h1_games": 8, "h2_snaps": 400, "h2_games": 9,
+        }]
+        df = make_history_df(history)
+        result = self.no_qb_feature.compute("test", "QB", df, pd.DataFrame(), {})
+        # QB is in NO_TRAJECTORY_POSITIONS → returns plain PPG
+        assert result == pytest.approx(15.0)
+
+    def test_rookie_unknown_position_fallback(self):
+        """Unknown position falls back to base snap-only trajectory."""
+        history = [{
+            "season": 2024, "ppg": 10.0, "games_played": 17,
+            "h1_snaps": 200, "h1_games": 8,   # 25 SPG
+            "h2_snaps": 360, "h2_games": 9,   # 40 SPG → factor 1.5 (clamped)
+        }]
+        result = self._project(history, "UNKNOWN")
+        # Falls back to base class snap-only: 10 * 1.5 = 15.0
+        assert result == pytest.approx(15.0)
+
+    def test_veteran_path_unchanged(self):
+        """Veterans (2+ seasons) use same weighted average as base class."""
+        history = [
+            {"season": 2023, "ppg": 14.0, "games_played": 17},
+            {"season": 2024, "ppg": 18.0, "games_played": 17},
+        ]
+        growth_result = self._project(history, "WR")
+        base_feature = WeightedPPGFeature()
+        base_result = base_feature.compute("test", "WR", make_history_df(history), pd.DataFrame(), {})
+        assert growth_result == pytest.approx(base_result)
+
+    def test_rookie_snap_trajectory_suppresses_growth(self):
+        """When snap data exists, growth delta is NOT applied (snap captures momentum)."""
+        history = [{
+            "season": 2024, "ppg": 10.0, "games_played": 17,
+            "h1_snaps": 200, "h1_games": 8,   # 25 SPG
+            "h2_snaps": 270, "h2_games": 9,   # 30 SPG → factor = 1.2
+        }]
+        result = self._project(history, "RB")
+        # snap_factor = 30/25 = 1.2, growth_delta = 0 (snap data present)
+        # result = 10.0 * 1.2 = 12.0
+        assert result == pytest.approx(12.0)
+
+    def test_rookie_no_snap_data_gets_growth(self):
+        """Without snap data, growth delta applies (snap_factor == 1.0)."""
+        history = [{
+            "season": 2024, "ppg": 10.0, "games_played": 17,
+        }]
+        result = self._project(history, "RB")
+        # snap_factor = 1.0 (no snap data) → growth applies
+        # growth_delta = 10.0 * (1.047 - 1.0) * 0.5 = 0.235
+        # result = 10.0 * 1.0 + 0.235 = 10.235
+        rb_curve = ROOKIE_GROWTH_CURVES["RB"]
+        growth_delta = 10.0 * (rb_curve["growth_ratio"] - 1.0) * 0.5
+        expected = 10.0 + growth_delta
+        assert result == pytest.approx(expected)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #281

- Add position-specific rookie growth curves computed from 2018-2025 historical data (WR 1.04, RB 1.047, TE 1.051, QB 0.95, K 1.022)
- Add small-sample blending for rookies with <4 games — PPG blended toward positional rookie mean
- Growth delta only applied when snap trajectory data is absent (snap factor already captures within-season momentum); dampened 50%
- New analysis script `analyze_rookie_growth.py` for computing/updating growth constants
- New v17_rookie_growth model registered with 10 new tests

## Results

| Segment | v14 MAE | v17 MAE | v14 Bias | v17 Bias |
|---------|---------|---------|----------|----------|
| Rookie | 2.567 | 2.568 | -0.168 | -0.201 |
| Young | 2.523 | 2.523 | +0.157 | +0.157 |
| Veteran | 2.456 | 2.456 | +0.481 | +0.481 |
| **ALL** | **2.515** | **2.516** | **+0.170** | **+0.163** |

Neutral overall. The existing age_curve + regression_to_mean features already capture most of the rookie growth signal. The primary value is the analysis infrastructure and small-sample blending for edge cases. Draft capital (issue item 3) deferred — no data source exists.

## Test plan
- [x] All 105 tests pass (`pytest scripts/tests/test_feature_projections.py`)
- [x] v17 projections generated and backtested across 2022-2025
- [x] Segment analysis confirms no regression in any experience segment
- [x] Accuracy report regenerated with v17 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)