### PR TITLE
docs: scrub stale make references missed by Justfile migration

### DIFF
--- a/.claude/commands/review-permission-gates.md
+++ b/.claude/commands/review-permission-gates.md
@@ -30,7 +30,7 @@ Group manual permission gates by command family (the first word of the command, 
 | **Command pattern** | e.g. `which`, `mkdir -p`, `curl`, `brew install` |
 | **Count** | How many times in this session |
 | **Purpose** | What was being accomplished |
-| **Already a just target?** | Does an existing `just <recipe>` cover this? |
+| **Just target?** | Does an existing `just <recipe>` cover this? |
 | **Disposition** | One of: `new-just-target` · `new-allowlist-entry` · `use-existing-just` · `one-off` |
 
 ## Step 4 — Make recommendations

--- a/.cursorrules
+++ b/.cursorrules
@@ -17,4 +17,4 @@ This repository maintains universal instructions for AI agents in `AGENTS.md`.
 ## Key Directives
 - **Package Manager:** Strictly use `npm` for all frontend tasks (do not use `yarn`, `pnpm`, or `bun`).
 - **Commits:** Do not commit directly to `main`. Use PRs.
-- **Architectural Rules:** Adhere strictly to rules in `AGENTS.md` (e.g., config sync, shared Supabase client). Run `make check-arch` to verify.
+- **Architectural Rules:** Adhere strictly to rules in `AGENTS.md` (e.g., config sync, shared Supabase client). Run `just check-arch` to verify.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,4 +17,4 @@ This repository maintains universal instructions for AI agents in `AGENTS.md`.
 ## Key Directives
 - **Package Manager:** Strictly use `npm` for all frontend tasks (do not use `yarn`, `pnpm`, or `bun`).
 - **Commits:** Do not commit directly to `main`. Use PRs.
-- **Architectural Rules:** Adhere strictly to rules in `AGENTS.md` (e.g., config sync, shared Supabase client). Run `make check-arch` to verify.
+- **Architectural Rules:** Adhere strictly to rules in `AGENTS.md` (e.g., config sync, shared Supabase client). Run `just check-arch` to verify.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,8 @@
 
 <!-- How were these changes verified? -->
 
-- [ ] Python tests pass (`make test-python`)
-- [ ] Web tests pass (`make test-web`)
-- [ ] ESLint clean (`make lint`)
-- [ ] TypeScript compiles (`make typecheck`)
-- [ ] Production build succeeds (`make build`)
+- [ ] Python tests pass (`just test-python`)
+- [ ] Web tests pass (`just test-web`)
+- [ ] ESLint clean (`just lint`)
+- [ ] TypeScript compiles (`just typecheck`)
+- [ ] Production build succeeds (`just build`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ CLAUDE.md                              ← Claude Code specific instructions
 docs/
 ├── ARCHITECTURE.md                    # System design, data + analysis pipelines, tech stack
 ├── CODE_ORGANIZATION.md               # Key file locations, Python/TS config
-├── COMMANDS.md                        # All CLI commands (frontend, backend, make, cron)
+├── COMMANDS.md                        # All CLI commands (frontend, backend, just recipes, cron)
 ├── FRONTEND.md                        # Routes, components, types, analysis logic
 ├── GIT_WORKFLOW.md                    # Branch strategy, PR requirements
 ├── TESTING.md                         # Python + web test setup and CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Comprehensive database and analytics platform for Ottoneu Fantasy Football Leagu
 
 ## Quick Reference
 
-- **Commands:** See [docs/COMMANDS.md](docs/COMMANDS.md) for all CLI commands (frontend, backend, make, cron)
+- **Commands:** See [docs/COMMANDS.md](docs/COMMANDS.md) for all CLI commands (frontend, backend, just recipes, cron)
 - **Architecture:** See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for system design, data pipeline, and analysis pipeline
 - **Frontend:** See [docs/FRONTEND.md](docs/FRONTEND.md) for routes, components, types, and config
 - **Code layout:** See [docs/CODE_ORGANIZATION.md](docs/CODE_ORGANIZATION.md) for key file locations and config
@@ -37,7 +37,7 @@ AGENTS.md                              ← universal agent instructions
 docs/
 ├── ARCHITECTURE.md                    # System design, data + analysis pipelines, tech stack
 ├── CODE_ORGANIZATION.md               # Key file locations, Python/TS config
-├── COMMANDS.md                        # All CLI commands (frontend, backend, make, cron)
+├── COMMANDS.md                        # All CLI commands (frontend, backend, just recipes, cron)
 ├── FRONTEND.md                        # Routes, components, types, analysis logic
 ├── GIT_WORKFLOW.md                    # Branch strategy, PR requirements
 ├── TESTING.md                         # Python + web test setup and CI


### PR DESCRIPTION
## Summary

Follow-up to #436 (Justfile migration) and #437 (retro). Six files still referenced `make` after the migration — most visibly, every new PR's Test Plan checklist was telling authors to run commands that no longer exist.

## Files

- `CLAUDE.md` (x2) — Quick Reference and Documentation Map
- `AGENTS.md` (x1) — Documentation Map
- `.github/pull_request_template.md` (x5) — Test Plan checklist (most user-visible)
- `.github/copilot-instructions.md` (x1) — architectural rules
- `.cursorrules` (x1) — architectural rules
- `.claude/commands/review-permission-gates.md` — align "Already a just target?" table header with "Just target?" used elsewhere in the same skill

## Why #437's retro didn't catch this

The `retro` skill scans conversation friction, not the completed work against the codebase. A simple grep for the removed concept (`make `) post-migration would have surfaced all of these. Worth considering as a future enhancement to the `retro` / `review-permission-gates` skills.

## Test plan

- [x] `just check-arch` passes locally (22 py tests + 14 jest tests)
- [x] No remaining `make <target>` references in project docs (verified via grep) — historical plan/spec files in `docs/superpowers/` intentionally left as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)