### PR TITLE
fix: null-guard arbitration plan lookups

### DIFF
--- a/web/app/api/arbitration-plans/[id]/duplicate/route.ts
+++ b/web/app/api/arbitration-plans/[id]/duplicate/route.ts
@@ -25,7 +25,9 @@ export async function POST(req: NextRequest, context: RouteContext) {
     .eq("id", id)
     .single();
 
-  if (fetchError) return NextResponse.json({ error: fetchError.message }, { status: 404 });
+  if (fetchError || !sourcePlan) {
+    return NextResponse.json({ error: fetchError?.message ?? "Plan not found" }, { status: 404 });
+  }
   if (sourcePlan.user_id !== user.userId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   // Create new plan
@@ -40,6 +42,9 @@ export async function POST(req: NextRequest, context: RouteContext) {
       return NextResponse.json({ error: "A plan with that name already exists" }, { status: 409 });
     }
     return NextResponse.json({ error: planError.message }, { status: 500 });
+  }
+  if (!newPlan) {
+    return NextResponse.json({ error: "Failed to create plan" }, { status: 500 });
   }
 
   // Copy allocations from source plan

--- a/web/app/api/arbitration-plans/[id]/route.ts
+++ b/web/app/api/arbitration-plans/[id]/route.ts
@@ -18,7 +18,9 @@ export async function GET(_req: NextRequest, context: RouteContext) {
     .eq("id", id)
     .single();
 
-  if (planError) return NextResponse.json({ error: planError.message }, { status: 404 });
+  if (planError || !plan) {
+    return NextResponse.json({ error: planError?.message ?? "Plan not found" }, { status: 404 });
+  }
   if (plan.user_id !== user.userId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const { data: allocs, error: allocError } = await getSupabaseAdmin()
@@ -51,7 +53,9 @@ export async function PUT(req: NextRequest, context: RouteContext) {
     .eq("id", id)
     .single();
 
-  if (fetchError) return NextResponse.json({ error: fetchError.message }, { status: 404 });
+  if (fetchError || !plan) {
+    return NextResponse.json({ error: fetchError?.message ?? "Plan not found" }, { status: 404 });
+  }
   if (plan.user_id !== user.userId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const { name, notes, allocations } = await req.json();
@@ -115,7 +119,9 @@ export async function DELETE(_req: NextRequest, context: RouteContext) {
     .eq("id", id)
     .single();
 
-  if (fetchError) return NextResponse.json({ error: fetchError.message }, { status: 404 });
+  if (fetchError || !plan) {
+    return NextResponse.json({ error: fetchError?.message ?? "Plan not found" }, { status: 404 });
+  }
   if (plan.user_id !== user.userId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const { error } = await getSupabaseAdmin()


### PR DESCRIPTION
## Summary
Four ownership checks in the arbitration-plans API dereferenced \`.single()\` results after only checking for an error:

\`\`\`ts
if (fetchError) return 404;
if (plan.user_id !== user.userId) return 403;  // crashes if plan is null
\`\`\`

Supabase's \`PostgrestSingleResponse<T>\` is a discriminated union (\`{data: T, error: null} | {data: null, error: PostgrestError}\`), but the call sites weren't narrowing it properly. A future SDK change or edge case (no row, no error) would crash. Combine the checks:

\`\`\`ts
if (fetchError || !plan) {
  return NextResponse.json({ error: fetchError?.message ?? \"Plan not found\" }, { status: 404 });
}
\`\`\`

Also guard the duplicate route's newly-created plan before the \`newPlan.id\` dereference used in allocation copy.

## Files
- \`web/app/api/arbitration-plans/[id]/route.ts\` — GET, PUT, DELETE
- \`web/app/api/arbitration-plans/[id]/duplicate/route.ts\` — POST (source plan + new plan)

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx eslint app/api/arbitration-plans/\` — clean
- [x] \`npx jest\` — 100 passed
- [ ] Manual: GET/PUT/DELETE a non-existent plan id (should 404 cleanly, not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)