### PR TITLE
retro: add test-web-file recipe for single-file Jest runs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -54,6 +54,10 @@ test-python:
 test-web:
     cd web && npx jest --coverage
 
+# Run a single web test file (no coverage)  (e.g. just test-web-file __tests__/lib/session.test.ts)
+test-web-file file:
+    cd web && npx jest {{file}} --no-coverage
+
 # ──────────────────────────────────────────────
 # Backend
 # ──────────────────────────────────────────────

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -104,6 +104,7 @@ just typecheck          # TypeScript type check
 just test               # Run all tests (Python + web)
 just test-python        # Python tests with coverage
 just test-web           # Jest tests with coverage
+just test-web-file <path>  # Run a single web test file (e.g. just test-web-file __tests__/lib/session.test.ts)
 just scrape             # Full scrape pipeline
 just analyze            # Run all analysis scripts
 just check-db           # Verify database contents

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -12,7 +12,8 @@
 
 - **Location:** `web/__tests__/`
 - **Config:** `web/jest.config.ts`
-- **Run:** `npm test` from `web/`
+- **Run all:** `just test-web` (runs the full suite with coverage)
+- **Run one file:** `just test-web-file <path>` — e.g. `just test-web-file __tests__/lib/session.test.ts`. Prefer this over raw `npx jest <file>` so the call is covered by the `Bash(just:*)` allowlist.
 
 ### TypeScript type-checking
 


### PR DESCRIPTION
## Summary

Retro follow-up to #430 / #444. During that task I reached for `cd web && npx jest <file> --no-coverage` to run a single test file; that command is not in the allowlist and required manual approval. This PR adds a `just test-web-file <path>` recipe so the pre-approved `Bash(just:*)` entry covers the single-file case, and documents it so future sessions don't re-learn the habit.

## Friction points

| # | What happened | Category | Root cause | Proposed fix |
|---|---|---|---|---|
| 1 | `npx jest <file>` required manual approval during iteration | approval-gate | No `just` recipe for running a single web test file | New `just test-web-file <path>` recipe + docs |

## Files changed

- `Justfile` — add `test-web-file file` recipe wrapping `cd web && npx jest {{file}} --no-coverage`.
- `docs/COMMANDS.md` — list the new recipe in the `just` recipe section.
- `docs/TESTING.md` — point "Web Tests" at `just test-web` for the suite and `just test-web-file <path>` for a single file, with a note on why this is preferred over raw `npx jest`.

## Test plan
- [x] `just test-web-file __tests__/lib/scoring.test.ts` — 17/17 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)