### PR TITLE
feat: standardize player UI components across all tables

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -34,8 +34,21 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `SummaryCard` | Metric display cards with variant styles (default, positive, negative) |
 | `PositionFilter` | Position selection buttons with multi-select support |
 | `ScatterChart` | Player efficiency scatter plot with interactive filters |
+| `PositionBadge` | Colored position pill (QB, RB, etc.) — canonical across all views |
+| `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
+| `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
+| `PlayerHoverCard` | Rich hover preview card for player context |
 
-Column definitions live in `web/lib/columns.ts` for consistent table layouts.
+### Column Factories (`components/columns.tsx`)
+
+Column definitions for `DataTable` are built via **composable factory functions** to prevent drift across pages. Individual factories (`playerNameCol`, `positionCol`, `salaryCol`, etc.) inject atomic components (`PositionBadge`, `PlayerName`) via `renderCell`. Pages compose columns from these factories:
+
+```typescript
+import { corePlayerCols, salaryCol, ppgCol } from "@/components/columns";
+const columns = [...corePlayerCols({ hoverDataMap }), salaryCol(), ppgCol("Proj PPG")];
+```
+
+Static column arrays (no React components) remain in `web/lib/columns.ts` for backward compatibility.
 
 ## TypeScript Types
 

--- a/web/app/arb-planner-public/PublicTeamRosterSection.tsx
+++ b/web/app/arb-planner-public/PublicTeamRosterSection.tsx
@@ -2,6 +2,9 @@
 
 import { useState } from "react";
 import { PublicArbPlayer } from "@/lib/types";
