### PR TITLE
fix: return 401 when unauthenticated on admin API

### DIFF
--- a/web/app/api/admin/users/[id]/route.ts
+++ b/web/app/api/admin/users/[id]/route.ts
@@ -8,7 +8,8 @@ interface RouteContext {
 
 export async function PUT(req: NextRequest, context: RouteContext) {
   const user = await getAuthenticatedUser();
-  if (!user?.isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!user.isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const { id } = await context.params;
   const { has_projections_access } = await req.json();
@@ -27,7 +28,8 @@ export async function PUT(req: NextRequest, context: RouteContext) {
 
 export async function DELETE(_req: NextRequest, context: RouteContext) {
   const user = await getAuthenticatedUser();
-  if (!user?.isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!user.isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const { id } = await context.params;
 

--- a/web/app/api/admin/users/route.ts
+++ b/web/app/api/admin/users/route.ts
@@ -5,7 +5,8 @@ import { getAuthenticatedUser } from "@/lib/auth";
 
 export async function GET() {
   const user = await getAuthenticatedUser();
-  if (!user?.isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!user.isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const { data, error } = await getSupabaseAdmin()
     .from("users")
@@ -18,7 +19,8 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   const user = await getAuthenticatedUser();
-  if (!user?.isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!user.isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const { email, password, has_projections_access } = await req.json();
 


### PR DESCRIPTION
## Summary
- Admin routes collapsed \"no session\" and \"non-admin session\" into a single 403 via \`if (!user?.isAdmin)\`.
- These are different conditions — unauthenticated callers should get 401, authenticated-but-not-admin callers should get 403.
- Split the check so clients can distinguish auth failure from authorization failure.

## Change
\`\`\`diff
- if (!user?.isAdmin) return NextResponse.json({ error: \"Forbidden\" }, { status: 403 });
+ if (!user) return NextResponse.json({ error: \"Unauthorized\" }, { status: 401 });
+ if (!user.isAdmin) return NextResponse.json({ error: \"Forbidden\" }, { status: 403 });
\`\`\`

## Files
- \`web/app/api/admin/users/route.ts\` (GET, POST)
- \`web/app/api/admin/users/[id]/route.ts\` (PUT, DELETE)

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx eslint app/api/admin/\` — clean
- [x] \`npx jest\` — 100 passed
- [ ] Manual: hit each endpoint with no cookie (should 401) and with a non-admin cookie (should 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)