### PR TITLE
retro: document projection workflow and feature test requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,10 @@ When any task modifies the projection system — including `scripts/feature_proj
 
 This ensures every projection change is empirically validated before merge.
 
+### Feature changes require test updates
+
+When adding or rewriting a projection feature, check and update the corresponding tests in `scripts/tests/test_feature_projections.py`. Each feature class has a `Test<FeatureName>Feature` test class. Behavioral changes (e.g., a feature that previously required 2 seasons now works with 1) will cause existing tests to fail in CI if not updated.
+
 ### Rookie snap trajectory (weighted_ppg feature)
 
 The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year players (`_rookie_trajectory`). This is appropriate for skill positions (WR/RB/TE) where rising snap share signals growing role. It is **not** appropriate for:

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -60,6 +60,14 @@ python scripts/feature_projections/cli.py segment-analysis --segments experience
 python scripts/feature_projections/cli.py segment-analysis --models v8_age_regression --seasons 2024,2025  # Custom models/seasons
 python scripts/feature_projections/promote.py v14_qb_starter                                           # Promote model to production player_projections table
 
+# Projection Development Workflow (two-step process)
+# Step 1: Generate projections for the model (required after any feature code change)
+python scripts/feature_projections/cli.py run --model <name> --seasons 2022,2023,2024,2025
+# Step 2: Backtest to evaluate accuracy (uses stored projections from step 1)
+python scripts/feature_projections/cli.py backtest --model <name> --test-seasons 2022,2023,2024,2025
+# Note: accuracy_report.py --run-backtest re-backtests ALL models but does NOT re-generate
+# projections. If you changed feature code, you MUST run step 1 first or results will be stale.
+
 # Utilities
 python scripts/check_db.py                           # Verify database contents
 streamlit run scripts/visualize_app.py               # Streamlit dashboard

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -23,11 +23,18 @@ cd web && ./node_modules/.bin/tsc --noEmit
 
 `npm run build` requires `config.json` (present in CI/production, absent in local dev) and will fail with a "Module not found" error unrelated to your changes.
 
+## Key Test Files
+
+- **`scripts/tests/test_feature_projections.py`** — Tests for all projection features (`TestWeightedPPGFeature`, `TestAgeCurveFeature`, `TestUsageShareFeature`, etc.), the combiner, and model config
+- **`scripts/tests/test_architecture.py`** — Structural/architectural enforcement tests
+- **`scripts/tests/test_projection_methods.py`** — Legacy projection method tests
+
 ## Coupled Test Data
 
 Some tests have hardcoded expected values tied to configuration constants. When updating these constants, the corresponding tests must be updated too:
 
 - **`POSITION_AGE_CURVES`** in `features/age_curve.py` → `test_feature_projections.py::TestAgeCurveFeature` (test_qb_at_peak, test_qb_past_peak, test_rb_young)
+- **Feature behavior changes** (e.g., minimum data requirements, scaling factors) → corresponding `Test<FeatureName>Feature` class in `test_feature_projections.py`
 
 ## Structural / Architectural Tests
 


### PR DESCRIPTION
## Summary
Retrospective from the usage_share rewrite task (#285, PR #366).

## Friction Points

| # | What happened | Category | Root cause | Proposed fix |
|---|--------------|----------|------------|--------------|
| 1 | Supabase 502 during backtest | other | Transient DB outage | No action needed |
| 2 | Tried nonexistent `--models` flag on accuracy_report.py | agent-error | One-off | No action needed |
| 3 | Didn't know `cli.py run` must precede `--run-backtest` for changed features | missing-docs | Two-step workflow not documented | Added to COMMANDS.md |
| 4 | CI failed: test expected old trend-based behavior | missing-guardrail | No reminder to update tests when rewriting features | Added to AGENTS.md |
| 5 | Had to search for test files across multiple locations | missing-docs | Test file paths not listed | Added to TESTING.md |

## Files Changed
- **`docs/COMMANDS.md`** — Added "Projection Development Workflow" section documenting the two-step run → backtest process
- **`AGENTS.md`** — Added reminder that feature changes require test updates in `test_feature_projections.py`
- **`docs/TESTING.md`** — Added "Key Test Files" section and coupled test data note for feature behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)