### PR TITLE
retro: document path setup pattern and CLI flag differences

### DIFF
--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -27,3 +27,25 @@ All configuration constants live here:
 - Shared Supabase client via `get_supabase_client()`
 
 All scripts import from `scripts/config.py` to eliminate duplication and ensure consistency.
+
+## Path Setup for New Python Scripts
+
+Scripts under `scripts/feature_projections/` need two paths on `sys.path` to resolve all imports:
+
+```python
+import os
+import sys
+
+# Setup paths so imports work when run directly
+script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # → scripts/
+repo_root = os.path.dirname(script_dir)                                    # → project root
+if script_dir not in sys.path:
+    sys.path.insert(0, script_dir)
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+```
+
+- **`script_dir`** (`scripts/`) — resolves `from config import ...` and `from analysis_utils import ...`
+- **`repo_root`** (project root) — resolves `from scripts.feature_projections.features import ...`
+
+Both are required. Only adding `script_dir` causes `ModuleNotFoundError: No module named 'scripts'`. See `cli.py` for the canonical example.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -45,6 +45,7 @@ python scripts/scrape_arbitration_progress.py        # Scrape Ottoneu arbitratio
 
 # Feature-based Projections
 python scripts/feature_projections/cli.py list                                              # List available model definitions
+# Note: `run` uses --seasons but `backtest` uses --test-seasons (different flag names)
 python scripts/feature_projections/cli.py run --model v1_baseline_weighted_ppg --seasons 2024,2025,2026  # Generate projections
 python scripts/feature_projections/cli.py backtest --model v1_baseline_weighted_ppg --test-seasons 2024,2025  # Backtest against actuals
 python scripts/feature_projections/cli.py compare --models v1_baseline_weighted_ppg,v2_age_adjusted --season 2024  # Compare models


### PR DESCRIPTION
## Summary
Retrospective from the learned combiner work (#367, PR #370).

## Friction points

| # | What happened | Category | Proposed fix |
|---|--------------|----------|--------------|
| 1 | `train_model.py` failed with `ModuleNotFoundError` — missing `repo_root` in sys.path | agent-error | Document two-path boilerplate in CODE_ORGANIZATION.md |
| 4 | Had to discover `--test-seasons` flag (not `--seasons`) for backtest CLI | missing-docs | Add note in COMMANDS.md |

## Files changed
- **`docs/CODE_ORGANIZATION.md`** — Added "Path Setup for New Python Scripts" section documenting the two-path pattern (`script_dir` + `repo_root`) with explanation of why both are needed
- **`docs/COMMANDS.md`** — Added note clarifying `run --seasons` vs `backtest --test-seasons` flag difference

🤖 Generated with [Claude Code](https://claude.com/claude-code)