+import PlayerName from "@/components/PlayerName";
+import PositionBadge from "@/components/PositionBadge";
+import StatValue from "@/components/StatValue";
 
 interface PublicTeamRosterSectionProps {
     teamName: string;
@@ -63,13 +66,13 @@ export default function PublicTeamRosterSection({
                                     Pos
                                 </th>
                                 <th className="text-left px-3 py-2 font-medium text-slate-600 dark:text-slate-400">
-                                    NFL Team
+                                    Team
                                 </th>
                                 <th className="text-right px-3 py-2 font-medium text-slate-600 dark:text-slate-400">
                                     Salary
                                 </th>
                                 <th className="text-right px-3 py-2 font-medium text-slate-600 dark:text-slate-400">
-                                    2025 PPG
+                                    PPG
                                 </th>
                                 <th className="text-right px-3 py-2 font-medium text-slate-600 dark:text-slate-400">
                                     GP
@@ -90,23 +93,26 @@ export default function PublicTeamRosterSection({
                                         className={`border-b border-slate-100 dark:border-slate-800 ${hasAlloc ? "bg-blue-50 dark:bg-blue-950/20" : ""
                                             }`}
                                     >
-                                        <td className="px-3 py-2 text-slate-900 dark:text-white font-medium">
-                                            {p.name}
+                                        <td className="px-3 py-2">
+                                            <PlayerName
+                                                name={p.name}
+                                                mode="plain"
+                                            />
                                         </td>
-                                        <td className="px-3 py-2 text-slate-600 dark:text-slate-400">
-                                            {p.position}
+                                        <td className="px-3 py-2">
+                                            <PositionBadge position={p.position} />
                                         </td>
                                         <td className="px-3 py-2 text-slate-600 dark:text-slate-400">
                                             {p.nfl_team}
                                         </td>
                                         <td className="px-3 py-2 text-right text-slate-900 dark:text-white">
-                                            ${p.price}
+                                            <StatValue value={p.price} format="currency" />
                                         </td>
                                         <td className="px-3 py-2 text-right text-slate-900 dark:text-white">
-                                            {p.ppg.toFixed(2)}
+                                            <StatValue value={p.ppg} format="decimal" />
                                         </td>
                                         <td className="px-3 py-2 text-right text-slate-600 dark:text-slate-400">
-                                            {p.games_played}
+                                            <StatValue value={p.games_played} format="number" />
                                         </td>
                                         <td className="px-3 py-2 text-center">
                                             <input

--- a/web/app/arbitration-planner/TeamRosterSection.tsx
+++ b/web/app/arbitration-planner/TeamRosterSection.tsx
@@ -2,7 +2,9 @@
 
 import { useState } from "react";
 import { ArbitrationTarget, PlayerHoverData } from "@/lib/types";
-import PlayerHoverCard from "@/components/PlayerHoverCard";
+import PlayerName from "@/components/PlayerName";
+import PositionBadge from "@/components/PositionBadge";
+import StatValue from "@/components/StatValue";
 
 interface TeamRosterSectionProps {
   teamName: string;
@@ -68,7 +70,7 @@ export default function TeamRosterSection({
                   Pos
                 </th>
                 <th className="text-left px-3 py-2 font-medium text-slate-600 dark:text-slate-400">
-                  NFL Team
+                  Team
                 </th>
                 <th className="text-right px-3 py-2 font-medium text-slate-600 dark:text-slate-400">
                   Salary
@@ -80,7 +82,7 @@ export default function TeamRosterSection({
                   Surplus
                 </th>
                 <th className="text-right px-3 py-2 font-medium text-slate-600 dark:text-slate-400">
-                  2025 PPG
+                  PPG
                 </th>
                 <th className="text-right px-3 py-2 font-medium text-slate-600 dark:text-slate-400">
                   GP
@@ -114,28 +116,25 @@ export default function TeamRosterSection({
                     key={p.player_id}
                     className={`border-b border-slate-100 dark:border-slate-800 ${rowClass}`}
                   >
-                    <td className="px-3 py-2 text-slate-900 dark:text-white font-medium">
-                      {hoverDataMap && p.ottoneu_id ? (
-                        <PlayerHoverCard
-                          name={p.name}
-                          ottoneuId={p.ottoneu_id}
-                          hoverData={hoverDataMap[p.player_id]}
-                        />
-                      ) : (
-                        p.name
-                      )}
+                    <td className="px-3 py-2">
+                      <PlayerName
+                        name={p.name}
+                        ottoneuId={p.ottoneu_id}
+                        mode={hoverDataMap ? "hover" : "link"}
+                        hoverData={hoverDataMap?.[p.player_id]}
+                      />
                     </td>
-                    <td className="px-3 py-2 text-slate-600 dark:text-slate-400">
-                      {p.position}
+                    <td className="px-3 py-2">
+                      <PositionBadge position={p.position} />
                     </td>
                     <td className="px-3 py-2 text-slate-600 dark:text-slate-400">
                       {p.nfl_team}
                     </td>
                     <td className="px-3 py-2 text-right text-slate-900 dark:text-white">
-                      ${p.price}
+                      <StatValue value={p.price} format="currency" />
                     </td>
                     <td className="px-3 py-2 text-right text-slate-900 dark:text-white">
-                      ${p.dollar_value}
+                      <StatValue value={p.dollar_value} format="currency" />
                     </td>
                     <td
                       className={`px-3 py-2 text-right font-medium ${p.surplus >= 0
@@ -143,13 +142,13 @@ export default function TeamRosterSection({
                           : "text-red-600 dark:text-red-400"
                         }`}
                     >
-                      ${p.surplus}
+                      <StatValue value={p.surplus} format="currency" />
                     </td>
                     <td className="px-3 py-2 text-right text-slate-900 dark:text-white">
-                      {p.ppg.toFixed(2)}
+                      <StatValue value={p.ppg} format="decimal" />
                     </td>
                     <td className="px-3 py-2 text-right text-slate-600 dark:text-slate-400">
-                      {p.games_played}
+                      <StatValue value={p.games_played} format="number" />
                     </td>
                     {adjustedSurplus && (
                       <td
@@ -158,7 +157,7 @@ export default function TeamRosterSection({
                             : "text-red-600 dark:text-red-400"
                           }`}
                       >
-                        {adjSurp !== undefined ? `$${adjSurp}` : "-"}
+                        {adjSurp !== undefined ? <StatValue value={adjSurp} format="currency" /> : "—"}
                       </td>
                     )}
                     <td className="px-3 py-2 text-center">

--- a/web/app/arbitration-simulation/SimulationControls.tsx
+++ b/web/app/arbitration-simulation/SimulationControls.tsx
@@ -7,10 +7,17 @@ import {
   NUM_SIMULATIONS,
   VALUE_VARIATION,
 } from "@/lib/analysis";
-import type { Player, PlayerHoverData, SimulationResult } from "@/lib/types";
-import DataTable, { Column, HighlightRule } from "@/components/DataTable";
-import { makePlayerNameColumn } from "@/components/PlayerHoverCard";
+import type { Player, PlayerHoverData, SimulationResult, Column, HighlightRule } from "@/lib/types";
+import DataTable from "@/components/DataTable";
 import SimulationTeams from "./SimulationTeams";
+import {
+  playerNameCol,
+  positionCol,
+  nflTeamCol,
+  ownerCol,
+  salaryCol,
+  valueCol,
+} from "@/components/columns";
 
 interface SimulationControlsProps {
   initialPlayers: Player[];
@@ -21,10 +28,10 @@ interface SimulationControlsProps {
 
 function getMyRosterColumns(hdm: Record<string, PlayerHoverData> | null): Column<SimulationResult>[] {
   return [
-    makePlayerNameColumn<SimulationResult>(hdm),
-    { key: "position", label: "Pos" },
-    { key: "price", label: "Salary", format: "currency" },
-    { key: "dollar_value", label: "Value", format: "currency" },
+    playerNameCol<SimulationResult>({ hoverDataMap: hdm }),
+    positionCol<SimulationResult>(),
+    salaryCol<SimulationResult>(),
+    valueCol<SimulationResult>(),
     { key: "surplus", label: "Surplus", format: "currency" },
     { key: "mean_arb", label: "Expected Arb", format: "currency" },
     { key: "std_arb", label: "Std Dev", format: "currency" },
@@ -35,12 +42,12 @@ function getMyRosterColumns(hdm: Record<string, PlayerHoverData> | null): Column
 
 function getVulnerableColumns(hdm: Record<string, PlayerHoverData> | null): Column<SimulationResult>[] {
   return [
-    makePlayerNameColumn<SimulationResult>(hdm),
-    { key: "position", label: "Pos" },
-    { key: "nfl_team", label: "NFL" },
-    { key: "team_name", label: "Owner" },
-    { key: "price", label: "Salary", format: "currency" },
-    { key: "dollar_value", label: "Value", format: "currency" },
+    playerNameCol<SimulationResult>({ hoverDataMap: hdm }),
+    positionCol<SimulationResult>(),
+    nflTeamCol<SimulationResult>(),
+    ownerCol<SimulationResult>(),
+    salaryCol<SimulationResult>(),
+    valueCol<SimulationResult>(),
     { key: "surplus", label: "Surplus", format: "currency" },
     { key: "mean_arb", label: "Expected Arb", format: "currency" },
     { key: "std_arb", label: "Std Dev", format: "currency" },
@@ -50,12 +57,12 @@ function getVulnerableColumns(hdm: Record<string, PlayerHoverData> | null): Colu
 
 function getCutCandidateColumns(hdm: Record<string, PlayerHoverData> | null): Column<SimulationResult>[] {
   return [
-    makePlayerNameColumn<SimulationResult>(hdm),
-    { key: "position", label: "Pos" },
-    { key: "nfl_team", label: "NFL" },
-    { key: "team_name", label: "Owner" },
-    { key: "price", label: "Salary", format: "currency" },
-    { key: "dollar_value", label: "Value", format: "currency" },
+    playerNameCol<SimulationResult>({ hoverDataMap: hdm }),
+    positionCol<SimulationResult>(),
+    nflTeamCol<SimulationResult>(),
+    ownerCol<SimulationResult>(),
+    salaryCol<SimulationResult>(),
+    valueCol<SimulationResult>(),
     { key: "surplus", label: "Surplus", format: "currency" },
     { key: "mean_arb", label: "Expected Arb", format: "currency" },
     { key: "salary_after_arb", label: "After Arb", format: "currency" },

--- a/web/app/arbitration-simulation/SimulationTeams.tsx
+++ b/web/app/arbitration-simulation/SimulationTeams.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import type { SimulationResult, PlayerHoverData } from "@/lib/types";
-import DataTable, { Column } from "@/components/DataTable";
-import { makePlayerNameColumn } from "@/components/PlayerHoverCard";
+import type { SimulationResult, PlayerHoverData, Column } from "@/lib/types";
+import DataTable from "@/components/DataTable";
+import {
+  playerNameCol,
+  positionCol,
+  salaryCol,
+  valueCol,
+} from "@/components/columns";
 
 interface SimulationTeamsProps {
   results: SimulationResult[];
@@ -12,10 +17,10 @@ interface SimulationTeamsProps {
 
 function getTeamPlayerColumns(hdm: Record<string, PlayerHoverData> | null): Column<SimulationResult>[] {
   return [
-    makePlayerNameColumn<SimulationResult>(hdm),
-    { key: "position", label: "Pos" },
-    { key: "price", label: "Salary", format: "currency" },
-    { key: "dollar_value", label: "Value", format: "currency" },
+    playerNameCol<SimulationResult>({ hoverDataMap: hdm }),
+    positionCol<SimulationResult>(),
+    salaryCol<SimulationResult>(),
+    valueCol<SimulationResult>(),
     { key: "surplus", label: "Surplus", format: "currency" },
     { key: "mean_arb", label: "Expected Arb", format: "currency" },
     { key: "salary_after_arb", label: "After Arb", format: "currency" },

--- a/web/app/arbitration/ArbitrationTeams.tsx
+++ b/web/app/arbitration/ArbitrationTeams.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import { useState } from "react";
-import DataTable, { Column } from "@/components/DataTable";
-import { makePlayerNameColumn } from "@/components/PlayerHoverCard";
-import type { PlayerHoverData } from "@/lib/types";
+import DataTable from "@/components/DataTable";
+import type { Column, PlayerHoverData } from "@/lib/types";
+import {
+  playerNameCol,
+  positionCol,
+  salaryCol,
+  valueCol,
+  ownerCol,
+} from "@/components/columns";
 
 interface TeamPlayer {
   name: string;
@@ -25,10 +31,10 @@ interface TeamGroup {
 
 function getBaseColumns(hoverDataMap: Record<string, PlayerHoverData> | null): Column[] {
   return [
-    makePlayerNameColumn(hoverDataMap),
-    { key: "position", label: "Pos" },
-    { key: "price", label: "Salary", format: "currency" },
-    { key: "dollar_value", label: "Value", format: "currency" },
+    playerNameCol({ hoverDataMap }),
+    positionCol(),
+    salaryCol(),
+    valueCol(),
     { key: "surplus", label: "Surplus", format: "currency" },
     { key: "surplus_after_arb", label: "Surplus (Post-Arb)", format: "currency" },
   ];
@@ -36,12 +42,12 @@ function getBaseColumns(hoverDataMap: Record<string, PlayerHoverData> | null): C
 
 function getProjectedColumns(hoverDataMap: Record<string, PlayerHoverData> | null): Column[] {
   return [
-    makePlayerNameColumn(hoverDataMap),
-    { key: "position", label: "Pos" },
-    { key: "price", label: "Salary", format: "currency" },
+    playerNameCol({ hoverDataMap }),
+    positionCol(),
+    salaryCol(),
     { key: "observed_ppg", label: "Obs PPG", format: "decimal" },
     { key: "ppg", label: "Proj PPG", format: "decimal" },
-    { key: "dollar_value", label: "Value", format: "currency" },
+    valueCol(),
     { key: "surplus", label: "Surplus", format: "currency" },
     { key: "surplus_after_arb", label: "Surplus (Post-Arb)", format: "currency" },
   ];

--- a/web/app/arbitration/page.tsx
+++ b/web/app/arbitration/page.tsx
@@ -16,12 +16,20 @@ import {
   DEFAULT_PROJECTION_YEAR,
   getHistoricalSeasonsForYear,
 } from "@/lib/analysis";
-import type { ArbitrationTarget } from "@/lib/types";
+import type { ArbitrationTarget, Column, HighlightRule } from "@/lib/types";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getAuthenticatedUser } from "@/lib/auth";
-import DataTable, { Column, HighlightRule } from "@/components/DataTable";
+import DataTable from "@/components/DataTable";
 import ArbitrationTeams from "./ArbitrationTeams";
 import ModeToggle, { ValueMode } from "@/components/ModeToggle";
+import {
+  playerNameCol,
+  positionCol,
+  nflTeamCol,
+  ownerCol,
+  salaryCol,
+  valueCol,
+} from "@/components/columns";
 
 interface Props {
   searchParams: Promise<{ mode?: string }>;
@@ -31,31 +39,35 @@ type ProjectedTarget = ArbitrationTarget & {
   observed_ppg?: number;
 };
 
-const BASE_COLUMNS: Column<ProjectedTarget>[] = [
-  { key: "name", label: "Player" },
-  { key: "position", label: "Pos" },
-  { key: "nfl_team", label: "NFL Team" },
-  { key: "team_name", label: "Owner" },
-  { key: "price", label: "Salary", format: "currency" },
-  { key: "dollar_value", label: "Value", format: "currency" },
-  { key: "surplus", label: "Surplus", format: "currency" },
-  { key: "salary_after_arb", label: "After Arb", format: "currency" },
-  { key: "surplus_after_arb", label: "Surplus (Post-Arb)", format: "currency" },
-];
+function buildBaseColumns(hoverDataMap: Record<string, import("@/lib/types").PlayerHoverData> | null): Column<ProjectedTarget>[] {
+  return [
+    playerNameCol<ProjectedTarget>({ hoverDataMap }),
+    positionCol<ProjectedTarget>(),
+    nflTeamCol<ProjectedTarget>(),
+    ownerCol<ProjectedTarget>(),
+    salaryCol<ProjectedTarget>(),
+    valueCol<ProjectedTarget>(),
+    { key: "surplus", label: "Surplus", format: "currency" },
+    { key: "salary_after_arb", label: "After Arb", format: "currency" },
+    { key: "surplus_after_arb", label: "Surplus (Post-Arb)", format: "currency" },
+  ];
+}
 
-const PROJECTED_COLUMNS: Column<ProjectedTarget>[] = [
-  { key: "name", label: "Player" },
-  { key: "position", label: "Pos" },
-  { key: "nfl_team", label: "NFL Team" },
-  { key: "team_name", label: "Owner" },
-  { key: "price", label: "Salary", format: "currency" },
-  { key: "observed_ppg", label: "Obs PPG", format: "decimal" },
-  { key: "ppg", label: "Proj PPG", format: "decimal" },
-  { key: "dollar_value", label: "Value", format: "currency" },
-  { key: "surplus", label: "Surplus", format: "currency" },
-  { key: "salary_after_arb", label: "After Arb", format: "currency" },
-  { key: "surplus_after_arb", label: "Surplus (Post-Arb)", format: "currency" },
-];
+function buildProjectedColumns(hoverDataMap: Record<string, import("@/lib/types").PlayerHoverData> | null): Column<ProjectedTarget>[] {
+  return [
+    playerNameCol<ProjectedTarget>({ hoverDataMap }),
+    positionCol<ProjectedTarget>(),
+    nflTeamCol<ProjectedTarget>(),
+    ownerCol<ProjectedTarget>(),
+    salaryCol<ProjectedTarget>(),
+    { key: "observed_ppg", label: "Obs PPG", format: "decimal" },
+    { key: "ppg", label: "Proj PPG", format: "decimal" },
+    valueCol<ProjectedTarget>(),
+    { key: "surplus", label: "Surplus", format: "currency" },
+    { key: "salary_after_arb", label: "After Arb", format: "currency" },
+    { key: "surplus_after_arb", label: "Surplus (Post-Arb)", format: "currency" },
+  ];
+}
 
 const ARB_TARGET_RULES: HighlightRule<ProjectedTarget>[] = [
   { key: "surplus_after_arb", op: "lt", value: 0, className: "bg-red-50 dark:bg-red-950/30" },
@@ -146,7 +158,7 @@ export default async function ArbitrationPage({ searchParams }: Props) {
   const projectionYear = DEFAULT_PROJECTION_YEAR;
   const historicalSeasons = getHistoricalSeasonsForYear(projectionYear);
   const mostRecentSeason = Math.max(...historicalSeasons);
-  const columns = isProjected ? PROJECTED_COLUMNS : BASE_COLUMNS;
+  const columns = isProjected ? buildProjectedColumns(hoverDataMap) : buildBaseColumns(hoverDataMap);
 
   return (
     <main className="min-h-screen bg-white dark:bg-black p-8">
@@ -259,7 +271,6 @@ export default async function ArbitrationPage({ searchParams }: Props) {
             columns={columns}
             data={targets.slice(0, 20)}
             highlightRules={ARB_TARGET_RULES}
-            hoverDataMap={hoverDataMap}
           />
         </section>
 

--- a/web/app/players/[id]/page.tsx
+++ b/web/app/players/[id]/page.tsx
@@ -2,7 +2,9 @@ import { fetchPlayerDetail, fetchPlayerProjection } from "@/lib/data";
 import { getAuthenticatedUser } from "@/lib/auth";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { POSITION_COLORS, Position } from "@/lib/types";
+import { POSITION_COLORS, type Position } from "@/lib/types";
+import PositionBadge from "@/components/PositionBadge";
+import StatValue from "@/components/StatValue";
 
 export async function generateMetadata({
     params,
@@ -34,8 +36,7 @@ export default async function PlayerCardPage({
         ? await fetchPlayerProjection(player.id)
         : null;
 
-    const posColor =
-        POSITION_COLORS[player.position as Position] ?? "#6B7280";
+    const posColor = POSITION_COLORS[player.position as Position] ?? "#6B7280";
 
     const age = player.birth_date
         ? (() => {
@@ -68,12 +69,7 @@ export default async function PlayerCardPage({
                                     <h1 className="text-3xl font-bold text-slate-900 dark:text-white">
                                         {player.name}
                                     </h1>
-                                    <span
-                                        className="px-2 py-1 rounded text-xs font-bold text-white"
-                                        style={{ backgroundColor: posColor }}
-                                    >
-                                        {player.position}
-                                    </span>
+                                    <PositionBadge position={player.position} />
                                 </div>
                                 <p className="text-slate-500 dark:text-slate-400 mt-1">
                                     {player.nfl_team}{age != null ? ` · Age ${age}` : ""} · Ottoneu ID: {player.ottoneu_id}
@@ -149,16 +145,16 @@ export default async function PlayerCardPage({
                                         >
                                             <td className="px-3 py-2 font-semibold text-slate-700 dark:text-slate-300">{s.season}</td>
                                             <td className="px-3 py-2 text-right font-mono text-slate-800 dark:text-slate-200">
-                                                {s.total_points != null ? s.total_points.toFixed(1) : "—"}
+                                                <StatValue value={s.total_points} format="decimal" />
                                             </td>
                                             <td className="px-3 py-2 text-right font-mono text-slate-800 dark:text-slate-200">
-                                                {s.games_played ?? "—"}
+                                                <StatValue value={s.games_played} format="number" />
                                             </td>
                                             <td className="px-3 py-2 text-right font-mono text-slate-800 dark:text-slate-200">
                                                 {s.snaps != null ? s.snaps.toLocaleString() : "—"}
                                             </td>
                                             <td className="px-3 py-2 text-right font-mono text-slate-800 dark:text-slate-200">
-                                                {s.ppg != null ? s.ppg.toFixed(2) : "—"}
+                                                <StatValue value={s.ppg} format="decimal" />
                                             </td>
                                             <td className="px-3 py-2 text-right font-mono text-slate-800 dark:text-slate-200">
                                                 {s.pps != null ? s.pps.toFixed(4) : "—"}

--- a/web/app/projected-salary/ProjectedSalaryClient.tsx
+++ b/web/app/projected-salary/ProjectedSalaryClient.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import DataTable, { Column } from "@/components/DataTable";
-import { makePlayerNameColumn } from "@/components/PlayerHoverCard";
-import type { PlayerHoverData } from "@/lib/types";
+import DataTable from "@/components/DataTable";
+import type { Column, PlayerHoverData } from "@/lib/types";
+import {
+  playerNameCol,
+  nflTeamCol,
+  salaryCol,
+  valueCol,
+  ppgCol,
+  totalPointsCol,
+  gamesPlayedCol,
+} from "@/components/columns";
 
 interface PlayerRow {
   player_id: string;
@@ -22,14 +30,14 @@ interface PlayerRow {
 
 function getColumns(hoverDataMap: Record<string, PlayerHoverData> | null): Column[] {
   return [
-    makePlayerNameColumn(hoverDataMap),
-    { key: "nfl_team", label: "Team" },
-    { key: "price", label: "Salary", format: "currency" },
-    { key: "dollar_value", label: "Value", format: "currency" },
+    playerNameCol({ hoverDataMap }),
+    nflTeamCol(),
+    salaryCol(),
+    valueCol(),
     { key: "surplus", label: "Surplus", format: "currency" },
-    { key: "ppg", label: "PPG", format: "decimal" },
-    { key: "total_points", label: "Points", format: "decimal" },
-    { key: "games_played", label: "GP", format: "number" },
+    ppgCol(),
+    totalPointsCol(),
+    gamesPlayedCol(),
     { key: "recommendation", label: "Recommendation" },
   ];
 }

--- a/web/app/projection-accuracy/ProjectionAccuracyClient.tsx
+++ b/web/app/projection-accuracy/ProjectionAccuracyClient.tsx
@@ -6,18 +6,27 @@ import { BacktestPlayer, Position, POSITIONS, ProjectionModel } from "@/lib/type
 import { calculateMetrics, PositionMetrics } from "./metrics";
 import AccuracyScatterChart from "./AccuracyScatterChart";
 import FeatureBreakdown from "./FeatureBreakdown";
-import DataTable, { Column } from "@/components/DataTable";
+import DataTable from "@/components/DataTable";
+import type { Column } from "@/lib/types";
 import PositionFilter from "@/components/PositionFilter";
 import SummaryCard from "@/components/SummaryCard";
+import {
+  playerNameCol,
+  positionCol,
+  nflTeamCol,
+  ownerCol,
+  salaryCol,
+  gamesPlayedCol,
+} from "@/components/columns";
 
 const PLAYER_COLUMNS: Column<BacktestPlayer>[] = [
-  { key: "name", label: "Player" },
-  { key: "position", label: "Pos" },
-  { key: "nfl_team", label: "Team" },
-  { key: "team_name", label: "Owner" },
-  { key: "price", label: "Salary", format: "currency" },
+  playerNameCol<BacktestPlayer>(),
+  positionCol<BacktestPlayer>(),
+  nflTeamCol<BacktestPlayer>(),
+  ownerCol<BacktestPlayer>(),
+  salaryCol<BacktestPlayer>(),
   { key: "seasons_used", label: "Seasons" },
-  { key: "games_played", label: "GP", format: "number" },
+  gamesPlayedCol<BacktestPlayer>(),
   { key: "projected_ppg", label: "Proj PPG", format: "decimal" },
   { key: "actual_ppg", label: "Actual PPG", format: "decimal" },
   { key: "error", label: "Error", format: "decimal" },
@@ -34,9 +43,9 @@ const METRICS_COLUMNS: Column[] = [
 ];
 
 const DELTA_COLUMNS: Column[] = [
-  { key: "name", label: "Player" },
-  { key: "position", label: "Pos" },
-  { key: "nfl_team", label: "Team" },
+  playerNameCol(),
+  positionCol(),
+  nflTeamCol(),
   { key: "proj_a", label: "Model A Proj", format: "decimal" },
   { key: "proj_b", label: "Model B Proj", format: "decimal" },
   { key: "delta", label: "Delta (B−A)", format: "decimal" },

--- a/web/app/projections/ProjectionsClient.tsx
+++ b/web/app/projections/ProjectionsClient.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { POSITIONS, PROJECTION_YEARS, SEASON } from "@/lib/analysis";
 import PositionFilter from "@/components/PositionFilter";
 import ProjectionYearSelector from "@/components/ProjectionYearSelector";
-import { Position } from "@/lib/types";
+import DataTable from "@/components/DataTable";
+import PlayerName from "@/components/PlayerName";
+import PositionBadge from "@/components/PositionBadge";
+import type { Column, Position } from "@/lib/types";
 
 export interface ProjectionRow {
   player_id: string;
@@ -22,11 +24,58 @@ export interface ProjectionRow {
   [key: string]: string | number | null | undefined;
 }
 
-type SortKey = keyof Omit<ProjectionRow, "[key: string]">;
-
 interface Props {
   initialData: ProjectionRow[];
   projectionYear: number;
+}
+
+/** Rookie/College badge components for the player name cell. */
+function ProjectionBadges({ method }: { method: string }) {
+  if (method === "rookie_trajectory") {
+    return (
+      <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+        Rookie
+      </span>
+    );
+  }
+  if (method === "college_prospect") {
+    return (
+      <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300">
+        College
+      </span>
+    );
+  }
+  return null;
+}
+
+function getProjectionColumns(projectionYear: number): Column<ProjectionRow>[] {
+  return [
+    {
+      key: "name",
+      label: "Player",
+      renderCell: (value: unknown, row: ProjectionRow) => (
+        <PlayerName
+          name={String(value ?? "—")}
+          ottoneuId={row.ottoneu_id}
+          mode={row.ottoneu_id ? "link" : "plain"}
+          badges={<ProjectionBadges method={row.projection_method} />}
+        />
+      ),
+    },
+    {
+      key: "position",
+      label: "Pos",
+      renderCell: (value: unknown) => (
+        <PositionBadge position={String(value ?? "")} />
+      ),
+    },
+    { key: "nfl_team", label: "Team" },
+    { key: "team_name", label: "Owner" },
+    { key: "price", label: "Salary", format: "currency" },
+    { key: "observed_ppg", label: `${SEASON} PPG`, format: "decimal" },
+    { key: "projected_ppg", label: `Proj ${projectionYear}`, format: "decimal" },
+    { key: "ppg_delta", label: `Δ ${projectionYear} vs ${SEASON}`, format: "decimal" },
+  ];
 }
 
 export default function ProjectionsClient({ initialData, projectionYear }: Props) {
@@ -48,39 +97,10 @@ export default function ProjectionsClient({ initialData, projectionYear }: Props
     );
   };
 
-  const handleSort = (key: string) => {
-    if (sortKey === key) {
-      setSortAsc(!sortAsc);
-    } else {
-      setSortKey(key);
-      setSortAsc(false); // numeric columns default to desc
-    }
-  };
-
   const filteredData = initialData
-    .filter((p) => selectedPositions.includes(p.position as Position))
-    .sort((a, b) => {
-      const av = a[sortKey as SortKey];
-      const bv = b[sortKey as SortKey];
-      if (av == null && bv == null) return 0;
-      if (av == null) return 1;
-      if (bv == null) return -1;
-      if (typeof av === "number" && typeof bv === "number") {
-        return sortAsc ? av - bv : bv - av;
-      }
-      const as = String(av);
-      const bs = String(bv);
-      return sortAsc ? as.localeCompare(bs) : bs.localeCompare(as);
-    });
+    .filter((p) => selectedPositions.includes(p.position as Position));
 
-  const thClass =
-    "px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-300 cursor-pointer select-none whitespace-nowrap hover:bg-slate-200 dark:hover:bg-slate-700";
-  const tdClass = "px-3 py-2 text-slate-800 dark:text-slate-200 whitespace-nowrap";
-
-  const sortIndicator = (key: string) =>
-    sortKey === key ? (
-      <span className="ml-1">{sortAsc ? "▲" : "▼"}</span>
-    ) : null;
+  const columns = getProjectionColumns(projectionYear);
 
   return (
     <section>
@@ -98,104 +118,18 @@ export default function ProjectionsClient({ initialData, projectionYear }: Props
         />
       </div>
 
-      <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-800">
-        <table className="min-w-full text-sm">
-          <thead>
-            <tr className="bg-slate-100 dark:bg-slate-800">
-              <th className={thClass} onClick={() => handleSort("name")}>
-                Player{sortIndicator("name")}
-              </th>
-              <th className={thClass} onClick={() => handleSort("position")}>
-                Pos{sortIndicator("position")}
-              </th>
-              <th className={thClass} onClick={() => handleSort("nfl_team")}>
-                Team{sortIndicator("nfl_team")}
-              </th>
-              <th className={thClass} onClick={() => handleSort("team_name")}>
-                Owner{sortIndicator("team_name")}
-              </th>
-              <th className={thClass} onClick={() => handleSort("price")}>
-                Salary{sortIndicator("price")}
-              </th>
-              <th className={thClass} onClick={() => handleSort("observed_ppg")}>
-                {SEASON} PPG{sortIndicator("observed_ppg")}
-              </th>
-              <th className={thClass} onClick={() => handleSort("projected_ppg")}>
-                Proj {projectionYear}{sortIndicator("projected_ppg")}
-              </th>
-              <th className={thClass} onClick={() => handleSort("ppg_delta")}>
-                Δ {projectionYear} vs {SEASON}{sortIndicator("ppg_delta")}
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {filteredData.map((row, i) => {
-              const delta = row.ppg_delta;
-              const isOutperform = typeof delta === "number" && delta >= 1.5;
-              const isUnderperform = typeof delta === "number" && delta <= -1.5;
-              const rowBg = isOutperform
-                ? "bg-green-50 dark:bg-green-950"
-                : isUnderperform
-                ? "bg-red-50 dark:bg-red-950"
-                : i % 2 === 0
-                ? "bg-white dark:bg-slate-950"
-                : "bg-slate-50 dark:bg-slate-900";
-
-              const isRookie = row.projection_method === "rookie_trajectory";
-              const isCollege = row.projection_method === "college_prospect";
-
-              return (
-                <tr
-                  key={i}
-                  className={`border-t border-slate-100 dark:border-slate-800 ${rowBg}`}
-                >
-                  <td className={tdClass}>
-                    {row.ottoneu_id ? (
-                      <Link
-                        href={`/players/${row.ottoneu_id}`}
-                        className="text-blue-600 dark:text-blue-400 hover:underline"
-                      >
-                        {row.name}
-                      </Link>
-                    ) : (
-                      row.name
-                    )}
-                    {isRookie && (
-                      <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
-                        Rookie
-                      </span>
-                    )}
-                    {isCollege && (
-                      <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300">
-                        College
-                      </span>
-                    )}
-                  </td>
-                  <td className={tdClass}>{row.position}</td>
-                  <td className={tdClass}>{row.nfl_team}</td>
-                  <td className={tdClass}>{row.team_name}</td>
-                  <td className={tdClass}>${row.price}</td>
-                  <td className={tdClass}>
-                    {typeof row.observed_ppg === "number"
-                      ? row.observed_ppg.toFixed(2)
-                      : "—"}
-                  </td>
-                  <td className={tdClass}>
-                    {typeof row.projected_ppg === "number"
-                      ? row.projected_ppg.toFixed(2)
-                      : "—"}
-                  </td>
-                  <td className={tdClass}>
-                    {typeof row.ppg_delta === "number"
-                      ? row.ppg_delta.toFixed(2)
-                      : "—"}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
+      <DataTable
+        columns={columns}
+        data={filteredData}
+        highlightRow={(row) => {
+          const delta = row.ppg_delta;
+          if (typeof delta === "number" && delta >= 1.5)
+            return "bg-green-50 dark:bg-green-950";
+          if (typeof delta === "number" && delta <= -1.5)
+            return "bg-red-50 dark:bg-red-950";
+          return undefined;
+        }}
+      />
     </section>
   );
 }

--- a/web/app/rosters/TeamRosterSection.tsx
+++ b/web/app/rosters/TeamRosterSection.tsx
@@ -1,21 +1,26 @@
 "use client";
 
 import { useState } from "react";
-import DataTable, { Column } from "@/components/DataTable";
-import { makePlayerNameColumn } from "@/components/PlayerHoverCard";
+import DataTable from "@/components/DataTable";
 import { type TeamRoster } from "@/lib/roster-reconstruction";
-import type { PlayerHoverData } from "@/lib/types";
+import type { Column, PlayerHoverData } from "@/lib/types";
 import { MY_TEAM, CAP_PER_TEAM } from "@/lib/arb-logic";
+import {
+  playerNameCol,
+  positionCol,
+  nflTeamCol,
+  gamesPlayedCol,
+} from "@/components/columns";
 
 function getRosterColumns(hoverDataMap: Record<string, PlayerHoverData> | null): Column[] {
   return [
-    makePlayerNameColumn(hoverDataMap),
-    { key: "position", label: "Pos" },
-    { key: "nfl_team", label: "NFL Team" },
+    playerNameCol({ hoverDataMap }),
+    positionCol(),
+    nflTeamCol(),
     { key: "salary", label: "Salary", format: "currency" },
     { key: "ppg", label: "PPG", format: "decimal" },
     { key: "pps", label: "PPS", format: "decimal" },
-    { key: "games_played", label: "G" },
+    gamesPlayedCol("G"),
     { key: "acquired_date", label: "Acquired" },
   ];
 }
@@ -49,7 +54,7 @@ export default function TeamRosterSection({ roster, hoverDataMap = null }: TeamR
               ${roster.total_salary}
             </span>
             <span className="text-slate-400 dark:text-slate-500">
-              /${CAP_PER_TEAM}
+              /{CAP_PER_TEAM}
             </span>
           </span>
           <span

--- a/web/app/surplus-value/page.tsx
+++ b/web/app/surplus-value/page.tsx
@@ -8,8 +8,19 @@ import {
 } from "@/lib/analysis";
 import { fetchPlayersEndOfSeason } from "@/lib/data";
 import { getAuthenticatedUser } from "@/lib/auth";
-import DataTable, { Column, HighlightRule } from "@/components/DataTable";
-import type { SurplusPlayer } from "@/lib/types";
+import DataTable from "@/components/DataTable";
+import type { Column, HighlightRule, SurplusPlayer } from "@/lib/types";
+import {
+  corePlayerCols,
+  surplusCols,
+  ppgCol,
+  fullVorpCol,
+  ownerCol,
+  playerNameCol,
+  positionCol,
+  salaryCol,
+  valueCol,
+} from "@/components/columns";
 
 interface TeamSummaryRow {
   team_name: string;
@@ -17,38 +28,39 @@ interface TeamSummaryRow {
   total_salary: number;
   total_value: number;
   total_surplus: number;
+  [key: string]: string | number | null | undefined;
 }
 
-const CORE_COLUMNS: Column<SurplusPlayer>[] = [
-  { key: "name", label: "Player" },
-  { key: "position", label: "Pos" },
-  { key: "nfl_team", label: "Team" },
-  { key: "price", label: "Salary", format: "currency" },
-  { key: "dollar_value", label: "Value", format: "currency" },
-  { key: "surplus", label: "Surplus", format: "currency" },
-  { key: "ppg", label: "PPG", format: "decimal" },
-  { key: "full_season_vorp", label: "VORP", format: "decimal" },
-  { key: "team_name", label: "Owner" },
-];
+function buildCoreCols(hoverDataMap: Record<string, import("@/lib/types").PlayerHoverData> | null): Column<SurplusPlayer>[] {
+  return [
+    ...corePlayerCols<SurplusPlayer>({ hoverDataMap }),
+    ...surplusCols<SurplusPlayer>(),
+    ppgCol<SurplusPlayer>(),
+    fullVorpCol<SurplusPlayer>("VORP"),
+    ownerCol<SurplusPlayer>(),
+  ];
+}
 
-const MY_TEAM_COLUMNS: Column<SurplusPlayer>[] = [
-  { key: "name", label: "Player" },
-  { key: "position", label: "Pos" },
-  { key: "price", label: "Salary", format: "currency" },
-  { key: "dollar_value", label: "Value", format: "currency" },
-  { key: "surplus", label: "Surplus", format: "currency" },
-  { key: "ppg", label: "PPG", format: "decimal" },
-  { key: "full_season_vorp", label: "VORP", format: "decimal" },
-];
+function buildMyTeamCols(hoverDataMap: Record<string, import("@/lib/types").PlayerHoverData> | null): Column<SurplusPlayer>[] {
+  return [
+    playerNameCol<SurplusPlayer>({ hoverDataMap }),
+    positionCol<SurplusPlayer>(),
+    salaryCol<SurplusPlayer>(),
+    valueCol<SurplusPlayer>(),
+    { key: "surplus", label: "Surplus", format: "currency" },
+    ppgCol<SurplusPlayer>(),
+    fullVorpCol<SurplusPlayer>("VORP"),
+  ];
+}
 
-const FA_COLUMNS: Column<SurplusPlayer>[] = [
-  { key: "name", label: "Player" },
-  { key: "position", label: "Pos" },
-  { key: "nfl_team", label: "Team" },
-  { key: "dollar_value", label: "Value", format: "currency" },
-  { key: "ppg", label: "PPG", format: "decimal" },
-  { key: "full_season_vorp", label: "VORP", format: "decimal" },
-];
+function buildFACols(hoverDataMap: Record<string, import("@/lib/types").PlayerHoverData> | null): Column<SurplusPlayer>[] {
+  return [
+    ...corePlayerCols<SurplusPlayer>({ hoverDataMap }),
+    valueCol<SurplusPlayer>(),
+    ppgCol<SurplusPlayer>(),
+    fullVorpCol<SurplusPlayer>("VORP"),
+  ];
+}
 
 const TEAM_SUMMARY_COLUMNS: Column<TeamSummaryRow>[] = [
   { key: "team_name", label: "Team" },
@@ -156,6 +168,10 @@ export default async function SurplusValuePage() {
     }))
     .sort((a, b) => b.total_surplus - a.total_surplus);
 
+  const coreColumns = buildCoreCols(hoverDataMap);
+  const myTeamColumns = buildMyTeamCols(hoverDataMap);
+  const faColumns = buildFACols(hoverDataMap);
+
   return (
     <main className="min-h-screen bg-white dark:bg-black p-8">
       <div className="max-w-7xl mx-auto space-y-8">
@@ -175,10 +191,9 @@ export default async function SurplusValuePage() {
             Top 20 Bargains
           </h2>
           <DataTable
-            columns={CORE_COLUMNS}
+            columns={coreColumns}
             data={bestBargains}
             highlightRules={BARGAIN_RULES}
-            hoverDataMap={hoverDataMap}
           />
         </section>
 
@@ -188,10 +203,9 @@ export default async function SurplusValuePage() {
             Top 20 Most Overpaid
           </h2>
           <DataTable
-            columns={CORE_COLUMNS}
+            columns={coreColumns}
             data={mostOverpaid}
             highlightRules={OVERPAID_RULES}
-            hoverDataMap={hoverDataMap}
           />
         </section>
 
@@ -202,10 +216,9 @@ export default async function SurplusValuePage() {
               {MY_TEAM} — Surplus Breakdown
             </h2>
             <DataTable
-              columns={MY_TEAM_COLUMNS}
+              columns={myTeamColumns}
               data={myTeam}
               highlightRules={MY_TEAM_RULES}
-              hoverDataMap={hoverDataMap}
             />
             <div className="mt-3 flex flex-wrap gap-6 text-sm text-slate-600 dark:text-slate-400">
               <span>
@@ -242,7 +255,7 @@ export default async function SurplusValuePage() {
             <h2 className="text-xl font-semibold text-slate-900 dark:text-white mb-3">
               Top Free Agents by Value
             </h2>
-            <DataTable columns={FA_COLUMNS} data={freeAgents} hoverDataMap={hoverDataMap} />
+            <DataTable columns={faColumns} data={freeAgents} />
           </section>
         )}
 

--- a/web/app/vorp/VorpClient.tsx
+++ b/web/app/vorp/VorpClient.tsx
@@ -10,11 +10,22 @@ import {
   Tooltip,
   Cell,
 } from "recharts";
-import DataTable, { Column } from "@/components/DataTable";
-import { makePlayerNameColumn } from "@/components/PlayerHoverCard";
+import DataTable from "@/components/DataTable";
 import { POSITIONS, POSITION_COLORS } from "@/lib/analysis";
 import PositionFilter from "@/components/PositionFilter";
-import type { Position, PlayerHoverData } from "@/lib/types";
+import type { Column, Position, PlayerHoverData } from "@/lib/types";
+import {
+  playerNameCol,
+  positionCol,
+  nflTeamCol,
+  ppgCol,
+  totalPointsCol,
+  gamesPlayedCol,
+  vorpPerGameCol,
+  fullVorpCol,
+  salaryCol,
+  ownerCol,
+} from "@/components/columns";
 
 interface BarData {
   name: string;
@@ -40,16 +51,16 @@ interface VorpTableRow {
 
 function getTableColumns(hoverDataMap: Record<string, PlayerHoverData> | null): Column[] {
   return [
-    makePlayerNameColumn(hoverDataMap),
-    { key: "position", label: "Pos" },
-    { key: "nfl_team", label: "Team" },
-    { key: "ppg", label: "PPG", format: "decimal" },
-    { key: "total_points", label: "Points", format: "decimal" },
-    { key: "games_played", label: "GP", format: "number" },
-    { key: "vorp_per_game", label: "VORP/G", format: "decimal" },
-    { key: "full_season_vorp", label: "Full VORP", format: "decimal" },
-    { key: "price", label: "Salary", format: "currency" },
-    { key: "team_name", label: "Owner" },
+    playerNameCol({ hoverDataMap }),
+    positionCol(),
+    nflTeamCol(),
+    ppgCol(),
+    totalPointsCol(),
+    gamesPlayedCol(),
+    vorpPerGameCol(),
+    fullVorpCol(),
+    salaryCol(),
+    ownerCol(),
   ];
 }
 

--- a/web/components/GlobalPlayerSearch.tsx
+++ b/web/components/GlobalPlayerSearch.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Search, Loader2 } from "lucide-react";
 import { supabase } from "@/lib/supabase";
-import { POSITION_COLORS, Position } from "@/lib/types";
+import PositionBadge from "@/components/PositionBadge";
 
 interface SearchResult {
     id: string;
@@ -165,15 +165,7 @@ export default function GlobalPlayerSearch() {
                                             {player.nfl_team}
                                         </span>
                                     </div>
-                                    <span
-                                        className="inline-block px-1.5 py-0.5 rounded text-[10px] font-bold text-white shadow-sm"
-                                        style={{
-                                            backgroundColor:
-                                                POSITION_COLORS[player.position as Position] ?? "#6B7280",
-                                        }}
-                                    >
-                                        {player.position}
-                                    </span>
+                                    <PositionBadge position={player.position} size="sm" />
                                 </li>
                             ))}
                         </ul>

--- a/web/components/PlayerHoverCard.tsx
+++ b/web/components/PlayerHoverCard.tsx
@@ -2,8 +2,8 @@
 
 import Link from "next/link";
 import * as HoverCard from "@radix-ui/react-hover-card";
-import type { Column, PlayerHoverData, Position } from "@/lib/types";
-import { POSITION_COLORS } from "@/lib/types";
+import type { Column, PlayerHoverData } from "@/lib/types";
+import PositionBadge from "./PositionBadge";
 
 interface PlayerHoverCardProps {
   name: string;
@@ -16,11 +16,6 @@ export default function PlayerHoverCard({
   ottoneuId,
   hoverData,
 }: PlayerHoverCardProps) {
-  const posColor =
-    hoverData
-      ? POSITION_COLORS[hoverData.position as Position] ?? "#6B7280"
-      : "#6B7280";
-
   return (
     <HoverCard.Root openDelay={200} closeDelay={100}>
       <HoverCard.Trigger asChild>
@@ -43,12 +38,7 @@ export default function PlayerHoverCard({
             <div className="space-y-2">
               {/* Header: Name + Position + Team */}
               <div className="flex items-center gap-2">
-                <span
-                  className="px-1.5 py-0.5 rounded text-[10px] font-bold text-white"
-                  style={{ backgroundColor: posColor }}
-                >
-                  {hoverData.position}
-                </span>
+                <PositionBadge position={hoverData.position} size="sm" />
                 <span className="font-semibold text-sm text-slate-900 dark:text-white truncate">
                   {name}
                 </span>

--- a/web/components/PlayerName.tsx
+++ b/web/components/PlayerName.tsx
@@ -1,0 +1,75 @@
+/**
+ * Canonical player name renderer.
+ *
+ * Provides three modes of rendering so every player name across the app
+ * uses the same visual treatment:
+ *
+ * - "link" (default): clickable link to /players/{ottoneuId}
+ * - "hover": link wrapped in PlayerHoverCard for rich previews
+ * - "plain": no link, just text (for public/read-only contexts)
+ *
+ * Optional badge slot for appending tags like "Rookie" or "College".
+ */
+
+"use client";
+
+import Link from "next/link";
+import type { PlayerHoverData } from "@/lib/types";
+import PlayerHoverCard from "./PlayerHoverCard";
+import type React from "react";
+
+interface PlayerNameProps {
+  name: string;
+  /** Ottoneu ID used for building /players/{id} links */
+  ottoneuId?: number;
+  /** "link" = clickable, "hover" = link + hover card, "plain" = text only */
+  mode?: "link" | "hover" | "plain";
+  /** Required when mode is "hover" — the data to display in the hover card */
+  hoverData?: PlayerHoverData;
+  /** Optional inline elements to render after the name (e.g. Rookie/College badges) */
+  badges?: React.ReactNode;
+}
+
+export default function PlayerName({
+  name,
+  ottoneuId,
+  mode = "link",
+  hoverData,
+  badges,
+}: PlayerNameProps) {
+  if (mode === "plain" || !ottoneuId) {
+    return (
+      <span className="text-slate-900 dark:text-white font-medium">
+        {name}
+        {badges}
+      </span>
+    );
+  }
+
+  if (mode === "hover") {
+    return (
+      <span>
+        <PlayerHoverCard
+          name={name}
+          ottoneuId={ottoneuId}
+          hoverData={hoverData}
+        />
+        {badges}
+      </span>
+    );
+  }
+
+  // mode === "link"
+  return (
+    <span>
+      <Link
+        href={`/players/${ottoneuId}`}
+        className="text-blue-600 dark:text-blue-400 hover:underline font-medium"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {name}
+      </Link>
+      {badges}
+    </span>
+  );
+}

--- a/web/components/PlayerSearch.tsx
+++ b/web/components/PlayerSearch.tsx
@@ -1,12 +1,37 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import Link from "next/link";
 import { Search, X } from "lucide-react";
-import { PlayerListItem, POSITIONS, Position, POSITION_COLORS } from "@/lib/types";
+import { PlayerListItem, POSITIONS, Position } from "@/lib/types";
+import type { Column } from "@/lib/types";
+import DataTable from "@/components/DataTable";
+import PositionFilter from "@/components/PositionFilter";
+import {
+    playerNameCol,
+    positionCol,
+    nflTeamCol,
+    ownerCol,
+} from "@/components/columns";
 
 interface PlayerSearchProps {
     players: PlayerListItem[];
+}
+
+/**
+ * Build columns for the player directory table.
+ * Uses null hoverDataMap = link-only mode (no hover cards).
+ */
+function getPlayerCols(): Column<PlayerListItem>[] {
+    return [
+        playerNameCol<PlayerListItem>({ hoverDataMap: null }),
+        positionCol<PlayerListItem>(),
+        nflTeamCol<PlayerListItem>(),
+        { key: "price", label: "Salary", format: "currency" },
+        ownerCol<PlayerListItem>(),
+        { key: "ppg", label: "PPG", format: "decimal" },
+        { key: "total_points", label: "Points", format: "decimal" },
+        { key: "games_played", label: "GP", format: "number" },
+    ];
 }
 
 export default function PlayerSearch({ players }: PlayerSearchProps) {
@@ -34,6 +59,24 @@ export default function PlayerSearch({ players }: PlayerSearchProps) {
             position === "ALL" || p.position === position;
         return matchesQuery && matchesPosition;
     });
+
+    // Map players to add required fields for column factories
+    const tableData = filtered.map((p) => ({
+        ...p,
+        player_id: p.id,
+        ottoneu_id: p.ottoneu_id,
+        team_name: p.team_name ?? "Free Agent",
+    }));
+
+    const selectedPositions = position === "ALL" ? [...POSITIONS] : [position];
+
+    const handleToggle = (pos: Position) => {
+        setPosition(position === pos ? "ALL" : pos);
+    };
+
+    const handleToggleAll = () => {
+        setPosition("ALL");
+    };
 
     return (
         <div className="space-y-4">
@@ -69,36 +112,13 @@ export default function PlayerSearch({ players }: PlayerSearchProps) {
                         )}
                     </div>
                 </div>
-                <div className="flex gap-1.5 flex-wrap" role="group" aria-label="Filter by position">
-                    <button
-                        onClick={() => setPosition("ALL")}
-                        aria-pressed={position === "ALL" ? "true" : "false"}
-                        className={`px-3 py-1.5 rounded-md text-xs font-semibold transition-colors ${position === "ALL"
-                                ? "bg-slate-800 text-white dark:bg-white dark:text-black"
-                                : "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700"
-                            }`}
-                    >
-                        ALL
-                    </button>
-                    {POSITIONS.map((pos) => (
-                        <button
-                            key={pos}
-                            onClick={() => setPosition(pos)}
-                            aria-pressed={position === pos ? "true" : "false"}
-                            className={`px-3 py-1.5 rounded-md text-xs font-semibold transition-colors ${position === pos
-                                    ? "text-white"
-                                    : "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700"
-                                }`}
-                            style={
-                                position === pos
-                                    ? { backgroundColor: POSITION_COLORS[pos] }
-                                    : undefined
-                            }
-                        >
-                            {pos}
-                        </button>
-                    ))}
-                </div>
+                <PositionFilter
+                    positions={POSITIONS}
+                    selectedPositions={selectedPositions}
+                    onToggle={handleToggle}
+                    showAll
+                    onToggleAll={handleToggleAll}
+                />
             </div>
 
             {/* Results count */}
@@ -107,8 +127,8 @@ export default function PlayerSearch({ players }: PlayerSearchProps) {
             </p>
 
             {/* Player table */}
-            <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-800">
-                {filtered.length === 0 ? (
+            {filtered.length === 0 ? (
+                <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-800">
                     <div className="p-8 text-center text-slate-500 dark:text-slate-400">
                         <p className="text-lg font-medium mb-1">No players found</p>
                         <p className="text-sm mb-4">
@@ -126,70 +146,13 @@ export default function PlayerSearch({ players }: PlayerSearchProps) {
                             Clear filters
                         </button>
                     </div>
-                ) : (
-                    <table className="min-w-full text-sm">
-                        <thead>
-                            <tr className="bg-slate-100 dark:bg-slate-800">
-                                <th className="px-3 py-2.5 text-left font-semibold text-slate-700 dark:text-slate-300">Player</th>
-                                <th className="px-3 py-2.5 text-left font-semibold text-slate-700 dark:text-slate-300">Pos</th>
-                                <th className="px-3 py-2.5 text-left font-semibold text-slate-700 dark:text-slate-300">Team</th>
-                                <th className="px-3 py-2.5 text-right font-semibold text-slate-700 dark:text-slate-300">Salary</th>
-                                <th className="px-3 py-2.5 text-left font-semibold text-slate-700 dark:text-slate-300">Owner</th>
-                                <th className="px-3 py-2.5 text-right font-semibold text-slate-700 dark:text-slate-300">PPG</th>
-                                <th className="px-3 py-2.5 text-right font-semibold text-slate-700 dark:text-slate-300">Points</th>
-                                <th className="px-3 py-2.5 text-right font-semibold text-slate-700 dark:text-slate-300">GP</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {filtered.map((p, i) => (
-                                <tr
-                                    key={p.id}
-                                    className={`border-t border-slate-100 dark:border-slate-800 hover:bg-blue-50 dark:hover:bg-slate-800/50 transition-colors ${i % 2 === 0
-                                            ? "bg-white dark:bg-slate-950"
-                                            : "bg-slate-50 dark:bg-slate-900"
-                                        }`}
-                                >
-                                    <td className="px-3 py-2">
-                                        <Link
-                                            href={`/players/${p.ottoneu_id}`}
-                                            className="text-blue-600 dark:text-blue-400 hover:underline font-medium"
-                                        >
-                                            {p.name}
-                                        </Link>
-                                    </td>
-                                    <td className="px-3 py-2">
-                                        <span
-                                            className="inline-block px-1.5 py-0.5 rounded text-xs font-bold text-white"
-                                            style={{
-                                                backgroundColor:
-                                                    POSITION_COLORS[p.position as Position] ?? "#6B7280",
-                                            }}
-                                        >
-                                            {p.position}
-                                        </span>
-                                    </td>
-                                    <td className="px-3 py-2 text-slate-700 dark:text-slate-300">{p.nfl_team}</td>
-                                    <td className="px-3 py-2 text-right font-mono text-slate-800 dark:text-slate-200">
-                                        {p.price != null ? `$${p.price}` : "—"}
-                                    </td>
-                                    <td className="px-3 py-2 text-slate-600 dark:text-slate-400 text-xs truncate max-w-[180px]">
-                                        {p.team_name ?? "Free Agent"}
-                                    </td>
-                                    <td className="px-3 py-2 text-right font-mono text-slate-800 dark:text-slate-200">
-                                        {p.ppg != null ? Number(p.ppg).toFixed(1) : "—"}
-                                    </td>
-                                    <td className="px-3 py-2 text-right font-mono text-slate-800 dark:text-slate-200">
-                                        {p.total_points != null ? Number(p.total_points).toFixed(1) : "—"}
-                                    </td>
-                                    <td className="px-3 py-2 text-right font-mono text-slate-800 dark:text-slate-200">
-                                        {p.games_played ?? "—"}
-                                    </td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                )}
-            </div>
+                </div>
+            ) : (
+                <DataTable
+                    columns={getPlayerCols()}
+                    data={tableData}
+                />
+            )}
         </div>
     );
 }

--- a/web/components/PositionBadge.tsx
+++ b/web/components/PositionBadge.tsx
@@ -1,0 +1,36 @@
+/**
+ * Canonical position-colored badge.
+ *
+ * Provides a consistent visual representation of player positions
+ * across all views: tables, hover cards, search results, and player cards.
+ */
+
+import { POSITION_COLORS, type Position } from "@/lib/types";
+
+interface PositionBadgeProps {
+  position: string;
+  /** "sm" for compact contexts (hover cards, search dropdowns), "md" for tables/headers */
+  size?: "sm" | "md";
+}
+
+const SIZE_CLASSES = {
+  sm: "px-1.5 py-0.5 text-[10px]",
+  md: "px-1.5 py-0.5 text-xs",
+} as const;
+
+export default function PositionBadge({
+  position,
+  size = "md",
+}: PositionBadgeProps) {
+  const color =
+    POSITION_COLORS[position as Position] ?? "#6B7280";
+
+  return (
+    <span
+      className={`inline-block rounded font-bold text-white ${SIZE_CLASSES[size]}`}
+      style={{ backgroundColor: color }}
+    >
+      {position}
+    </span>
+  );
+}

--- a/web/components/StatValue.tsx
+++ b/web/components/StatValue.tsx
@@ -1,0 +1,45 @@
+/**
+ * Consistent numeric stat formatter.
+ *
+ * Single source of truth for displaying numeric values (currency, decimal,
+ * percent, integer) with null → "—" handling and monospace font for
+ * tabular alignment.
+ */
+
+interface StatValueProps {
+  value: unknown;
+  format?: "currency" | "decimal" | "number" | "percent";
+}
+
+export default function StatValue({ value, format }: StatValueProps) {
+  if (value == null) {
+    return <span className="text-slate-400 dark:text-slate-500">—</span>;
+  }
+
+  const num = Number(value);
+
+  if (format === "currency") {
+    const display = isNaN(num) ? String(value) : `$${num}`;
+    return <span className="font-mono">{display}</span>;
+  }
+
+  if (format === "decimal") {
+    const display = isNaN(num) ? String(value) : num.toFixed(2);
+    return <span className="font-mono">{display}</span>;
+  }
+
+  if (format === "percent") {
+    const display = isNaN(num)
+      ? String(value)
+      : `${(num * 100).toFixed(0)}%`;
+    return <span className="font-mono">{display}</span>;
+  }
+
+  if (format === "number") {
+    const display = isNaN(num) ? String(value) : String(num);
+    return <span className="font-mono">{display}</span>;
+  }
+
+  // No format specified — render as-is
+  return <span>{String(value)}</span>;
+}

--- a/web/components/columns.tsx
+++ b/web/components/columns.tsx
@@ -1,0 +1,170 @@
+/**
+ * Column factory functions for DataTable.
+ *
+ * These factories inject React components (PositionBadge, PlayerName)
+ * into column renderCell callbacks, ensuring every table renders player
+ * data identically. This file lives in web/components/ because it
+ * imports React components (web/lib/ must not).
+ *
+ * Usage:
+ *   import { corePlayerCols, salaryCol, ppgCol } from "@/components/columns";
+ *   const columns = [...corePlayerCols({ hoverDataMap }), salaryCol(), ppgCol()];
+ */
+
+import type React from "react";
+import type { Column, PlayerHoverData } from "@/lib/types";
+import PositionBadge from "@/components/PositionBadge";
+import PlayerName from "@/components/PlayerName";
+
+// =====================================================================
+// Individual column factories
+// =====================================================================
+
+/**
+ * Player name column. Supports three modes via hoverDataMap:
+ * - Pass a map → hover card mode (link + rich preview)
+ * - Pass null → link-only mode
+ * - Pass undefined → plain text mode
+ */
+export function playerNameCol<Row>(opts?: {
+  hoverDataMap?: Record<string, PlayerHoverData> | null;
+  label?: string;
+}): Column<Row> {
+  const { hoverDataMap, label = "Player" } = opts ?? {};
+
+  // Plain text — no links
+  if (hoverDataMap === undefined) {
+    return { key: "name", label };
+  }
+
+  // Link mode (null) or hover mode (map)
+  return {
+    key: "name",
+    label,
+    renderCell: (value: unknown, row: Row) => {
+      const r = row as { player_id?: string; ottoneu_id?: number };
+      const playerId = r.player_id;
+      const ottoneuId = r.ottoneu_id;
+
+      if (!ottoneuId) {
+        return String(value ?? "—");
+      }
+
+      if (hoverDataMap && playerId) {
+        return (
+          PlayerName({
+            name: String(value ?? "—"),
+            ottoneuId,
+            mode: "hover",
+            hoverData: hoverDataMap[playerId],
+          }) as React.ReactNode
+        );
+      }
+
+      return (
+        PlayerName({
+          name: String(value ?? "—"),
+          ottoneuId,
+          mode: "link",
+        }) as React.ReactNode
+      );
+    },
+  };
+}
+
+/** Position column — renders a colored PositionBadge. */
+export function positionCol<Row>(): Column<Row> {
+  return {
+    key: "position",
+    label: "Pos",
+    renderCell: (value: unknown) =>
+      PositionBadge({ position: String(value ?? "") }) as React.ReactNode,
+  };
+}
+
+/** NFL team column. */
+export function nflTeamCol<Row>(label = "Team"): Column<Row> {
+  return { key: "nfl_team", label };
+}
+
+/** Owner / team_name column. */
+export function ownerCol<Row>(label = "Owner"): Column<Row> {
+  return { key: "team_name", label };
+}
+
+/** Salary column (currency format). */
+export function salaryCol<Row>(label = "Salary"): Column<Row> {
+  return { key: "price", label, format: "currency" };
+}
+
+/** Dollar value column (currency format). */
+export function valueCol<Row>(label = "Value"): Column<Row> {
+  return { key: "dollar_value", label, format: "currency" };
+}
+
+/** Surplus column (currency format). */
+export function surplusCol<Row>(label = "Surplus"): Column<Row> {
+  return { key: "surplus", label, format: "currency" };
+}
+
+/** PPG column (2 decimal places). */
+export function ppgCol<Row>(label = "PPG"): Column<Row> {
+  return { key: "ppg", label, format: "decimal" };
+}
+
+/** Total points column (2 decimal places). */
+export function totalPointsCol<Row>(label = "Points"): Column<Row> {
+  return { key: "total_points", label, format: "decimal" };
+}
+
+/** Games played column. */
+export function gamesPlayedCol<Row>(label = "GP"): Column<Row> {
+  return { key: "games_played", label, format: "number" };
+}
+
+/** VORP per game column. */
+export function vorpPerGameCol<Row>(label = "VORP/G"): Column<Row> {
+  return { key: "vorp_per_game", label, format: "decimal" };
+}
+
+/** Full season VORP column. */
+export function fullVorpCol<Row>(label = "Full VORP"): Column<Row> {
+  return { key: "full_season_vorp", label, format: "decimal" };
+}
+
+// =====================================================================
+// Precomposed column sets
+// =====================================================================
+
+/**
+ * Core player identity columns: Player name + Position badge + NFL Team.
+ * Pass hoverDataMap for hover cards, null for link-only, undefined for plain text.
+ */
+export function corePlayerCols<Row>(opts?: {
+  hoverDataMap?: Record<string, PlayerHoverData> | null;
+  nameLabel?: string;
+}): Column<Row>[] {
+  return [
+    playerNameCol<Row>({
+      hoverDataMap: opts?.hoverDataMap,
+      label: opts?.nameLabel,
+    }),
+    positionCol<Row>(),
+    nflTeamCol<Row>(),
+  ];
+}
+
+/** Salary + Value + Surplus columns. */
+export function surplusCols<Row>(): Column<Row>[] {
+  return [salaryCol<Row>(), valueCol<Row>(), surplusCol<Row>()];
+}
+
+/** PPG + Total Points + Games Played. */
+export function statsCols<Row>(): Column<Row>[] {
+  return [ppgCol<Row>(), totalPointsCol<Row>(), gamesPlayedCol<Row>()];
+}
+
+/** VORP/G + Full Season VORP. */
+export function vorpCols<Row>(): Column<Row>[] {
+  return [vorpPerGameCol<Row>(), fullVorpCol<Row>()];
+}

--- a/web/lib/columns.ts
+++ b/web/lib/columns.ts
@@ -3,9 +3,17 @@
  *
  * Centralizes column configurations to ensure consistency across
  * analysis pages and reduce duplication.
+ *
+ * ARCHITECTURE NOTE: This file is in web/lib/ and MUST NOT import from
+ * web/components/. Column factories that inject React components
+ * (PositionBadge, PlayerName, etc.) live in web/components/columns.tsx.
  */
 
 import { Column } from "@/lib/types";
+
+// =====================================================================
+// Static column definitions (pure data, no React components)
+// =====================================================================
 
 export const CORE_PLAYER_COLUMNS: Column[] = [
   { key: "name", label: "Player" },


### PR DESCRIPTION
- Create atomic components: PositionBadge, PlayerName, StatValue
- Create composable column factory system (components/columns.tsx)
- Migrate 16 pages/components to use shared column factories
- Convert PlayerSearch and ProjectionsClient from hand-rolled tables to DataTable
- Adopt atomic components in custom tables (arb planner, public planner)
- Normalize column labels (Team, Pos, Salary, GP, Owner)
- Update FRONTEND.md documentation

All 22 arch tests + 133 web tests pass. Clean TypeScript compile.
