### PR TITLE
retro: permission gates, coverage docs, review-permission-gates skill

### DIFF
--- a/.claude/commands/retro.md
+++ b/.claude/commands/retro.md
@@ -4,6 +4,10 @@ description: Retrospective on the current task — identify friction points, pro
 
 Run a retrospective on the task just completed in this conversation. Follow these steps carefully.
 
+## Step 0 — Review permission gates
+
+Before collecting friction points, invoke the `review-permission-gates` skill. Its output identifies manual approval gates from this session — the findings slot directly into the Step 1 table under the `approval-gate` category with concrete proposed fixes already included. Complete Step 0 before proceeding to Step 1.
+
 ## Step 1 — Collect friction points
 
 Review the entire conversation history. Look for:

--- a/.claude/commands/review-permission-gates.md
+++ b/.claude/commands/review-permission-gates.md
@@ -1,0 +1,72 @@
+---
+description: Review Bash commands from the current session that required manual permission approval, group them by type, and evaluate which are candidates for new just targets or allowlist entries
+---
+
+Scan the current session for permission gate events and evaluate coverage against the Justfile and allowlist.
+
+## Step 1 — Load reference files
+
+Read `.claude/settings.local.json` — note every `Bash(...)` pattern in the allow list.
+
+Read `Justfile` — note every recipe name and what command it wraps.
+
+## Step 2 — Scan the conversation for Bash tool calls
+
+Review the full conversation history in this session. Find every `Bash(...)` tool call that was made (by you or by any subagent you dispatched).
+
+For each call, determine whether it is **pre-approved** under the current allowlist:
+- Matches `Bash(just:*)` → covered (starts with `just `)
+- Matches `Bash(git:*)` → covered
+- Matches `Bash(gh ...:*)` or exact gh entry → covered
+- Matches any other wildcard or exact entry → covered
+- **Otherwise → manual permission gate**
+
+## Step 3 — Group and categorize
+
+Group manual permission gates by command family (the first word of the command, or the logical operation). For each group:
+
+| Field | Description |
+|-------|-------------|
+| **Command pattern** | e.g. `which`, `mkdir -p`, `curl`, `brew install` |
+| **Count** | How many times in this session |
+| **Purpose** | What was being accomplished |
+| **Already a just target?** | Does an existing `just <recipe>` cover this? |
+| **Disposition** | One of: `new-just-target` · `new-allowlist-entry` · `use-existing-just` · `one-off` |
+
+## Step 4 — Make recommendations
+
+For each group, recommend the least-friction fix that keeps blast radius small:
+
+- **`new-just-target`** — write the exact recipe to add to the Justfile (name + body)
+- **`new-allowlist-entry`** — write the exact string to add to `settings.local.json` allow list
+- **`use-existing-just`** — note which `just` recipe should have been used and why it wasn't (doc gap vs agent habit)
+- **`one-off`** — explain why no action is needed
+
+## Step 5 — Present findings
+
+Display the table from Step 3, then list concrete proposed changes:
+
+```
+## Manual Permission Gates — [Session Date]
+
+| Command | Count | Purpose | Just target? | Disposition |
+|---------|-------|---------|--------------|-------------|
+| ...     | ...   | ...     | ...          | ...         |
+
+### Proposed changes
+
+**New Justfile recipes:**
+[exact recipe text]
+
+**New allowlist entries:**
+[exact JSON strings]
+
+**Agent habit / doc gaps:**
+[what should have been called and what doc needs updating]
+```
+
+## Notes
+
+- This output feeds directly into the retro Step 2 table — surface impactful items as `approval-gate` friction points.
+- Do not flag commands that are already in the allowlist — only flag ones that actually needed manual approval.
+- Prefer `just` targets over raw allowlist entries for anything that wraps a complex or project-specific command. Prefer raw allowlist entries for simple, safe system utilities (e.g. `which`, `mkdir`).

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -28,6 +28,8 @@
       "Bash(wc:*)",
       "Bash(jq:*)",
       "Bash(find:*)",
+      "Bash(which:*)",
+      "Bash(mkdir:*)",
       "Bash(psql:*)",
       "Bash(supabase --version:*)",
       "WebSearch",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ docs/
 
 - **Python venv:** The virtualenv lives at the main repo's `venv/`, not in worktrees. In a worktree, use the absolute path `<main-repo>/venv/bin/python` instead of `source venv/bin/activate` or relative `venv/bin/python`. The `source venv/bin/activate` command will fail in worktrees.
 - **Production actions** (like `promote.py`) should run from the main repo after merging, not from a worktree, since they modify shared production data.
+- **Directory creation:** Prefer `mcp__filesystem__create_directory` over `Bash(mkdir -p ...)` — the MCP tool is pre-approved and avoids a permission prompt.
 
 ## Python Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Comprehensive database and analytics platform for Ottoneu Fantasy Football Leagu
 
 ## Documentation Map
 
-Skills (`.claude/commands/`): `ablation`, `compare-models`, `create-pr`, `diagnose-segment`, `experiment`, `feature-importance`, `projection-accuracy`, `retro`, `run-analyses`, `run-scraper`, `run-tests`, `start-dev`
+Skills (`.claude/commands/`): `ablation`, `compare-models`, `create-pr`, `diagnose-segment`, `experiment`, `feature-importance`, `projection-accuracy`, `retro`, `review-permission-gates`, `run-analyses`, `run-scraper`, `run-tests`, `start-dev`
 
 ```
 CLAUDE.md                              ← you are here

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -5,7 +5,8 @@
 - **Location:** `scripts/tests/`
 - **Config:** `pyproject.toml` (or `scripts/pytest.ini`)
 - **Venv path:** `venv/` (not `.venv/`) — activate with `source venv/bin/activate`
-- **Run:** `python -m pytest` from project root (venv must be active), or directly via `venv/bin/pytest`
+- **Run:** `just test-python` (preferred) or `venv/bin/pytest` from project root
+- **Coverage flags:** `pyproject.toml` sets `addopts = "--cov=scripts --cov-report=term-missing"`. Do not pass `--cov` flags explicitly — they conflict with and override the configured scope.
 
 ## Web Tests
 


### PR DESCRIPTION
## Summary

Retrospective on the build-system-just session (replacing Makefile with Justfile).

## Friction point table

| # | What happened | Category | Root cause | Fix |
|---|---------------|----------|------------|-----|
| 1 | `which just ...` required manual approval | `approval-gate` | `Bash(which:*)` not in allowlist | Added `Bash(which:*)` and `Bash(mkdir:*)` to settings |
| 2 | `mkdir -p` required manual approval | `approval-gate` | Used Bash instead of pre-approved `mcp__filesystem__create_directory` | Added note to AGENTS.md |
| 3 | `test-python` spec had `--cov=.` conflicting with `pyproject.toml` | `agent-error` | Plan author didn't check pyproject.toml coverage config | Documented in TESTING.md |
| 4 | New `review-permission-gates` skill didn't reach main | `other` | Written on feature branch after PR was created; never pushed | Included in this PR |

## Files changed

- `.claude/settings.local.json` — add `Bash(which:*)` and `Bash(mkdir:*)` 
- `AGENTS.md` — prefer `mcp__filesystem__create_directory` over `mkdir -p`
- `docs/TESTING.md` — document that `pyproject.toml` owns `--cov` flags
- `.claude/commands/review-permission-gates.md` — new skill for permission gate analysis
- `.claude/commands/retro.md` — Step 0: always invoke `review-permission-gates` first
- `CLAUDE.md` — register `review-permission-gates` in skill list

🤖 Generated with [Claude Code](https://claude.ai/claude-code)