### PR TITLE
fix: player visibility and data model cleanup (#128)

### DIFF
--- a/migrations/021_drop_player_stats_raw_columns.sql
+++ b/migrations/021_drop_player_stats_raw_columns.sql
@@ -1,0 +1,23 @@
+-- Drop redundant raw NFL stat columns from player_stats.
+-- These columns duplicate data in the nfl_stats table (migration 011).
+-- player_stats now contains only Ottoneu fantasy data:
+--   player_id, season, total_points, games_played, snaps, ppg, pps,
+--   h1_snaps, h1_games, h2_snaps, h2_games
+
+ALTER TABLE player_stats
+  DROP COLUMN IF EXISTS passing_yards,
+  DROP COLUMN IF EXISTS passing_tds,
+  DROP COLUMN IF EXISTS interceptions,
+  DROP COLUMN IF EXISTS rushing_yards,
+  DROP COLUMN IF EXISTS rushing_tds,
+  DROP COLUMN IF EXISTS rushing_attempts,
+  DROP COLUMN IF EXISTS receptions,
+  DROP COLUMN IF EXISTS receiving_yards,
+  DROP COLUMN IF EXISTS receiving_tds,
+  DROP COLUMN IF EXISTS targets,
+  DROP COLUMN IF EXISTS fg_made_0_39,
+  DROP COLUMN IF EXISTS fg_made_40_49,
+  DROP COLUMN IF EXISTS fg_made_50_plus,
+  DROP COLUMN IF EXISTS pat_made,
+  DROP COLUMN IF EXISTS passing_attempts,
+  DROP COLUMN IF EXISTS completions;

--- a/scripts/analysis_utils.py
+++ b/scripts/analysis_utils.py
@@ -20,6 +20,7 @@ from config import (
     ARB_MAX_PER_PLAYER_PER_TEAM,
     ARB_MAX_PER_PLAYER_LEAGUE,
     get_supabase_client,
+    fetch_all_rows,
 )
 
 
@@ -56,12 +57,12 @@ def fetch_all_data(season: int = SEASON) -> tuple[pd.DataFrame, pd.DataFrame, pd
 
     prices_res = supabase.table('league_prices').select('*').execute()
     stats_res = supabase.table('player_stats').select('*').eq('season', season).execute()
-    players_res = supabase.table('players').select('*').execute()
+    players_data = fetch_all_rows(supabase, 'players')
 
     return (
         pd.DataFrame(prices_res.data),
         pd.DataFrame(stats_res.data),
-        pd.DataFrame(players_res.data),
+        pd.DataFrame(players_data),
     )
 
 

--- a/scripts/analysis_utils.py
+++ b/scripts/analysis_utils.py
@@ -35,7 +35,11 @@ def fetch_multi_season_stats(seasons: list[int]) -> pd.DataFrame:
     """
     supabase = get_supabase_client()
     print(f"Fetching multi-season stats for seasons {seasons}...")
-    res = supabase.table('player_stats').select('*').in_('season', seasons).execute()
+    # Select only Ottoneu-relevant columns; raw NFL stat columns live in nfl_stats
+    res = supabase.table('player_stats').select(
+        'player_id, season, total_points, games_played, snaps, ppg, pps, '
+        'h1_snaps, h1_games, h2_snaps, h2_games'
+    ).in_('season', seasons).execute()
     df = pd.DataFrame(res.data)
     if df.empty:
         return df

--- a/scripts/backfill_nfl_stats.py
+++ b/scripts/backfill_nfl_stats.py
@@ -140,8 +140,8 @@ def load_rosters(year: int) -> pd.DataFrame | None:
 
 def build_player_lookup(supabase) -> dict[str, str]:
     """Fetch all players from DB and return normalized_name -> uuid dict."""
-    result = supabase.table("players").select("id, name").execute()
-    players = result.data or []
+    from scripts.config import fetch_all_rows
+    players = fetch_all_rows(supabase, "players", "id, name")
     lookup: dict[str, str] = {}
     for p in players:
         norm = normalize_player_name(p["name"])
@@ -151,8 +151,9 @@ def build_player_lookup(supabase) -> dict[str, str]:
 
 def build_ottoneu_id_set(supabase) -> set[int]:
     """Fetch all existing ottoneu_ids to avoid collisions."""
-    result = supabase.table("players").select("ottoneu_id").execute()
-    return {r["ottoneu_id"] for r in (result.data or [])}
+    from scripts.config import fetch_all_rows
+    rows = fetch_all_rows(supabase, "players", "ottoneu_id")
+    return {r["ottoneu_id"] for r in rows}
 
 
 # --- Core Logic ---

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -80,3 +80,35 @@ def get_supabase_client() -> Client:
         print("Error: SUPABASE_URL and SUPABASE_KEY must be set in .env")
         exit(1)
     return create_client(url, key)
+
+
+def fetch_all_rows(supabase, table: str, select: str = "*",
+                   page_size: int = 1000) -> list[dict]:
+    """Fetch all rows from a Supabase table, paginating past the PostgREST limit.
+
+    PostgREST defaults to returning at most 1000 rows. This helper pages
+    through all results transparently.
+
+    Args:
+        supabase: Supabase client instance.
+        table: Table name to query.
+        select: Column selection string (default "*").
+        page_size: Rows per page (default 1000).
+
+    Returns:
+        List of row dicts.
+    """
+    all_data: list[dict] = []
+    offset = 0
+    while True:
+        batch = (
+            supabase.table(table).select(select)
+            .range(offset, offset + page_size - 1)
+            .execute()
+            .data or []
+        )
+        all_data.extend(batch)
+        if len(batch) < page_size:
+            break
+        offset += page_size
+    return all_data

--- a/scripts/feature_projections/analyze_rookie_growth.py
+++ b/scripts/feature_projections/analyze_rookie_growth.py
@@ -25,7 +25,7 @@ if script_dir not in sys.path:
 if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
-from config import get_supabase_client, MIN_GAMES
+from config import get_supabase_client, fetch_all_rows, MIN_GAMES
 
 
 def compute_rookie_growth_ratios(
@@ -59,8 +59,8 @@ def compute_rookie_growth_ratios(
     )
 
     # Fetch player positions
-    players_res = supabase.table("players").select("id, position").execute()
-    pos_map = {row["id"]: row["position"] for row in (players_res.data or [])}
+    players_data = fetch_all_rows(supabase, "players", "id, position")
+    pos_map = {row["id"]: row["position"] for row in players_data}
 
     # Organize stats by player
     player_seasons: dict[str, dict[int, dict]] = defaultdict(dict)

--- a/scripts/feature_projections/backtest.py
+++ b/scripts/feature_projections/backtest.py
@@ -13,7 +13,7 @@ script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if script_dir not in sys.path:
     sys.path.insert(0, script_dir)
 
-from config import get_supabase_client, POSITIONS, MIN_GAMES
+from config import get_supabase_client, fetch_all_rows, POSITIONS, MIN_GAMES
 
 
 def _compute_metrics(projected: list[float], actual: list[float]) -> dict:
@@ -68,8 +68,8 @@ def backtest_model(
     model_id = model_res.data[0]["id"]
 
     # Fetch players for position mapping
-    players_res = supabase.table("players").select("id, position").execute()
-    pos_map = {row["id"]: row["position"] for row in (players_res.data or [])}
+    players_data = fetch_all_rows(supabase, "players", "id, position")
+    pos_map = {row["id"]: row["position"] for row in players_data}
 
     all_results = {}
 

--- a/scripts/feature_projections/diagnostics.py
+++ b/scripts/feature_projections/diagnostics.py
@@ -29,7 +29,7 @@ if script_dir not in sys.path:
 if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
-from config import get_supabase_client, MIN_GAMES, POSITIONS
+from config import get_supabase_client, fetch_all_rows, MIN_GAMES, POSITIONS
 from scripts.feature_projections.model_config import MODELS
 
 
@@ -144,8 +144,8 @@ def run_diagnostics(
     }
 
     # Fetch player info
-    players_res = supabase.table("players").select("id, name, position, nfl_team").execute()
-    player_info = {row["id"]: row for row in (players_res.data or [])}
+    players_data = fetch_all_rows(supabase, "players", "id, name, position, nfl_team")
+    player_info = {row["id"]: row for row in players_data}
 
     # Count seasons of data per player (for rookie detection)
     stats_res = (

--- a/scripts/feature_projections/external_sources/ingest_external.py
+++ b/scripts/feature_projections/external_sources/ingest_external.py
@@ -38,7 +38,7 @@ for _p in [_scripts_dir, _repo_root]:
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
-from config import get_supabase_client  # noqa: E402
+from config import get_supabase_client, fetch_all_rows  # noqa: E402
 
 from scripts.feature_projections.external_sources.fantasypros_fetcher import (  # noqa: E402
     fetch_all_positions,
@@ -99,8 +99,8 @@ def _ensure_model_in_db(supabase, model_def: dict) -> str:
 
 def _fetch_players(supabase) -> pd.DataFrame:
     """Fetch the players table for name matching."""
-    res = supabase.table("players").select("id, name, position, nfl_team").execute()
-    return pd.DataFrame(res.data or [])
+    players_data = fetch_all_rows(supabase, "players", "id, name, position, nfl_team")
+    return pd.DataFrame(players_data)
 
 
 def _upsert_records(supabase, records: list[dict]) -> None:

--- a/scripts/feature_projections/residual_analysis.py
+++ b/scripts/feature_projections/residual_analysis.py
@@ -29,7 +29,7 @@ if script_dir not in sys.path:
 if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
-from config import get_supabase_client, POSITIONS, MIN_GAMES
+from config import get_supabase_client, fetch_all_rows, POSITIONS, MIN_GAMES
 
 
 def _compute_distribution_stats(residuals: List[float]) -> dict:
@@ -110,8 +110,8 @@ def collect_residuals(
     model_id = model_res.data[0]["id"]
 
     # Fetch player info
-    players_res = supabase.table("players").select("id, name, position").execute()
-    player_info = {row["id"]: row for row in (players_res.data or [])}
+    players_data = fetch_all_rows(supabase, "players", "id, name, position")
+    player_info = {row["id"]: row for row in players_data}
 
     rows = []
     for season in seasons:

--- a/scripts/feature_projections/runner.py
+++ b/scripts/feature_projections/runner.py
@@ -14,7 +14,7 @@ script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if script_dir not in sys.path:
     sys.path.insert(0, script_dir)
 
-from config import get_supabase_client, MIN_GAMES
+from config import get_supabase_client, MIN_GAMES, fetch_all_rows
 from analysis_utils import fetch_multi_season_stats
 from scripts.feature_projections.features import FEATURE_REGISTRY
 from scripts.feature_projections.model_config import ModelDefinition, PositionOverride, get_model
@@ -351,8 +351,8 @@ def run_model(
 
 
     # Fetch players table
-    players_res = supabase.table("players").select("id, name, position, nfl_team, birth_date, is_college").execute()
-    players_df = pd.DataFrame(players_res.data or [])
+    players_data = fetch_all_rows(supabase, "players", "id, name, position, nfl_team, birth_date, is_college")
+    players_df = pd.DataFrame(players_data)
     players_df = players_df.rename(columns={"id": "player_id_ref"})
 
     total_records = 0

--- a/scripts/feature_projections/segment_analysis.py
+++ b/scripts/feature_projections/segment_analysis.py
@@ -24,7 +24,7 @@ if script_dir not in sys.path:
 if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
-from config import get_supabase_client, POSITIONS, MIN_GAMES
+from config import get_supabase_client, fetch_all_rows, POSITIONS, MIN_GAMES
 from scripts.feature_projections.backtest import _compute_metrics
 
 # Default models and seasons
@@ -151,8 +151,8 @@ def run_segment_analysis(
             raise ValueError(f"Model '{mn}' not found in projection_models table")
 
     # Fetch player info (once)
-    players_res = supabase.table("players").select("id, name, position, birth_date").execute()
-    player_info = {row["id"]: row for row in (players_res.data or [])}
+    players_data = fetch_all_rows(supabase, "players", "id, name, position, birth_date")
+    player_info = {row["id"]: row for row in players_data}
 
     # Collect tagged records: list of dicts with segment values + projected/actual
     # keyed by (segment_name) -> (segment_value, model) -> lists of (projected, actual)

--- a/scripts/feature_projections/sweep_feature_combos.py
+++ b/scripts/feature_projections/sweep_feature_combos.py
@@ -27,7 +27,7 @@ if script_dir not in sys.path:
 if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
-from config import get_supabase_client, POSITIONS, MIN_GAMES
+from config import get_supabase_client, fetch_all_rows, POSITIONS, MIN_GAMES
 from analysis_utils import fetch_multi_season_stats
 from scripts.feature_projections.features import FEATURE_REGISTRY
 from scripts.feature_projections.features.base import ProjectionFeature
@@ -93,10 +93,8 @@ def _run_combo(
     all_features = [base_instance] + adj_instances
 
     # Fetch players table
-    players_res = supabase.table("players").select(
-        "id, position, nfl_team, birth_date, is_college"
-    ).execute()
-    players_df = pd.DataFrame(players_res.data or [])
+    players_data = fetch_all_rows(supabase, "players", "id, position, nfl_team, birth_date, is_college")
+    players_df = pd.DataFrame(players_data)
     players_df = players_df.rename(columns={"id": "player_id_ref"})
 
     pos_map = {row["player_id_ref"]: row["position"] for _, row in players_df.iterrows()}

--- a/scripts/feature_projections/sweep_recency_weights.py
+++ b/scripts/feature_projections/sweep_recency_weights.py
@@ -25,7 +25,7 @@ if script_dir not in sys.path:
 if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
-from config import get_supabase_client, POSITIONS, MIN_GAMES
+from config import get_supabase_client, fetch_all_rows, POSITIONS, MIN_GAMES
 from analysis_utils import fetch_multi_season_stats
 from scripts.feature_projections.features.weighted_ppg import WeightedPPGFeature
 
@@ -78,8 +78,8 @@ def _run_projections_for_weights(
     feature = WeightedPPGFeature()
 
     # Fetch players for position mapping
-    players_res = supabase.table("players").select("id, position").execute()
-    pos_map = {row["id"]: row["position"] for row in (players_res.data or [])}
+    players_data = fetch_all_rows(supabase, "players", "id, position")
+    pos_map = {row["id"]: row["position"] for row in players_data}
 
     all_results: dict[int, dict[str, dict]] = {}
 

--- a/scripts/feature_projections/train_model.py
+++ b/scripts/feature_projections/train_model.py
@@ -33,7 +33,7 @@ if script_dir not in sys.path:
 if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
-from config import get_supabase_client, MIN_GAMES
+from config import get_supabase_client, MIN_GAMES, fetch_all_rows
 from analysis_utils import fetch_multi_season_stats
 from scripts.feature_projections.features import FEATURE_REGISTRY
 from scripts.feature_projections.model_config import get_model
@@ -71,8 +71,8 @@ def collect_training_data(
     supabase = get_supabase_client()
 
     # Fetch players
-    players_res = supabase.table("players").select("id, name, position, nfl_team, birth_date, is_college").execute()
-    players_df = pd.DataFrame(players_res.data or [])
+    players_data = fetch_all_rows(supabase, "players", "id, name, position, nfl_team, birth_date, is_college")
+    players_df = pd.DataFrame(players_data)
     players_df = players_df.rename(columns={"id": "player_id_ref"})
 
     # Instantiate features

--- a/scripts/feature_projections/tune_age_curve.py
+++ b/scripts/feature_projections/tune_age_curve.py
@@ -33,7 +33,7 @@ if script_dir not in sys.path:
 if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
-from config import get_supabase_client, POSITIONS, MIN_GAMES
+from config import get_supabase_client, fetch_all_rows, POSITIONS, MIN_GAMES
 from analysis_utils import fetch_multi_season_stats
 from scripts.feature_projections.features.weighted_ppg import WeightedPPGFeature
 from scripts.feature_projections.features.age_curve import (
@@ -87,10 +87,10 @@ def _precompute_base_projections(
     feature = WeightedPPGFeature()
 
     # Fetch players for position and birth_date
-    players_res = supabase.table("players").select("id, position, birth_date").execute()
+    players_data = fetch_all_rows(supabase, "players", "id, position, birth_date")
     pos_map = {}
     birth_map = {}
-    for row in (players_res.data or []):
+    for row in players_data:
         pos_map[row["id"]] = row["position"]
         if row.get("birth_date"):
             try:

--- a/scripts/seed_qb_starters.py
+++ b/scripts/seed_qb_starters.py
@@ -22,7 +22,7 @@ import pandas as pd
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from scripts.config import get_supabase_client
+from scripts.config import get_supabase_client, fetch_all_rows
 
 DEFAULT_SEASONS = list(range(2020, 2026))
 OUTPUT_PATH = Path(__file__).parent.parent / "data" / "qb_starters.json"
@@ -187,8 +187,8 @@ def seed_starters(seasons: list[int], dry_run: bool = False) -> dict:
     supabase = get_supabase_client()
 
     # Fetch player info
-    players_res = supabase.table("players").select("id, name, position, nfl_team").execute()
-    players_df = pd.DataFrame(players_res.data or [])
+    players_data = fetch_all_rows(supabase, "players", "id, name, position, nfl_team")
+    players_df = pd.DataFrame(players_data)
     qb_ids = set(players_df[players_df["position"] == "QB"]["id"].values)
     id_to_name = dict(zip(players_df["id"], players_df["name"]))
 

--- a/scripts/tasks/pull_player_stats.py
+++ b/scripts/tasks/pull_player_stats.py
@@ -149,10 +149,9 @@ def run(params: dict, supabase: Client) -> TaskResult:
 
             season = int(row["season"])
 
-            stat_row: dict = {
-                "player_id": player_uuid,
-                "season": season,
-                "games_played": _safe_int(row.get("games_played")),
+            # Build raw stats dict for points calculation only — these are
+            # NOT persisted to player_stats (raw NFL stats live in nfl_stats)
+            raw_stats = {
                 "passing_yards": _safe_int(row.get("passing_yards")),
                 "passing_tds": _safe_int(row.get("passing_tds")),
                 "interceptions": _safe_int(row.get("interceptions")),
@@ -168,9 +167,16 @@ def run(params: dict, supabase: Client) -> TaskResult:
                 "fg_made_50_plus": _safe_int(row.get("fg_made_50_plus")),
                 "pat_made": _safe_int(row.get("pat_made")),
             }
-            stat_row["total_points"] = round(_calc_points(stat_row), 2)
-            games = stat_row.get("games_played") or 0
-            stat_row["ppg"] = round(stat_row["total_points"] / games, 2) if games > 0 else 0.0
+            total_points = round(_calc_points(raw_stats), 2)
+            games = _safe_int(row.get("games_played")) or 0
+
+            stat_row: dict = {
+                "player_id": player_uuid,
+                "season": season,
+                "games_played": games if games > 0 else None,
+                "total_points": total_points,
+                "ppg": round(total_points / games, 2) if games > 0 else 0.0,
+            }
 
             upsert_rows.append(stat_row)
             matched += 1

--- a/scripts/tasks/pull_player_stats.py
+++ b/scripts/tasks/pull_player_stats.py
@@ -40,8 +40,8 @@ def _calc_points(row: dict) -> float:
 
 def _build_player_lookup(supabase: Client) -> dict[str, str]:
     """Fetch all players from DB and return normalized_name -> uuid dict."""
-    result = supabase.table("players").select("id, name").execute()
-    players = result.data or []
+    from scripts.config import fetch_all_rows
+    players = fetch_all_rows(supabase, "players", "id, name")
     lookup: dict[str, str] = {}
     for p in players:
         norm = normalize_player_name(p["name"])

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -6,7 +6,7 @@ export const revalidate = 3600 // Revalidate every hour
 
 export default async function Home() {
   // Fetch Players
-  const { data: players } = await supabase.from('players').select('*')
+  const { data: players } = await supabase.from('players').select('*').gt('ottoneu_id', 0)
   const { data: stats } = await supabase.from('player_stats').select('*').eq('season', 2025)
   const { data: prices } = await supabase.from('league_prices').select('*').eq('league_id', 309)
 

--- a/web/lib/analysis.ts
+++ b/web/lib/analysis.ts
@@ -22,7 +22,7 @@ export function getHistoricalSeasonsForYear(year: number): number[] {
 // === Data Fetching ===
 export async function fetchAndMergeData(): Promise<Player[]> {
   const [playersRes, statsRes, pricesRes] = await Promise.all([
-    supabase.from("players").select("*"),
+    supabase.from("players").select("*").gt("ottoneu_id", 0),
     supabase.from("player_stats").select("*").eq("season", SEASON),
     supabase
       .from("league_prices")
@@ -81,7 +81,7 @@ export async function fetchAndMergeData(): Promise<Player[]> {
  */
 export async function fetchPublicArbPlayers(): Promise<import("./types").PublicArbPlayer[]> {
   const [playersRes, statsRes, pricesRes] = await Promise.all([
-    supabase.from("players").select("*"),
+    supabase.from("players").select("*").gt("ottoneu_id", 0),
     supabase.from("player_stats").select("*").eq("season", SEASON),
     supabase.from("league_prices").select("*").eq("league_id", LEAGUE_ID),
   ]);
@@ -207,7 +207,7 @@ export async function fetchModelBacktestData(
   modelId: string
 ): Promise<BacktestPlayer[]> {
   const [playersRes, targetStatsRes, pricesRes] = await Promise.all([
-    supabase.from("players").select("id, name, position, nfl_team"),
+    supabase.from("players").select("id, name, position, nfl_team").gt("ottoneu_id", 0),
     supabase
       .from("player_stats")
       .select("player_id, ppg, games_played")
@@ -370,7 +370,7 @@ export async function fetchBacktestData(
 ): Promise<BacktestPlayer[]> {
   const [playersRes, targetStatsRes, pricesRes] =
     await Promise.all([
-      supabase.from("players").select("id, name, position, nfl_team"),
+      supabase.from("players").select("id, name, position, nfl_team").gt("ottoneu_id", 0),
       supabase
         .from("player_stats")
         .select("player_id, ppg, games_played")

--- a/web/lib/players.ts
+++ b/web/lib/players.ts
@@ -9,6 +9,7 @@ export async function fetchAllPlayers(): Promise<PlayerListItem[]> {
     const { data: players } = await supabase
         .from("players")
         .select("id, ottoneu_id, name, position, nfl_team")
+        .gt("ottoneu_id", 0)
         .order("name");
 
     if (!players) return [];

--- a/web/lib/roster-reconstruction.ts
+++ b/web/lib/roster-reconstruction.ts
@@ -68,7 +68,7 @@ export async function fetchRosterData(): Promise<RosterData> {
       .eq("league_id", LEAGUE_ID)
       .eq("season", SEASON)
       .order("transaction_date", { ascending: true }),
-    supabase.from("players").select("id, ottoneu_id, name, position, nfl_team"),
+    supabase.from("players").select("id, ottoneu_id, name, position, nfl_team").gt("ottoneu_id", 0),
     supabase
       .from("player_stats")
       .select("player_id, ppg, pps, games_played, snaps")

--- a/web/lib/supabase.ts
+++ b/web/lib/supabase.ts
@@ -9,6 +9,10 @@ import { Database } from "../types/supabase"
 
 export const supabase = createClient<Database>(supabaseUrl || "http://localhost:54321", supabaseKey || "fake-anon-key")
 
+// NOTE: The players table has 3000+ rows (most from historical backfill with
+// negative synthetic ottoneu_ids). All web queries MUST add .gt("ottoneu_id", 0)
+// to filter to scraper-origin players and avoid the PostgREST 1000-row limit.
+
 /**
  * Server-side admin client using the secret key — bypasses RLS.
  * Only use in server components, API routes, and server-side auth logic.


### PR DESCRIPTION
## Summary
- **Root cause:** The `players` table has 3255 rows (360 scraper + 2895 backfill). Supabase PostgREST silently truncates at 1000 rows, hiding most players including Parker Washington (alphabetical position ~2692).
- **Web frontend (6 locations):** Added `.gt("ottoneu_id", 0)` filter to all unfiltered `players` queries. Backfill players have synthetic negative IDs and aren't relevant to the web UI. Returns ~360 rows, well under the limit.
- **Python scripts (16 locations):** Added `fetch_all_rows()` pagination helper that transparently pages through all results. Python needs all 3255 players for name-matching and projections.
- **Data model cleanup (issue #128):** Narrowed `fetch_multi_season_stats()` to Ottoneu-only columns. Stopped `pull_player_stats.py` from writing redundant raw NFL stat columns. Added migration 021 to drop 16 redundant columns from `player_stats` (they live in `nfl_stats`).

## Test plan
- [x] 594 Python tests pass
- [x] Zero TypeScript compilation errors
- [ ] Verify Parker Washington appears in player directory after deploy
- [ ] Verify all analysis pages load correctly (projected salary, VORP, surplus, arbitration)
- [ ] Run migration 021 to drop redundant columns
- [ ] Run `/run-scraper` and verify complete roster data

🤖 Generated with [Claude Code](https://claude.com/claude-code)