### PR TITLE
feat: add Zod validation layer for API route inputs (#432)

### DIFF
--- a/web/__tests__/lib/schemas/arbitration-plan.test.ts
+++ b/web/__tests__/lib/schemas/arbitration-plan.test.ts
@@ -1,0 +1,77 @@
+import {
+    CreatePlanSchema,
+    DuplicatePlanSchema,
+    UpdatePlanSchema,
+} from "@/lib/schemas/arbitration-plan";
+
+describe("CreatePlanSchema", () => {
+    test("accepts a valid payload", () => {
+        const result = CreatePlanSchema.safeParse({ name: "My Plan", notes: "scratch" });
+        expect(result.success).toBe(true);
+    });
+
+    test("trims the name", () => {
+        const result = CreatePlanSchema.parse({ name: "  Padded  " });
+        expect(result.name).toBe("Padded");
+    });
+
+    test("rejects empty / whitespace-only names", () => {
+        expect(CreatePlanSchema.safeParse({ name: "" }).success).toBe(false);
+        expect(CreatePlanSchema.safeParse({ name: "   " }).success).toBe(false);
+    });
+
+    test("rejects name longer than 100 chars", () => {
+        const result = CreatePlanSchema.safeParse({ name: "a".repeat(101) });
+        expect(result.success).toBe(false);
+    });
+
+    test("rejects notes longer than 2000 chars", () => {
+        const result = CreatePlanSchema.safeParse({
+            name: "Plan",
+            notes: "x".repeat(2001),
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test("notes can be null", () => {
+        const result = CreatePlanSchema.safeParse({ name: "Plan", notes: null });
+        expect(result.success).toBe(true);
+    });
+});
+
+describe("UpdatePlanSchema", () => {
+    test("accepts a valid full payload", () => {
+        const result = UpdatePlanSchema.safeParse({
+            name: "Renamed",
+            notes: "updated",
+            allocations: { abc: 5, def: 0 },
+        });
+        expect(result.success).toBe(true);
+    });
+
+    test("accepts an empty payload (everything optional)", () => {
+        expect(UpdatePlanSchema.safeParse({}).success).toBe(true);
+    });
+
+    test("rejects negative allocation amounts", () => {
+        const result = UpdatePlanSchema.safeParse({ allocations: { abc: -1 } });
+        expect(result.success).toBe(false);
+    });
+
+    test("rejects non-integer allocation amounts", () => {
+        const result = UpdatePlanSchema.safeParse({ allocations: { abc: 1.5 } });
+        expect(result.success).toBe(false);
+    });
+
+    test("rejects empty player_id keys", () => {
+        const result = UpdatePlanSchema.safeParse({ allocations: { "": 1 } });
+        expect(result.success).toBe(false);
+    });
+});
+
+describe("DuplicatePlanSchema", () => {
+    test("requires a non-empty name", () => {
+        expect(DuplicatePlanSchema.safeParse({ name: "Copy" }).success).toBe(true);
+        expect(DuplicatePlanSchema.safeParse({ name: "" }).success).toBe(false);
+    });
+});

--- a/web/__tests__/lib/schemas/surplus-adjustment.test.ts
+++ b/web/__tests__/lib/schemas/surplus-adjustment.test.ts
@@ -1,0 +1,60 @@
+import {
+    SurplusAdjustmentSchema,
+    SurplusAdjustmentsArraySchema,
+} from "@/lib/schemas/surplus-adjustment";
+
+describe("SurplusAdjustmentSchema", () => {
+    test("accepts a valid row", () => {
+        const result = SurplusAdjustmentSchema.safeParse({
+            player_id: "p-123",
+            adjustment: -2.5,
+        });
+        expect(result.success).toBe(true);
+    });
+
+    test("rejects NaN adjustment", () => {
+        const result = SurplusAdjustmentSchema.safeParse({
+            player_id: "p-123",
+            adjustment: Number.NaN,
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test("rejects Infinity adjustment", () => {
+        const result = SurplusAdjustmentSchema.safeParse({
+            player_id: "p-123",
+            adjustment: Number.POSITIVE_INFINITY,
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test("rejects empty player_id", () => {
+        const result = SurplusAdjustmentSchema.safeParse({
+            player_id: "",
+            adjustment: 1,
+        });
+        expect(result.success).toBe(false);
+    });
+});
+
+describe("SurplusAdjustmentsArraySchema", () => {
+    test("accepts an empty array", () => {
+        expect(SurplusAdjustmentsArraySchema.safeParse([]).success).toBe(true);
+    });
+
+    test("accepts a list of valid rows", () => {
+        const result = SurplusAdjustmentsArraySchema.safeParse([
+            { player_id: "a", adjustment: 1 },
+            { player_id: "b", adjustment: -1, notes: "ok" },
+        ]);
+        expect(result.success).toBe(true);
+    });
+
+    test("rejects when any row is invalid", () => {
+        const result = SurplusAdjustmentsArraySchema.safeParse([
+            { player_id: "a", adjustment: 1 },
+            { player_id: "b", adjustment: "nope" },
+        ]);
+        expect(result.success).toBe(false);
+    });
+});

--- a/web/__tests__/lib/schemas/user.test.ts
+++ b/web/__tests__/lib/schemas/user.test.ts
@@ -1,0 +1,74 @@
+import { CreateUserSchema, UpdateUserSchema } from "@/lib/schemas/user";
+
+describe("CreateUserSchema", () => {
+    test("accepts a valid payload", () => {
+        const result = CreateUserSchema.safeParse({
+            email: "user@example.com",
+            password: "secret123",
+            has_projections_access: true,
+        });
+        expect(result.success).toBe(true);
+    });
+
+    test("normalizes email (trim + lowercase)", () => {
+        const result = CreateUserSchema.parse({
+            email: "  USER@Example.COM ",
+            password: "secret123",
+        });
+        expect(result.email).toBe("user@example.com");
+    });
+
+    test("rejects passwords shorter than 6 characters", () => {
+        const result = CreateUserSchema.safeParse({
+            email: "u@example.com",
+            password: "short",
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test("rejects passwords longer than 72 characters (bcrypt limit)", () => {
+        const result = CreateUserSchema.safeParse({
+            email: "u@example.com",
+            password: "a".repeat(73),
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test("rejects invalid email", () => {
+        const result = CreateUserSchema.safeParse({
+            email: "not-an-email",
+            password: "secret123",
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test("rejects missing required fields", () => {
+        const result = CreateUserSchema.safeParse({ email: "u@example.com" });
+        expect(result.success).toBe(false);
+    });
+
+    test("has_projections_access is optional", () => {
+        const result = CreateUserSchema.safeParse({
+            email: "u@example.com",
+            password: "secret123",
+        });
+        expect(result.success).toBe(true);
+    });
+});
+
+describe("UpdateUserSchema", () => {
+    test("accepts has_projections_access", () => {
+        const result = UpdateUserSchema.safeParse({ has_projections_access: false });
+        expect(result.success).toBe(true);
+    });
+
+    test("accepts empty object", () => {
+        const result = UpdateUserSchema.safeParse({});
+        expect(result.success).toBe(true);
+    });
+
+    test("rejects non-boolean has_projections_access", () => {
+        const result = UpdateUserSchema.safeParse({ has_projections_access: "yes" });
+        expect(result.success).toBe(false);
+    });
+});

--- a/web/__tests__/lib/validate.test.ts
+++ b/web/__tests__/lib/validate.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment node
+ *
+ * Uses the node environment so the global Web `Request` constructor is
+ * available — `next/server` (imported transitively via `@/lib/validate`)
+ * extends it. JSDOM's Request shim doesn't expose all the fields next/server
+ * relies on.
+ */
+import { z } from "zod";
+import { parseJson } from "@/lib/validate";
+import type { NextRequest } from "next/server";
+
+function fakeRequest(body: unknown, { malformed = false } = {}): NextRequest {
+    const json = malformed
+        ? () => Promise.reject(new Error("Unexpected token"))
+        : () => Promise.resolve(body);
+    // We only exercise the `json()` method on the request — cast is safe for tests.
+    return { json } as unknown as NextRequest;
+}
+
+const Schema = z.object({ name: z.string().min(1) });
+
+describe("parseJson", () => {
+    test("returns parsed data on a valid body", async () => {
+        const result = await parseJson(fakeRequest({ name: "ok" }), Schema);
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.data.name).toBe("ok");
+    });
+
+    test("returns 400 with issues on schema failure", async () => {
+        const result = await parseJson(fakeRequest({ name: "" }), Schema);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.response.status).toBe(400);
+            const json = await result.response.json();
+            expect(json.error).toBe("Invalid request body");
+            expect(Array.isArray(json.issues)).toBe(true);
+            expect(json.issues.length).toBeGreaterThan(0);
+        }
+    });
+
+    test("returns 400 on malformed JSON", async () => {
+        const result = await parseJson(fakeRequest(null, { malformed: true }), Schema);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.response.status).toBe(400);
+            const json = await result.response.json();
+            expect(json.error).toBe("Invalid JSON");
+        }
+    });
+});

--- a/web/app/api/admin/users/[id]/route.ts
+++ b/web/app/api/admin/users/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getAuthenticatedUser } from "@/lib/auth";
+import { parseJson } from "@/lib/validate";
+import { UpdateUserSchema } from "@/lib/schemas/user";
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -12,7 +14,9 @@ export async function PUT(req: NextRequest, context: RouteContext) {
   if (!user.isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const { id } = await context.params;
-  const { has_projections_access } = await req.json();
+  const parsed = await parseJson(req, UpdateUserSchema);
+  if (!parsed.ok) return parsed.response;
+  const { has_projections_access } = parsed.data;
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
   if (has_projections_access !== undefined) updates.has_projections_access = has_projections_access;

--- a/web/app/api/admin/users/route.ts
+++ b/web/app/api/admin/users/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getAuthenticatedUser } from "@/lib/auth";
+import { parseJson } from "@/lib/validate";
+import { CreateUserSchema } from "@/lib/schemas/user";
 
 export async function GET() {
   const user = await getAuthenticatedUser();
@@ -22,26 +24,16 @@ export async function POST(req: NextRequest) {
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   if (!user.isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
-  const { email, password, has_projections_access } = await req.json();
-
-  if (!email || !password) {
-    return NextResponse.json({ error: "Email and password are required" }, { status: 400 });
-  }
-
-  if (password.length < 6) {
-    return NextResponse.json({ error: "Password must be at least 6 characters" }, { status: 400 });
-  }
-
-  if (password.length > 72) {
-    return NextResponse.json({ error: "Password must be at most 72 characters" }, { status: 400 });
-  }
+  const parsed = await parseJson(req, CreateUserSchema);
+  if (!parsed.ok) return parsed.response;
+  const { email, password, has_projections_access } = parsed.data;
 
   const password_hash = await bcrypt.hash(password, 12);
 
   const { data, error } = await getSupabaseAdmin()
     .from("users")
     .insert({
-      email: email.toLowerCase().trim(),
+      email,
       password_hash,
       has_projections_access: has_projections_access ?? false,
     })

--- a/web/app/api/arbitration-plans/[id]/duplicate/route.ts
+++ b/web/app/api/arbitration-plans/[id]/duplicate/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { LEAGUE_ID } from "@/lib/arb-logic";
 import { getAuthenticatedUser } from "@/lib/auth";
+import { parseJson } from "@/lib/validate";
+import { DuplicatePlanSchema } from "@/lib/schemas/arbitration-plan";
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -12,11 +14,9 @@ export async function POST(req: NextRequest, context: RouteContext) {
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { id } = await context.params;
-  const { name } = await req.json();
-
-  if (!name || typeof name !== "string" || name.trim().length === 0) {
-    return NextResponse.json({ error: "Name is required" }, { status: 400 });
-  }
+  const parsed = await parseJson(req, DuplicatePlanSchema);
+  if (!parsed.ok) return parsed.response;
+  const { name } = parsed.data;
 
   // Verify ownership of source plan
   const { data: sourcePlan, error: fetchError } = await getSupabaseAdmin()
@@ -33,7 +33,7 @@ export async function POST(req: NextRequest, context: RouteContext) {
   // Create new plan
   const { data: newPlan, error: planError } = await getSupabaseAdmin()
     .from("arbitration_plans")
-    .insert({ league_id: LEAGUE_ID, user_id: user.userId, name: name.trim() })
+    .insert({ league_id: LEAGUE_ID, user_id: user.userId, name })
     .select("id, name, notes, created_at, updated_at")
     .single();
 

--- a/web/app/api/arbitration-plans/[id]/route.ts
+++ b/web/app/api/arbitration-plans/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getAuthenticatedUser } from "@/lib/auth";
+import { parseJson } from "@/lib/validate";
+import { UpdatePlanSchema } from "@/lib/schemas/arbitration-plan";
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -58,7 +60,9 @@ export async function PUT(req: NextRequest, context: RouteContext) {
   }
   if (plan.user_id !== user.userId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
-  const { name, notes, allocations } = await req.json();
+  const parsed = await parseJson(req, UpdatePlanSchema);
+  if (!parsed.ok) return parsed.response;
+  const { name, notes, allocations } = parsed.data;
 
   // Update plan metadata
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
@@ -78,7 +82,7 @@ export async function PUT(req: NextRequest, context: RouteContext) {
   }
 
   // Upsert allocations if provided
-  if (allocations && typeof allocations === "object") {
+  if (allocations) {
     const { error: delError } = await getSupabaseAdmin()
       .from("arbitration_plan_allocations")
       .delete()
@@ -86,7 +90,7 @@ export async function PUT(req: NextRequest, context: RouteContext) {
 
     if (delError) return NextResponse.json({ error: delError.message }, { status: 500 });
 
-    const rows = Object.entries(allocations as Record<string, number>)
+    const rows = Object.entries(allocations)
       .filter(([, amount]) => amount > 0)
       .map(([player_id, amount]) => ({
         plan_id: id,

--- a/web/app/api/arbitration-plans/route.ts
+++ b/web/app/api/arbitration-plans/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { LEAGUE_ID } from "@/lib/arb-logic";
 import { getAuthenticatedUser } from "@/lib/auth";
+import { parseJson } from "@/lib/validate";
+import { CreatePlanSchema } from "@/lib/schemas/arbitration-plan";
 
 export async function GET() {
   const user = await getAuthenticatedUser();
@@ -22,15 +24,13 @@ export async function POST(req: NextRequest) {
   const user = await getAuthenticatedUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { name, notes } = await req.json();
-
-  if (!name || typeof name !== "string" || name.trim().length === 0) {
-    return NextResponse.json({ error: "Name is required" }, { status: 400 });
-  }
+  const parsed = await parseJson(req, CreatePlanSchema);
+  if (!parsed.ok) return parsed.response;
+  const { name, notes } = parsed.data;
 
   const { data, error } = await getSupabaseAdmin()
     .from("arbitration_plans")
-    .insert({ league_id: LEAGUE_ID, user_id: user.userId, name: name.trim(), notes: notes ?? null })
+    .insert({ league_id: LEAGUE_ID, user_id: user.userId, name, notes: notes ?? null })
     .select("id, name, notes, created_at, updated_at")
     .single();
 

--- a/web/app/api/surplus-adjustments/route.ts
+++ b/web/app/api/surplus-adjustments/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { LEAGUE_ID } from "@/lib/arb-logic";
 import { getAuthenticatedUser } from "@/lib/auth";
+import { parseJson } from "@/lib/validate";
+import { SurplusAdjustmentsArraySchema } from "@/lib/schemas/surplus-adjustment";
 
 export async function GET() {
   const user = await getAuthenticatedUser();
@@ -17,19 +19,14 @@ export async function GET() {
   return NextResponse.json(data ?? []);
 }
 
-interface AdjustmentRow {
-  player_id: string;
-  adjustment: number;
-  notes?: string;
-}
-
 export async function POST(req: NextRequest) {
   const user = await getAuthenticatedUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const body: AdjustmentRow[] = await req.json();
+  const parsed = await parseJson(req, SurplusAdjustmentsArraySchema);
+  if (!parsed.ok) return parsed.response;
 
-  const rows = body.map((item) => ({
+  const rows = parsed.data.map((item) => ({
     player_id: item.player_id,
     league_id: LEAGUE_ID,
     user_id: user.userId,

--- a/web/lib/schemas/arbitration-plan.ts
+++ b/web/lib/schemas/arbitration-plan.ts
@@ -1,0 +1,30 @@
+/**
+ * Zod schemas for arbitration-plan API inputs.
+ */
+
+import { z } from "zod";
+
+export const CreatePlanSchema = z.object({
+    name: z.string().trim().min(1).max(100),
+    notes: z.string().max(2000).nullish(),
+});
+
+export type CreatePlanInput = z.infer<typeof CreatePlanSchema>;
+
+export const UpdatePlanSchema = z.object({
+    name: z.string().trim().min(1).max(100).optional(),
+    notes: z.string().max(2000).nullish(),
+    // Allocations are { player_id: amount }. Negative or NaN amounts get rejected.
+    // amount=0 is allowed (later filtered before insert) so the client can clear an entry.
+    allocations: z
+        .record(z.string().min(1), z.number().int().min(0))
+        .optional(),
+});
+
+export type UpdatePlanInput = z.infer<typeof UpdatePlanSchema>;
+
+export const DuplicatePlanSchema = z.object({
+    name: z.string().trim().min(1).max(100),
+});
+
+export type DuplicatePlanInput = z.infer<typeof DuplicatePlanSchema>;

--- a/web/lib/schemas/surplus-adjustment.ts
+++ b/web/lib/schemas/surplus-adjustment.ts
@@ -1,0 +1,17 @@
+/**
+ * Zod schemas for surplus-adjustment API inputs.
+ */
+
+import { z } from "zod";
+
+export const SurplusAdjustmentSchema = z.object({
+    player_id: z.string().min(1),
+    adjustment: z.number().finite(),
+    notes: z.string().max(2000).optional(),
+});
+
+export type SurplusAdjustmentInput = z.infer<typeof SurplusAdjustmentSchema>;
+
+export const SurplusAdjustmentsArraySchema = z.array(SurplusAdjustmentSchema);
+
+export type SurplusAdjustmentsInput = z.infer<typeof SurplusAdjustmentsArraySchema>;

--- a/web/lib/schemas/user.ts
+++ b/web/lib/schemas/user.ts
@@ -1,0 +1,20 @@
+/**
+ * Zod schemas for user-management API inputs.
+ * bcrypt's 72-byte password limit drives the upper bound.
+ */
+
+import { z } from "zod";
+
+export const CreateUserSchema = z.object({
+    email: z.string().trim().toLowerCase().email().max(254),
+    password: z.string().min(6).max(72),
+    has_projections_access: z.boolean().optional(),
+});
+
+export type CreateUserInput = z.infer<typeof CreateUserSchema>;
+
+export const UpdateUserSchema = z.object({
+    has_projections_access: z.boolean().optional(),
+});
+
+export type UpdateUserInput = z.infer<typeof UpdateUserSchema>;

--- a/web/lib/validate.ts
+++ b/web/lib/validate.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared validation helper for API route inputs.
+ *
+ * Usage:
+ *   const parsed = await parseJson(req, MySchema);
+ *   if (!parsed.ok) return parsed.response;
+ *   const data = parsed.data; // typed as z.infer<typeof MySchema>
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import type { z, ZodType } from "zod";
+
+export type ParseResult<T> =
+    | { ok: true; data: T }
+    | { ok: false; response: NextResponse };
+
+/**
+ * Parse and validate a JSON request body against a Zod schema.
+ * On failure, returns a 400 response with a `issues` array (Zod's default).
+ * On success, returns the typed, parsed data.
+ */
+export async function parseJson<T extends ZodType>(
+    req: NextRequest,
+    schema: T,
+): Promise<ParseResult<z.infer<T>>> {
+    let body: unknown;
+    try {
+        body = await req.json();
+    } catch {
+        return {
+            ok: false,
+            response: NextResponse.json(
+                { error: "Invalid JSON", issues: [] },
+                { status: 400 },
+            ),
+        };
+    }
+    const result = schema.safeParse(body);
+    if (!result.success) {
+        return {
+            ok: false,
+            response: NextResponse.json(
+                { error: "Invalid request body", issues: result.error.issues },
+                { status: 400 },
+            ),
+        };
+    }
+    return { ok: true, data: result.data };
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,7 +17,8 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "recharts": "^3.6.0",
-        "tailwind-merge": "^3.4.0"
+        "tailwind-merge": "^3.4.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -110,6 +111,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -697,6 +699,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -720,6 +723,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3440,6 +3444,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3456,6 +3461,7 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3466,6 +3472,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3561,6 +3568,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -4067,6 +4075,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4585,6 +4594,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5598,6 +5608,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5783,6 +5794,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8457,6 +8469,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9858,6 +9871,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9867,6 +9881,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9878,13 +9893,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -9951,7 +9968,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -10999,6 +11017,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11091,6 +11110,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11281,6 +11301,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11902,11 +11923,11 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-      "dev": true,
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,8 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "recharts": "^3.6.0",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4


### PR DESCRIPTION
Closes #432.

## Summary
- Add `zod` (^4.3.6) to `web/package.json`.
- New `web/lib/validate.ts` exports `parseJson(req, schema)` — returns `{ ok: true, data }` on success or `{ ok: false, response }` on failure (400 with Zod's `issues[]`). Also handles malformed JSON.
- New schemas under `web/lib/schemas/`:
  - `user.ts` — `CreateUserSchema` (email normalize + bcrypt 72-byte cap), `UpdateUserSchema`
  - `arbitration-plan.ts` — `CreatePlanSchema`, `UpdatePlanSchema` (incl. typed allocations), `DuplicatePlanSchema`
  - `surplus-adjustment.ts` — `SurplusAdjustmentSchema` + array variant (rejects NaN/Infinity)
- Routes migrated: `POST /api/admin/users`, `PUT /api/admin/users/[id]`, `POST /api/arbitration-plans`, `PUT /api/arbitration-plans/[id]`, `POST /api/arbitration-plans/[id]/duplicate`, `POST /api/surplus-adjustments`.
- Removed the hand-rolled checks the schemas now cover, plus the inline `AdjustmentRow` interface.

## Test plan
- [x] `just typecheck` — clean.
- [x] `just test-web` — 15 suites, 132 tests pass (4 new test files: per-schema valid/invalid + helper malformed-JSON / schema-failure / happy paths).
- [x] All schema files report 100% line coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)