### PR TITLE
fix: player directory hits Supabase 1000-row limit

### DIFF
--- a/web/lib/players.ts
+++ b/web/lib/players.ts
@@ -6,43 +6,55 @@ import { PlayerListItem, PlayerCardData, Transaction, SeasonStats } from "./type
  * for the index / search page.
  */
 export async function fetchAllPlayers(): Promise<PlayerListItem[]> {
-    const { data: players } = await supabase
-        .from("players")
-        .select("id, ottoneu_id, name, position, nfl_team")
-        .order("name");
+    // Fetch stats, prices, and transactions first to determine which players
+    // are relevant (have stats or are rostered). The players table has thousands
+    // of backfill records that would exceed Supabase's default 1000-row limit.
+    const [statsRes, pricesRes, transactionsRes] = await Promise.all([
+        supabase
+            .from("player_stats")
+            .select("player_id, total_points, games_played, ppg")
+            .eq("season", 2025),
+        supabase
+            .from("league_prices")
+            .select("player_id, price, team_name")
+            .eq("league_id", 309),
+        supabase
+            .from("transactions")
+            .select("player_id, transaction_type, team_name, salary")
+            .eq("league_id", 309)
+            .order("transaction_date", { ascending: false }),
+    ]);
 
-    if (!players) return [];
+    const stats = statsRes.data ?? [];
+    const prices = pricesRes.data ?? [];
+    const transactions = transactionsRes.data ?? [];
 
-    const { data: stats } = await supabase
-        .from("player_stats")
-        .select("player_id, total_points, games_played, ppg")
-        .eq("season", 2025);
+    const statsMap = new Map(stats.map((s) => [s.player_id, s]));
+    const priceMap = new Map(prices.map((p) => [p.player_id, p]));
 
-    const { data: prices } = await supabase
-        .from("league_prices")
-        .select("player_id, price, team_name")
-        .eq("league_id", 309);
-
-    const { data: transactions } = await supabase
-        .from("transactions")
-        .select("player_id, transaction_type, team_name, salary")
-        .eq("league_id", 309)
-        .order("transaction_date", { ascending: false });
-
-    const statsMap = new Map(
-        (stats ?? []).map((s) => [s.player_id, s])
-    );
-    const priceMap = new Map(
-        (prices ?? []).map((p) => [p.player_id, p])
-    );
-
-    // keys are player_id, values are the LATEST transaction (since sorted desc)
     const transactionMap = new Map();
-    (transactions ?? []).forEach((t) => {
+    transactions.forEach((t) => {
         if (!transactionMap.has(t.player_id)) {
             transactionMap.set(t.player_id, t);
         }
     });
+
+    // Collect all relevant player IDs (have stats, prices, or transactions)
+    const relevantIds = new Set<string>();
+    stats.forEach((s) => relevantIds.add(s.player_id));
+    prices.forEach((p) => relevantIds.add(p.player_id));
+    transactions.forEach((t) => relevantIds.add(t.player_id));
+
+    if (relevantIds.size === 0) return [];
+
+    // Fetch only relevant players by ID
+    const { data: players } = await supabase
+        .from("players")
+        .select("id, ottoneu_id, name, position, nfl_team")
+        .in("id", Array.from(relevantIds))
+        .order("name");
+
+    if (!players) return [];
 
     return players.map((p) => {
         const s = statsMap.get(p.id);


### PR DESCRIPTION
## Summary
- `fetchAllPlayers()` queried all 3255 players from the `players` table, but Supabase's default 1000-row limit silently truncated results
- Parker Washington (alphabetical position ~2692) was never returned despite being rostered and having stats
- Fix: fetch stats/prices/transactions first, collect relevant player IDs, then fetch only those ~360 players by ID — avoids the row limit entirely

## Test plan
- [ ] Verify Parker Washington appears in the player directory after deploy
- [ ] Verify all rostered players appear (not just A-E names)
- [ ] Check player count shown matches expected (~360 relevant players)

🤖 Generated with [Claude Code](https://claude.com/claude-code)