### PR TITLE
fix: atomic job claim in worker to prevent duplicate execution

### DIFF
--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -104,12 +104,23 @@ class ScraperWorker:
                 if not dep_data or dep_data["status"] != "completed":
                     continue
 
-            # Claim it
-            self.supabase.table("scraper_jobs").update({
-                "status": "running",
-                "started_at": "now()",
-                "attempts": job["attempts"] + 1,
-            }).eq("id", job["id"]).execute()
+            # Atomic claim — only succeeds if the row is still 'pending'. If
+            # another worker claimed it first the update affects zero rows and
+            # we move on to the next candidate.
+            claim_result = (
+                self.supabase.table("scraper_jobs")
+                .update({
+                    "status": "running",
+                    "started_at": "now()",
+                    "attempts": job["attempts"] + 1,
+                })
+                .eq("id", job["id"])
+                .eq("status", "pending")
+                .execute()
+            )
+            claimed_rows = claim_result.data if hasattr(claim_result, "data") else claim_result[1]
+            if not claimed_rows:
+                continue
 
             job["attempts"] += 1
             job["status"] = "running"


### PR DESCRIPTION
## Summary
- Two workers polling \`scraper_jobs\` concurrently could both claim the same 'pending' row and run the task twice, also double-enqueuing any child jobs the task produced.
- Add \`status='pending'\` as a filter on the claim UPDATE so only one worker wins. PostgREST returns the empty update result to the loser, which moves on.

## Before
\`\`\`python
self.supabase.table(\"scraper_jobs\").update({...})
    .eq(\"id\", job[\"id\"]).execute()
\`\`\`
No atomicity between the initial SELECT and the UPDATE.

## After
\`\`\`python
claim_result = (
    self.supabase.table(\"scraper_jobs\")
    .update({...})
    .eq(\"id\", job[\"id\"])
    .eq(\"status\", \"pending\")  # atomic claim
    .execute()
)
if not claimed_rows: continue
\`\`\`

## Risk
- Today the project runs a single worker (see \`ottoneu_scraper.py\` wrapper), so the bug is latent rather than actively biting. The change is a no-op in the single-worker case — the claim always succeeds because no other worker exists to race with.
- Safe to ship independently.

## Test plan
- [x] \`venv/bin/python -m pytest scripts/tests/\` — 594 passed, 5 skipped
- [x] \`venv/bin/python -c \"from scripts.worker import ScraperWorker\"\` — module imports cleanly
- [ ] Manual smoke: run the worker against a non-empty queue and verify jobs still complete end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)