### PR TITLE
fix: log exceptions during roster row processing

### DIFF
--- a/scripts/tasks/scrape_roster.py
+++ b/scripts/tasks/scrape_roster.py
@@ -133,8 +133,9 @@ async def run(params: dict, context, supabase, nfl_stats: pd.DataFrame) -> TaskR
             nfl_stats_opt = pd.DataFrame()
 
         processed = 0
+        errors = 0
 
-        for row in rows:
+        for i, row in enumerate(rows):
             try:
                 result = await _process_row(
                     row, page, context, supabase, nfl_stats_opt,
@@ -144,10 +145,14 @@ async def run(params: dict, context, supabase, nfl_stats: pd.DataFrame) -> TaskR
                     processed += 1
                     if result.get("child_job"):
                         child_jobs.append(result["child_job"])
-            except Exception:
-                pass
+            except Exception as e:
+                errors += 1
+                print(f"  Error processing {position} row {i}: {type(e).__name__}: {e}")
 
-        print(f"Processed {processed} players for {position}.")
+        if errors:
+            print(f"Processed {processed} players for {position} ({errors} errors).")
+        else:
+            print(f"Processed {processed} players for {position}.")
         return TaskResult(success=True, data={"processed": processed}, child_jobs=child_jobs)
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- The row loop in \`scrape_roster.run\` wrapped each \`_process_row\` call in \`try/except Exception: pass\`, silently dropping any failure.
- The only symptom was \"Processed N players\" where N was lower than the row count — no way to tell which rows failed or why.
- Log the exception with row index and track an error count; surface it in the summary.

## Change
\`\`\`diff
- for row in rows:
+ for i, row in enumerate(rows):
      try:
          result = await _process_row(...)
          ...
-     except Exception:
-         pass
+     except Exception as e:
+         errors += 1
+         print(f\"  Error processing {position} row {i}: {type(e).__name__}: {e}\")
\`\`\`

Control flow is unchanged — we still skip the row and continue scraping. This is fail-loud instrumentation only.

## Test plan
- [x] \`venv/bin/python -m pytest scripts/tests/test_scrape_roster.py\` — 7 passed
- [ ] Next scraper run will include any row-level errors in the log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)