### PR TITLE
test: add unit coverage to auth/session/data/scoring/vorp/surplus (#430)

### DIFF
--- a/web/__tests__/lib/auth.test.ts
+++ b/web/__tests__/lib/auth.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for auth.ts. Uses the node environment for Web Crypto (session
+ * signing runs through the real session module).
+ */
+import bcrypt from "bcryptjs";
+import { signSession } from "@/lib/session";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockCookieStore = {
+    get: jest.fn(),
+    set: jest.fn(),
+    delete: jest.fn(),
+};
+
+jest.mock("next/headers", () => ({
+    cookies: jest.fn(async () => mockCookieStore),
+}));
+
+const mockSingle = jest.fn();
+const supabaseAdminChain = {
+    from: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    single: mockSingle,
+};
+
+jest.mock("@/lib/supabase", () => ({
+    supabase: {},
+    getSupabaseAdmin: jest.fn(() => supabaseAdminChain),
+}));
+
+// Import AFTER mocks are registered.
+import { authenticateUser, getAuthenticatedUser } from "@/lib/auth";
+
+const ORIGINAL_SECRET = process.env.SESSION_SECRET;
+
+beforeAll(() => {
+    process.env.SESSION_SECRET = "test-secret-do-not-use-in-prod";
+});
+
+afterAll(() => {
+    if (ORIGINAL_SECRET === undefined) delete process.env.SESSION_SECRET;
+    else process.env.SESSION_SECRET = ORIGINAL_SECRET;
+});
+
+beforeEach(() => {
+    mockCookieStore.get.mockReset();
+    mockCookieStore.set.mockReset();
+    mockCookieStore.delete.mockReset();
+    mockSingle.mockReset();
+    supabaseAdminChain.from.mockClear();
+    supabaseAdminChain.select.mockClear();
+    supabaseAdminChain.eq.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// authenticateUser
+// ---------------------------------------------------------------------------
+
+describe("authenticateUser", () => {
+    test("returns user info when email + password match", async () => {
+        const hash = await bcrypt.hash("correct-password", 4);
+        mockSingle.mockResolvedValueOnce({
+            data: {
+                id: "user-1",
+                password_hash: hash,
+                is_admin: true,
+                has_projections_access: false,
+            },
+            error: null,
+        });
+
+        const result = await authenticateUser("User@Example.com", "correct-password");
+        expect(result).toEqual({
+            userId: "user-1",
+            isAdmin: true,
+            hasProjectionsAccess: false,
+        });
+        // Email is lowercased + trimmed before the lookup.
+        expect(supabaseAdminChain.eq).toHaveBeenCalledWith("email", "user@example.com");
+    });
+
+    test("returns null on wrong password", async () => {
+        const hash = await bcrypt.hash("correct-password", 4);
+        mockSingle.mockResolvedValueOnce({
+            data: {
+                id: "user-1",
+                password_hash: hash,
+                is_admin: false,
+                has_projections_access: false,
+            },
+            error: null,
+        });
+
+        const result = await authenticateUser("user@example.com", "wrong-password");
+        expect(result).toBeNull();
+    });
+
+    test("returns null when user not found", async () => {
+        mockSingle.mockResolvedValueOnce({ data: null, error: { message: "not found" } });
+        const result = await authenticateUser("missing@example.com", "whatever");
+        expect(result).toBeNull();
+    });
+
+    test("returns null on database error", async () => {
+        mockSingle.mockResolvedValueOnce({ data: null, error: { message: "db fail" } });
+        const result = await authenticateUser("user@example.com", "whatever");
+        expect(result).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// getAuthenticatedUser
+// ---------------------------------------------------------------------------
+
+describe("getAuthenticatedUser", () => {
+    test("returns user info for a valid cookie", async () => {
+        const token = await signSession("user-42", true, true);
+        mockCookieStore.get.mockReturnValueOnce({ value: token });
+
+        const result = await getAuthenticatedUser();
+        expect(result).toEqual({
+            userId: "user-42",
+            isAdmin: true,
+            hasProjectionsAccess: true,
+        });
+    });
+
+    test("returns null when cookie is missing", async () => {
+        mockCookieStore.get.mockReturnValueOnce(undefined);
+        expect(await getAuthenticatedUser()).toBeNull();
+    });
+
+    test("returns null for a malformed cookie value", async () => {
+        mockCookieStore.get.mockReturnValueOnce({ value: "not-a-valid-token" });
+        expect(await getAuthenticatedUser()).toBeNull();
+    });
+
+    test("returns null for a cookie signed with a different secret", async () => {
+        const token = await signSession("user-42", false, false);
+        process.env.SESSION_SECRET = "different-secret";
+        mockCookieStore.get.mockReturnValueOnce({ value: token });
+
+        const result = await getAuthenticatedUser();
+        expect(result).toBeNull();
+
+        process.env.SESSION_SECRET = "test-secret-do-not-use-in-prod";
+    });
+
+    test("returns null for an expired cookie", async () => {
+        const EIGHT_DAYS_MS = 8 * 24 * 60 * 60 * 1000;
+        jest.spyOn(Date, "now").mockReturnValueOnce(Date.now() - EIGHT_DAYS_MS);
+        const expired = await signSession("user-42", false, false);
+        mockCookieStore.get.mockReturnValueOnce({ value: expired });
+
+        expect(await getAuthenticatedUser()).toBeNull();
+    });
+
+    test("defaults isAdmin/hasProjectionsAccess to false when session flags are absent", async () => {
+        const token = await signSession("user-42", false, false);
+        mockCookieStore.get.mockReturnValueOnce({ value: token });
+
+        const result = await getAuthenticatedUser();
+        expect(result).toEqual({
+            userId: "user-42",
+            isAdmin: false,
+            hasProjectionsAccess: false,
+        });
+    });
+});

--- a/web/__tests__/lib/data.test.ts
+++ b/web/__tests__/lib/data.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Unit tests for data.ts — the unified data-access layer.
+ *
+ * Uses a chainable, per-table Supabase mock. Each call to `supabase.from(table)`
+ * returns a query builder that records query options and resolves to the
+ * pre-seeded `{ data, error }` payload for that table. The builder is
+ * thenable so `await supabase.from(...).select(...).eq(...)` works.
+ */
+
+// ---------------------------------------------------------------------------
+// Supabase mock
+// ---------------------------------------------------------------------------
+
+type TableResult = { data: unknown; error: unknown };
+const tableResults = new Map<string, TableResult>();
+const terminalMap = new Map<string, "single" | "maybeSingle" | null>();
+
+function setTable(
+    table: string,
+    data: unknown,
+    opts: { error?: unknown; terminal?: "single" | "maybeSingle" } = {}
+) {
+    tableResults.set(table, { data, error: opts.error ?? null });
+    terminalMap.set(table, opts.terminal ?? null);
+}
+
+function makeBuilder(table: string) {
+    const builder: Record<string, unknown> = {};
+    const chain = (fn: string) =>
+        jest.fn((..._args: unknown[]) => {
+            void _args;
+            void fn;
+            return builder;
+        });
+    builder.select = chain("select");
+    builder.eq = chain("eq");
+    builder.gt = chain("gt");
+    builder.lte = chain("lte");
+    builder.order = chain("order");
+
+    const result = () => {
+        const entry = tableResults.get(table);
+        if (!entry) return Promise.resolve({ data: null, error: null });
+        return Promise.resolve(entry);
+    };
+    builder.single = jest.fn(result);
+    builder.maybeSingle = jest.fn(result);
+    builder.then = (
+        onFulfilled: (v: TableResult) => unknown,
+        onRejected?: (e: unknown) => unknown
+    ) => result().then(onFulfilled, onRejected);
+    return builder;
+}
+
+jest.mock("@/lib/supabase", () => ({
+    supabase: {
+        from: jest.fn((table: string) => makeBuilder(table)),
+    },
+}));
+
+// Imports AFTER the mock so data.ts binds to the mocked supabase.
+import {
+    fetchPlayers,
+    fetchPlayerList,
+    fetchPlayersAtDate,
+    fetchPlayerDetail,
+    fetchPublicArbPlayers,
+    fetchPlayerProjection,
+} from "@/lib/data";
+
+beforeEach(() => {
+    tableResults.clear();
+    terminalMap.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const playerRows = [
+    {
+        id: "p1",
+        ottoneu_id: 100,
+        name: "Josh Allen",
+        position: "QB",
+        nfl_team: "BUF",
+        birth_date: "1996-05-21",
+        is_college: false,
+    },
+    {
+        id: "p2",
+        ottoneu_id: 200,
+        name: "Saquon Barkley",
+        position: "RB",
+        nfl_team: "PHI",
+        birth_date: "1997-02-09",
+        is_college: false,
+    },
+    // No stats for p3 — filtered out by fetchers that require stats.
+    {
+        id: "p3",
+        ottoneu_id: 300,
+        name: "No Stats Guy",
+        position: "WR",
+        nfl_team: "FA",
+        birth_date: null,
+        is_college: false,
+    },
+];
+
+const statsRows = [
+    { player_id: "p1", total_points: 300, games_played: 16, snaps: 1000, ppg: 18.75, pps: 0.3 },
+    { player_id: "p2", total_points: 250, games_played: 15, snaps: 800, ppg: 16.67, pps: 0.31 },
+];
+
+const pricesRows = [
+    { player_id: "p1", price: 45, team_name: "Team A" },
+    { player_id: "p2", price: 30, team_name: "Team B" },
+    { player_id: "p3", price: 1, team_name: null },
+];
+
+// ---------------------------------------------------------------------------
+// fetchPlayers
+// ---------------------------------------------------------------------------
+
+describe("fetchPlayers", () => {
+    test("joins players + stats + prices and drops players without stats", async () => {
+        setTable("players", playerRows);
+        setTable("player_stats", statsRows);
+        setTable("league_prices", pricesRows);
+
+        const result = await fetchPlayers();
+        expect(result.map((p) => p.player_id).sort()).toEqual(["p1", "p2"]);
+
+        const allen = result.find((p) => p.player_id === "p1")!;
+        expect(allen).toMatchObject({
+            name: "Josh Allen",
+            position: "QB",
+            total_points: 300,
+            ppg: 18.75,
+            price: 45,
+            team_name: "Team A",
+        });
+    });
+
+    test("throws when players query errors", async () => {
+        setTable("players", null, { error: { message: "boom" } });
+        setTable("player_stats", statsRows);
+        setTable("league_prices", pricesRows);
+
+        await expect(fetchPlayers()).rejects.toThrow(/Failed to fetch players/);
+    });
+
+    test("defaults price to 0 and team_name to null when prices row is missing", async () => {
+        setTable("players", [playerRows[0]]);
+        setTable("player_stats", [statsRows[0]]);
+        setTable("league_prices", []);
+
+        const [p] = await fetchPlayers();
+        expect(p.price).toBe(0);
+        expect(p.team_name).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fetchPlayerList
+// ---------------------------------------------------------------------------
+
+describe("fetchPlayerList", () => {
+    test("returns every player (including those without stats) with nullable fields", async () => {
+        setTable("players", playerRows);
+        setTable("player_stats", statsRows);
+        setTable("league_prices", pricesRows);
+
+        const result = await fetchPlayerList();
+        expect(result.map((p) => p.id).sort()).toEqual(["p1", "p2", "p3"]);
+
+        const noStats = result.find((p) => p.id === "p3")!;
+        expect(noStats.ppg).toBeNull();
+        expect(noStats.total_points).toBeNull();
+        expect(noStats.games_played).toBeNull();
+        expect(noStats.price).toBe(1);
+    });
+
+    test("returns empty array when players query returns null data", async () => {
+        setTable("players", null);
+        setTable("player_stats", []);
+        setTable("league_prices", []);
+        expect(await fetchPlayerList()).toEqual([]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fetchPlayersAtDate (covers buildSalaryMapAtDate via transaction replay)
+// ---------------------------------------------------------------------------
+
+describe("fetchPlayersAtDate / buildSalaryMapAtDate", () => {
+    test("replays transactions to pick the salary at the cutoff date", async () => {
+        setTable("players", [playerRows[0]]);
+        setTable("player_stats", [statsRows[0]]);
+        setTable("transactions", [
+            {
+                player_id: "p1",
+                transaction_type: "Auction Won",
+                team_name: "Team A",
+                salary: 10,
+                transaction_date: "2025-09-01",
+            },
+            {
+                player_id: "p1",
+                transaction_type: "Keep",
+                team_name: "Team A",
+                salary: 14, // +$4 end-of-season bump
+                transaction_date: "2025-12-31",
+            },
+        ]);
+        setTable("league_prices", [{ player_id: "p1", price: 999, team_name: "Team A" }]);
+
+        const [p] = await fetchPlayersAtDate("2025-12-31");
+        expect(p.price).toBe(14);
+        expect(p.team_name).toBe("Team A");
+    });
+
+    test("cut transaction clears team_name and resets salary state", async () => {
+        setTable("players", [playerRows[0]]);
+        setTable("player_stats", [statsRows[0]]);
+        setTable("transactions", [
+            {
+                player_id: "p1",
+                transaction_type: "Auction Won",
+                team_name: "Team A",
+                salary: 20,
+                transaction_date: "2025-09-01",
+            },
+            {
+                player_id: "p1",
+                transaction_type: "Cut",
+                team_name: null,
+                salary: 20,
+                transaction_date: "2025-11-01",
+            },
+        ]);
+        setTable("league_prices", []);
+
+        const [p] = await fetchPlayersAtDate("2025-12-01");
+        expect(p.team_name).toBeNull();
+    });
+
+    test("falls back to league_prices for players with no transaction history", async () => {
+        setTable("players", [playerRows[1]]);
+        setTable("player_stats", [statsRows[1]]);
+        setTable("transactions", []);
+        setTable("league_prices", [{ player_id: "p2", price: 1, team_name: "Team B" }]);
+
+        const [p] = await fetchPlayersAtDate("2025-12-01");
+        expect(p.price).toBe(1);
+        expect(p.team_name).toBe("Team B");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fetchPlayerDetail
+// ---------------------------------------------------------------------------
+
+describe("fetchPlayerDetail", () => {
+    test("returns null for unknown ottoneu_id", async () => {
+        setTable("players", null);
+        const result = await fetchPlayerDetail(99999);
+        expect(result).toBeNull();
+    });
+
+    test("assembles season stats and transactions for an existing player", async () => {
+        setTable("players", {
+            id: "p1",
+            ottoneu_id: 100,
+            name: "Josh Allen",
+            position: "QB",
+            nfl_team: "BUF",
+            birth_date: "1996-05-21",
+        });
+        setTable("player_stats", [
+            { season: 2025, total_points: 300, games_played: 16, snaps: 1000, ppg: 18.75, pps: 0.3 },
+            { season: 2024, total_points: 280, games_played: 15, snaps: 950, ppg: 18.67, pps: 0.29 },
+        ]);
+        setTable("league_prices", { price: 45, team_name: "Team A" });
+        setTable("transactions", [
+            {
+                id: "t1",
+                transaction_type: "Auction Won",
+                team_name: "Team A",
+                from_team: null,
+                salary: 45,
+                transaction_date: "2025-09-01",
+                raw_description: null,
+            },
+        ]);
+
+        const result = await fetchPlayerDetail(100);
+        expect(result).not.toBeNull();
+        expect(result!.name).toBe("Josh Allen");
+        expect(result!.price).toBe(45);
+        expect(result!.seasonStats).toHaveLength(2);
+        expect(result!.transactions).toHaveLength(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fetchPublicArbPlayers
+// ---------------------------------------------------------------------------
+
+describe("fetchPublicArbPlayers", () => {
+    test("only returns rostered players (team_name set and not FA)", async () => {
+        setTable("players", playerRows);
+        setTable("player_stats", [
+            ...statsRows,
+            { player_id: "p3", total_points: 0, games_played: 0, snaps: 0, ppg: 0, pps: 0 },
+        ]);
+        setTable("transactions", []);
+        setTable("league_prices", [
+            { player_id: "p1", price: 45, team_name: "Team A" },
+            { player_id: "p2", price: 30, team_name: "Team B" },
+            { player_id: "p3", price: 1, team_name: "FA" }, // excluded
+        ]);
+
+        const result = await fetchPublicArbPlayers();
+        expect(result.map((p) => p.player_id).sort()).toEqual(["p1", "p2"]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fetchPlayerProjection
+// ---------------------------------------------------------------------------
+
+describe("fetchPlayerProjection", () => {
+    test("returns projected_ppg + method when a row exists", async () => {
+        setTable(
+            "player_projections",
+            { projected_ppg: "17.5", projection_method: "weighted_average_ppg" },
+            { terminal: "maybeSingle" }
+        );
+
+        const result = await fetchPlayerProjection("p1", 2026);
+        expect(result).toEqual({
+            projected_ppg: 17.5,
+            projection_method: "weighted_average_ppg",
+        });
+    });
+
+    test("returns null when no projection row exists", async () => {
+        setTable("player_projections", null, { terminal: "maybeSingle" });
+        const result = await fetchPlayerProjection("p1", 2026);
+        expect(result).toBeNull();
+    });
+
+    test("returns null on query error", async () => {
+        setTable("player_projections", null, {
+            error: { message: "fail" },
+            terminal: "maybeSingle",
+        });
+        const result = await fetchPlayerProjection("p1", 2026);
+        expect(result).toBeNull();
+    });
+});

--- a/web/__tests__/lib/scoring.test.ts
+++ b/web/__tests__/lib/scoring.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for Ottoneu Half-PPR scoring formula.
+ *
+ * Each test isolates a single scoring rule so regressions to any one
+ * coefficient surface as a named failure rather than a generic total mismatch.
+ * Fixtures match the weights in config.json (the single source of truth).
+ */
+import { calculateFantasyPoints } from "@/lib/scoring";
+
+describe("calculateFantasyPoints — per-rule fixtures", () => {
+    test("empty stat line scores 0", () => {
+        expect(calculateFantasyPoints({})).toBe(0);
+    });
+
+    test("passing yards at 0.04 per yard", () => {
+        expect(calculateFantasyPoints({ passing_yards: 300 })).toBeCloseTo(12, 5);
+    });
+
+    test("passing touchdown at 4 points", () => {
+        expect(calculateFantasyPoints({ passing_tds: 3 })).toBe(12);
+    });
+
+    test("interception at -2 points", () => {
+        expect(calculateFantasyPoints({ interceptions: 2 })).toBe(-4);
+    });
+
+    test("rushing yards at 0.1 per yard", () => {
+        expect(calculateFantasyPoints({ rushing_yards: 100 })).toBeCloseTo(10, 5);
+    });
+
+    test("rushing touchdown at 6 points", () => {
+        expect(calculateFantasyPoints({ rushing_tds: 2 })).toBe(12);
+    });
+
+    test("receptions at 0.5 per catch (half PPR)", () => {
+        expect(calculateFantasyPoints({ receptions: 7 })).toBeCloseTo(3.5, 5);
+    });
+
+    test("receiving yards at 0.1 per yard", () => {
+        expect(calculateFantasyPoints({ receiving_yards: 150 })).toBeCloseTo(15, 5);
+    });
+
+    test("receiving touchdown at 6 points", () => {
+        expect(calculateFantasyPoints({ receiving_tds: 2 })).toBe(12);
+    });
+
+    test("field goal 0–39 yds at 3 points", () => {
+        expect(calculateFantasyPoints({ fg_made_0_39: 3 })).toBe(9);
+    });
+
+    test("field goal 40–49 yds at 4 points", () => {
+        expect(calculateFantasyPoints({ fg_made_40_49: 2 })).toBe(8);
+    });
+
+    test("field goal 50+ yds at 5 points", () => {
+        expect(calculateFantasyPoints({ fg_made_50_plus: 2 })).toBe(10);
+    });
+
+    test("PAT made at 1 point", () => {
+        expect(calculateFantasyPoints({ pat_made: 4 })).toBe(4);
+    });
+});
+
+describe("calculateFantasyPoints — combined stat lines", () => {
+    test("realistic QB line (300 pass yds, 2 pass TD, 1 INT, 20 rush yds)", () => {
+        const points = calculateFantasyPoints({
+            passing_yards: 300,
+            passing_tds: 2,
+            interceptions: 1,
+            rushing_yards: 20,
+        });
+        // 300*0.04 + 2*4 + 1*-2 + 20*0.1 = 12 + 8 - 2 + 2 = 20
+        expect(points).toBeCloseTo(20, 5);
+    });
+
+    test("realistic RB line (100 rush yds, 1 rush TD, 4 catches, 30 rec yds)", () => {
+        const points = calculateFantasyPoints({
+            rushing_yards: 100,
+            rushing_tds: 1,
+            receptions: 4,
+            receiving_yards: 30,
+        });
+        // 10 + 6 + 2 + 3 = 21
+        expect(points).toBeCloseTo(21, 5);
+    });
+
+    test("realistic kicker line (2x 0-39, 1x 40-49, 1x 50+, 3 PATs)", () => {
+        const points = calculateFantasyPoints({
+            fg_made_0_39: 2,
+            fg_made_40_49: 1,
+            fg_made_50_plus: 1,
+            pat_made: 3,
+        });
+        // 6 + 4 + 5 + 3 = 18
+        expect(points).toBeCloseTo(18, 5);
+    });
+
+    test("missing fields treated as 0 (partial stat line)", () => {
+        // Only specify some fields; others must not contribute NaN.
+        const points = calculateFantasyPoints({ passing_tds: 1 });
+        expect(points).toBe(4);
+        expect(Number.isNaN(points)).toBe(false);
+    });
+});

--- a/web/__tests__/lib/session.test.ts
+++ b/web/__tests__/lib/session.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment node
+ *
+ * Uses the node environment so that `crypto.subtle` (Web Crypto) is available
+ * on Node 18+. JSDOM's shim does not provide a fully featured subtle crypto.
+ */
+import { signSession, verifySession } from "@/lib/session";
+
+const ORIGINAL_SECRET = process.env.SESSION_SECRET;
+
+beforeEach(() => {
+    process.env.SESSION_SECRET = "test-secret-do-not-use-in-prod";
+});
+
+afterAll(() => {
+    if (ORIGINAL_SECRET === undefined) {
+        delete process.env.SESSION_SECRET;
+    } else {
+        process.env.SESSION_SECRET = ORIGINAL_SECRET;
+    }
+});
+
+describe("signSession / verifySession round-trip", () => {
+    test("signs and verifies a session with the embedded user info", async () => {
+        const token = await signSession("user-42", true, false);
+        const session = await verifySession(token);
+
+        expect(session.valid).toBe(true);
+        expect(session.userId).toBe("user-42");
+        expect(session.isAdmin).toBe(true);
+        expect(session.hasProjectionsAccess).toBe(false);
+    });
+
+    test("preserves hasProjectionsAccess=true through the round trip", async () => {
+        const token = await signSession("user-1", false, true);
+        const session = await verifySession(token);
+
+        expect(session.valid).toBe(true);
+        expect(session.isAdmin).toBe(false);
+        expect(session.hasProjectionsAccess).toBe(true);
+    });
+
+    test("each sign call produces a unique token (nonce)", async () => {
+        const a = await signSession("user-1", false, false);
+        const b = await signSession("user-1", false, false);
+        expect(a).not.toBe(b);
+    });
+});
+
+describe("verifySession rejection paths", () => {
+    test("rejects undefined / null / non-string tokens", async () => {
+        expect((await verifySession(undefined)).valid).toBe(false);
+        expect((await verifySession(null)).valid).toBe(false);
+        expect((await verifySession("")).valid).toBe(false);
+    });
+
+    test("rejects tokens without the payload.signature shape", async () => {
+        expect((await verifySession("not-a-token")).valid).toBe(false);
+        expect((await verifySession("too.many.parts")).valid).toBe(false);
+    });
+
+    test("rejects a tampered payload with a valid-looking signature", async () => {
+        const token = await signSession("user-42", false, false);
+        const [payload, signature] = token.split(".");
+        // Flip a character in the payload — signature no longer matches.
+        const tamperedPayload = payload.slice(0, -1) + (payload.slice(-1) === "A" ? "B" : "A");
+        const tampered = `${tamperedPayload}.${signature}`;
+
+        const session = await verifySession(tampered);
+        expect(session.valid).toBe(false);
+    });
+
+    test("rejects a token signed with a different secret", async () => {
+        const token = await signSession("user-42", false, false);
+        process.env.SESSION_SECRET = "different-secret";
+
+        const session = await verifySession(token);
+        expect(session.valid).toBe(false);
+    });
+
+    test("rejects an expired token (> 7 days old)", async () => {
+        const EIGHT_DAYS_MS = 8 * 24 * 60 * 60 * 1000;
+        const realNow = Date.now;
+        const past = realNow() - EIGHT_DAYS_MS;
+
+        // Sign at t=past, verify at t=now.
+        jest.spyOn(Date, "now").mockReturnValueOnce(past);
+        const token = await signSession("user-42", false, false);
+
+        const session = await verifySession(token);
+        expect(session.valid).toBe(false);
+
+        (Date.now as jest.Mock).mockRestore?.();
+    });
+
+    test("accepts a token 6 days old (within 7-day window)", async () => {
+        const SIX_DAYS_MS = 6 * 24 * 60 * 60 * 1000;
+        const past = Date.now() - SIX_DAYS_MS;
+
+        jest.spyOn(Date, "now").mockReturnValueOnce(past);
+        const token = await signSession("user-42", false, false);
+
+        const session = await verifySession(token);
+        expect(session.valid).toBe(true);
+
+        (Date.now as jest.Mock).mockRestore?.();
+    });
+
+    test("throws when SESSION_SECRET is missing (signSession)", async () => {
+        delete process.env.SESSION_SECRET;
+        await expect(signSession("user-42", false, false)).rejects.toThrow(
+            /SESSION_SECRET/
+        );
+    });
+
+    test("returns invalid (does not throw) when SESSION_SECRET is missing on verify", async () => {
+        const token = await signSession("user-42", false, false);
+        delete process.env.SESSION_SECRET;
+
+        const session = await verifySession(token);
+        // verifySession catches the thrown error from getSessionKey and returns invalid.
+        expect(session.valid).toBe(false);
+    });
+});

--- a/web/__tests__/lib/surplus.test.ts
+++ b/web/__tests__/lib/surplus.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for surplus.ts — dollar valuation and keep/cut classification.
+ */
+import {
+    analyzeProjectedSalary,
+    calculateSurplus,
+    computeDollarPerVorp,
+} from "@/lib/surplus";
+import { MY_TEAM } from "@/lib/config";
+import type { Player } from "@/lib/types";
+
+function makePlayer(overrides: Partial<Player> = {}): Player {
+    return {
+        player_id: overrides.player_id ?? "p",
+        ottoneu_id: 1,
+        name: overrides.name ?? "Player",
+        position: overrides.position ?? "RB",
+        nfl_team: "ANY",
+        birth_date: null,
+        is_college: false,
+        price: overrides.price ?? 1,
+        team_name: overrides.team_name ?? null,
+        total_points: overrides.total_points ?? 0,
+        games_played: overrides.games_played ?? 16,
+        snaps: 0,
+        ppg: overrides.ppg ?? 0,
+        pps: 0,
+        ...overrides,
+    };
+}
+
+/**
+ * Build a realistic-ish player pool so VORP has a non-zero replacement level
+ * and positive-VORP players exist for dollar allocation.
+ */
+function buildPool(): Player[] {
+    const pool: Player[] = [];
+    // 30 RBs: top 10 are star/value, bottom 20 spread across the replacement tier.
+    for (let i = 0; i < 30; i++) {
+        pool.push(
+            makePlayer({
+                player_id: `rb${i}`,
+                position: "RB",
+                team_name: `Team ${i % 12}`,
+                price: i < 10 ? 40 + i : 1 + i,
+                ppg: i < 10 ? 18 + i * 0.3 : 6 + (i - 10) * 0.2,
+                games_played: 16,
+                total_points: ((i < 10 ? 18 + i * 0.3 : 6 + (i - 10) * 0.2) as number) * 16,
+            })
+        );
+    }
+    return pool;
+}
+
+describe("calculateSurplus", () => {
+    test("returns empty array for empty input", () => {
+        expect(calculateSurplus([])).toEqual([]);
+    });
+
+    test("returns empty array when no players have positive VORP", () => {
+        // All players identical → zero VORP for everyone → no positive VORP pool.
+        const players: Player[] = Array.from({ length: 5 }, (_, i) =>
+            makePlayer({
+                player_id: `x${i}`,
+                position: "RB",
+                ppg: 10,
+                games_played: 16,
+                total_points: 160,
+            })
+        );
+        expect(calculateSurplus(players)).toEqual([]);
+    });
+
+    test("assigns dollar_value ≥ 1 even to players with zero or negative VORP", () => {
+        const players = buildPool();
+        const result = calculateSurplus(players);
+        for (const p of result) {
+            expect(p.dollar_value).toBeGreaterThanOrEqual(1);
+        }
+    });
+
+    test("surplus = dollar_value - price", () => {
+        const players = buildPool();
+        const result = calculateSurplus(players);
+        for (const p of result) {
+            expect(p.surplus).toBe(p.dollar_value - p.price);
+        }
+    });
+
+    test("negative surplus when price exceeds dollar value", () => {
+        const players = buildPool();
+        // Add a player who's paid $80 but performs at near-replacement level.
+        players.push(
+            makePlayer({
+                player_id: "overpriced",
+                position: "RB",
+                team_name: "Team A",
+                price: 80,
+                ppg: 6.5,
+                games_played: 16,
+                total_points: 104,
+            })
+        );
+        const result = calculateSurplus(players);
+        const overpriced = result.find((p) => p.player_id === "overpriced");
+        expect(overpriced).toBeDefined();
+        expect(overpriced!.surplus).toBeLessThan(0);
+    });
+
+    test("applies optional per-player adjustment", () => {
+        const players = buildPool();
+        const baseline = calculateSurplus(players);
+        const baselinePlayer = baseline.find((p) => p.player_id === "rb0")!;
+
+        const adjustments = new Map<string, number>([["rb0", 5]]);
+        const adjusted = calculateSurplus(players, adjustments);
+        const adjustedPlayer = adjusted.find((p) => p.player_id === "rb0")!;
+
+        expect(adjustedPlayer.dollar_value).toBe(baselinePlayer.dollar_value + 5);
+    });
+});
+
+describe("computeDollarPerVorp", () => {
+    test("returns 0 when no positive VORP exists", () => {
+        expect(computeDollarPerVorp([])).toBe(0);
+    });
+
+    test("returns a positive rate for a normal pool", () => {
+        expect(computeDollarPerVorp(buildPool())).toBeGreaterThan(0);
+    });
+});
+
+describe("analyzeProjectedSalary", () => {
+    test("returns empty array when MY_TEAM has no roster", () => {
+        const players = buildPool(); // uses "Team 0" … "Team 11", not MY_TEAM
+        expect(analyzeProjectedSalary(players)).toEqual([]);
+    });
+
+    test("classifies players based on surplus thresholds", () => {
+        // Seed a pool and attach one player to MY_TEAM for each tier.
+        const pool = buildPool();
+        pool.push(
+            makePlayer({
+                player_id: "keep_strong",
+                position: "RB",
+                team_name: MY_TEAM,
+                price: 1, // cheap star → high surplus
+                ppg: 25,
+                games_played: 16,
+                total_points: 400,
+            }),
+            makePlayer({
+                player_id: "cut",
+                position: "RB",
+                team_name: MY_TEAM,
+                price: 80, // overpaid → very negative surplus
+                ppg: 6,
+                games_played: 16,
+                total_points: 96,
+            })
+        );
+        const result = analyzeProjectedSalary(pool);
+        const valid = new Set(["Strong Keep", "Keep", "Borderline", "Cut Candidate"]);
+        for (const p of result) {
+            expect(valid.has(p.recommendation)).toBe(true);
+        }
+        expect(result.find((p) => p.player_id === "keep_strong")!.recommendation).toBe(
+            "Strong Keep"
+        );
+        expect(result.find((p) => p.player_id === "cut")!.recommendation).toBe(
+            "Cut Candidate"
+        );
+    });
+});

--- a/web/__tests__/lib/vorp.test.ts
+++ b/web/__tests__/lib/vorp.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for calculateVorp — pure positional VORP calculation.
+ *
+ * Exercises both the salary-implied replacement path (rostered players with
+ * enough data) and the fixed-rank fallback (sparse data or unrostered pools).
+ */
+import { calculateVorp } from "@/lib/vorp";
+import type { Player } from "@/lib/types";
+
+function makePlayer(overrides: Partial<Player> = {}): Player {
+    return {
+        player_id: overrides.player_id ?? "p",
+        ottoneu_id: 1,
+        name: overrides.name ?? "Player",
+        position: overrides.position ?? "RB",
+        nfl_team: "ANY",
+        birth_date: null,
+        is_college: false,
+        price: overrides.price ?? 1,
+        team_name: overrides.team_name ?? null,
+        total_points: overrides.total_points ?? 0,
+        games_played: overrides.games_played ?? 16,
+        snaps: 0,
+        ppg: overrides.ppg ?? 0,
+        pps: 0,
+        ...overrides,
+    };
+}
+
+describe("calculateVorp — edge cases", () => {
+    test("empty roster returns empty results", () => {
+        const result = calculateVorp([]);
+        expect(result.players).toEqual([]);
+        expect(result.replacementPpg).toEqual({});
+        expect(result.replacementN).toEqual({});
+    });
+
+    test("excludes kickers from VORP output", () => {
+        const players = [
+            makePlayer({ player_id: "k1", position: "K", ppg: 10 }),
+            makePlayer({ player_id: "rb1", position: "RB", ppg: 15 }),
+        ];
+        const { players: result } = calculateVorp(players);
+        expect(result).toHaveLength(1);
+        expect(result[0].player_id).toBe("rb1");
+    });
+
+    test("excludes players below minGames threshold", () => {
+        const players = [
+            makePlayer({ player_id: "a", position: "RB", ppg: 20, games_played: 2 }),
+            makePlayer({ player_id: "b", position: "RB", ppg: 10, games_played: 10 }),
+        ];
+        const { players: result } = calculateVorp(players, 4);
+        expect(result.map((p) => p.player_id)).toEqual(["b"]);
+    });
+
+    test("includes college players even with 0 games", () => {
+        const players = [
+            makePlayer({
+                player_id: "college",
+                position: "RB",
+                ppg: 8,
+                games_played: 0,
+                is_college: true,
+            }),
+            makePlayer({ player_id: "vet", position: "RB", ppg: 15, games_played: 16 }),
+        ];
+        const { players: result } = calculateVorp(players, 4);
+        expect(result.map((p) => p.player_id).sort()).toEqual(["college", "vet"]);
+    });
+
+    test("single qualifying player — fallback assigns their own ppg as replacement", () => {
+        const players = [makePlayer({ player_id: "only", position: "RB", ppg: 12 })];
+        const { players: result, replacementPpg } = calculateVorp(players);
+
+        expect(result).toHaveLength(1);
+        // Fixed-rank fallback: only 1 RB, rank > length, so last player's ppg is used.
+        expect(replacementPpg.RB).toBe(12);
+        expect(result[0].vorp_per_game).toBe(0);
+        expect(result[0].full_season_vorp).toBe(0);
+    });
+
+    test("player below replacement has negative VORP", () => {
+        // 30 RBs rostered: 6 bottom-quartile at $1 with mixed ppg, 24 above.
+        // Below-replacement player's ppg < replacement threshold.
+        const players: Player[] = [];
+        for (let i = 0; i < 30; i++) {
+            players.push(
+                makePlayer({
+                    player_id: `rb${i}`,
+                    position: "RB",
+                    team_name: "Team A",
+                    price: i < 8 ? 1 : 30 + i,
+                    ppg: i < 8 ? 5 + i * 0.5 : 15 + i * 0.3,
+                    games_played: 16,
+                    total_points: (i < 8 ? 5 + i * 0.5 : 15 + i * 0.3) * 16,
+                })
+            );
+        }
+        const { players: result, replacementPpg } = calculateVorp(players);
+
+        expect(replacementPpg.RB).toBeGreaterThan(0);
+        const cheap = result.find((p) => p.player_id === "rb0")!;
+        expect(cheap.vorp_per_game).toBeLessThan(0);
+        expect(cheap.full_season_vorp).toBeLessThan(0);
+    });
+
+    test("rounds vorp_per_game to 2 decimals and full_season_vorp to 1 decimal", () => {
+        const players = [
+            makePlayer({ player_id: "a", position: "RB", ppg: 10.555 }),
+            makePlayer({ player_id: "b", position: "RB", ppg: 20.123 }),
+        ];
+        const { players: result } = calculateVorp(players);
+        for (const p of result) {
+            expect(Math.round(p.vorp_per_game * 100) / 100).toBe(p.vorp_per_game);
+            expect(Math.round(p.full_season_vorp * 10) / 10).toBe(p.full_season_vorp);
+        }
+    });
+});


### PR DESCRIPTION
Closes #430.

## Summary
- Adds focused unit tests for the six `web/lib/` modules called out in the April 2026 audit. `web/lib/` line coverage moves from **75.55% → 87.32%**; `data.ts` from **22% → 98%**.
- No production code changed — tests only.

## Coverage details
| Module | Before | After |
|---|---|---|
| `session.ts` | untested | 98.55% |
| `auth.ts` | untested | 82.02% |
| `data.ts` | 22.37% | 98.38% |
| `scoring.ts` | untested | 100% |
| `vorp.ts` | 98.85% | 98.85% (branches improved) |
| `surplus.ts` | 90.66% | 100% |

## What each file covers
- **session.test.ts** — round-trip sign/verify, expired token (>7d), tampered payload, wrong secret, malformed shape, missing `SESSION_SECRET`.
- **auth.test.ts** — `authenticateUser` happy path + wrong password + DB error; `getAuthenticatedUser` with valid / missing / malformed / expired / mis-signed cookies; default flag handling. Mocks `next/headers` and the Supabase admin client; real session signing is used end-to-end.
- **data.test.ts** — chainable Supabase mock (thenable query builder) exercising `fetchPlayers`, `fetchPlayerList`, `fetchPlayersAtDate` (transaction replay + cut + `league_prices` fallback), `fetchPlayerDetail`, `fetchPublicArbPlayers` (FA filter), `fetchPlayerProjection`.
- **scoring.test.ts** — one fixture per Half-PPR rule (passing/rushing/receiving/FG by distance/PAT/INT) plus realistic QB, RB, K combined lines.
- **vorp.test.ts** — empty roster, kicker exclusion, `minGames` threshold, college-player inclusion, single-player fixed-rank fallback, below-replacement negative VORP, rounding invariants.
- **surplus.test.ts** — empty input, zero-VORP pool, dollar_value floor of 1, `surplus = value - price` invariant, negative surplus for an overpriced near-replacement player, optional adjustments, Strong Keep / Cut Candidate classification.

## Test plan
- [x] `just test-web` — 223/223 pass
- [x] `just typecheck` — clean
- [x] `just lint` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)