### PR TITLE
docs: daily harness audit 2026-04-19

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,11 @@ docs/
 ├── exec-plans/
 │   ├── [feature-projections.md](docs/exec-plans/feature-projections.md)         # Feature-based player projection system
 │   ├── [market-projections.md](docs/exec-plans/market-projections.md)          # Market-based projection system implementation plan
+│   ├── [projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md)  # 4-phase accuracy improvement roadmap
 │   └── [qb-usage-share.md](docs/exec-plans/qb-usage-share.md)              # QB Usage Share findings and next steps
 ├── generated/
 │   ├── [db-schema.md](docs/generated/db-schema.md)                   # Database tables, keys, relationships
+│   ├── [experiment-log.md](docs/generated/experiment-log.md)              # History of all model iteration attempts
 │   ├── [player-diagnostics.md](docs/generated/player-diagnostics.md)          # Per-player backtest diagnostics
 │   ├── [projection-accuracy.md](docs/generated/projection-accuracy.md)         # Projection model accuracy report
 │   └── [segment-analysis.md](docs/generated/segment-analysis.md)            # Segmented projection accuracy analysis

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -2,19 +2,28 @@
 
 ## Structure
 
-Next.js App Router with five pages. All pages are server components that fetch live data from Supabase (revalidate every hour) with client wrappers for interactivity.
+Next.js App Router. Most pages are server components that fetch live data from Supabase (revalidate every hour) with client wrappers for interactivity. Shared nav structure (see `web/components/Navigation.tsx`) groups routes into top-level pages, Projections, Value, and Arbitration menus.
 
 ## Routes
 
 | Route | Description |
 |-------|-------------|
 | `/` | Player Efficiency scatter chart (PPG/PPS vs salary) |
+| `/players` | Searchable player directory |
+| `/rosters` | League-wide roster view |
+| `/arb-progress` | Public arbitration progress: team completion status and allocation details |
+| `/arb-planner-public` | Public (read-only) arbitration planner view |
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
+| `/projections` | Player projections table (reads `player_projections`) |
+| `/projection-accuracy` | Model backtest accuracy explorer |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
+| `/surplus-adjustments` | Per-user manual value overrides (auth required) |
 | `/arbitration` | Arbitration targets with per-opponent breakdown |
-| `/arbitration-planner` | Plan and save arbitration budget allocations |
-| `/arb-progress` | Public arbitration progress: team completion status and allocation details |
+| `/arbitration-simulation` | Monte Carlo arbitration simulation |
+| `/arbitration-planner` | Plan and save arbitration budget allocations (auth required) |
+| `/login` | Email/password login |
+| `/admin` | User management (admin only) |
 
 ## Reusable Components
 


### PR DESCRIPTION
## Summary

Daily harness-doc audit. Reviewed the five commits merged since the last run; all were bug fixes with no architectural impact on documented behavior:

- `efd52e8` fix: null-guard arbitration plan lookups
- `774ac09` fix: atomic job claim in worker
- `9b076c4` fix: log exceptions during roster row processing
- `85316ff` fix: return 401 when unauthenticated on admin API
- `f1c7718` chore: delete stale root-level artifacts

## Changes

- **AGENTS.md Documentation Map** — added `docs/exec-plans/projection-accuracy-improvement.md` and `docs/generated/experiment-log.md`. Both are referenced from `CLAUDE.md` but were missing here, so AGENTS-only readers had an incomplete map.
- **docs/FRONTEND.md** — the lede claimed "five pages" while the table listed seven, and both were stale versus `web/app/` and `web/components/Navigation.tsx`. Rewrote the lede and expanded the routes table to cover the ~14 user-facing routes plus `/login` and `/admin`.

## Schema check

No new files in `migrations/` since the last audit (latest is `021_drop_player_stats_raw_columns.sql`). `docs/generated/db-schema.md` still matches the 17 `CREATE TABLE` statements in `schema.sql` — no schema-doc edits needed.

## Other checks

- Referenced file paths in harness docs all resolve.
- `docs/COMMANDS.md` targets still exist (`scripts/worker.py`, `scripts/enqueue.py`, `scripts/feature_projections/*`, Makefile targets).
- All `.claude/commands/*.md` skills referenced from `CLAUDE.md`'s Documentation Map are present.

## Flagged for human follow-up

None this run.

## Test plan

- [ ] `make check-docs` passes
- [ ] Markdown links in AGENTS.md and docs/FRONTEND.md render correctly on GitHub

https://claude.ai/code/session_01LhGPHwU2HvFVxNCZKfvwvH