### PR TITLE
docs: daily harness audit 2026-04-21

### DIFF
--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -12,6 +12,9 @@
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| Arb-progress transforms | `web/lib/arb-progress.ts` | Pure view-model transforms for `/arb-progress` (no DB / React) |
+| API validation helper | `web/lib/validate.ts` | `parseJson(req, schema)` — shared Zod body parser for API routes |
+| API input schemas | `web/lib/schemas/` | Zod schemas + inferred types per resource (arbitration plans, surplus adjustments, users) |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -63,4 +63,11 @@ Analysis math is ported to `web/lib/analysis.ts` (TS equivalent of `scripts/anal
 
 ## Configuration
 
-Frontend constants in `web/lib/config.ts` — **must stay in sync with `scripts/config.py`**.
+Frontend constants in `web/lib/config.ts` derive from `config.json` (the shared Python/TS source of truth). Value-equality is mechanically enforced by architecture tests — see [CODE_ORGANIZATION.md](CODE_ORGANIZATION.md#shared-configuration-configjson) for the add-a-new-constant workflow.
+
+## API Route Validation
+
+API route handlers under `web/app/api/` validate JSON bodies with Zod:
+
+- `web/lib/schemas/` — per-resource Zod schemas (`arbitration-plan.ts`, `surplus-adjustment.ts`, `user.ts`) with `z.infer` types exported alongside each schema.
+- `web/lib/validate.ts` — shared `parseJson(req, schema)` helper that returns either `{ ok: true, data }` (typed) or `{ ok: false, response }` (400 with Zod's `issues` array). Use this at the top of every POST/PATCH/PUT handler instead of reading `req.json()` directly.


### PR DESCRIPTION
## Summary

Daily audit of harness docs against commits merged since the last audit (#435 on 2026-04-19). Two small but real drifts fixed; schema doc still matches reality.

## Commits reviewed

All merged 2026-04-19 after the prior audit — nothing landed on 2026-04-20 or 2026-04-21:

- #445 retro: `test-web-file` recipe for single-file Jest runs
- #444 test: unit coverage for auth/session/data/scoring/vorp/surplus
- #443 refactor: split arb-progress server component (introduced `web/lib/arb-progress.ts`)
- #442 feat: standardize player UI components (PlayerName / PositionBadge / StatValue / columns factory) — already documented in FRONTEND.md by the PR itself
- #441 refactor: DataTable generic
- #440 feat: Zod validation layer for API routes (introduced `web/lib/validate.ts` + `web/lib/schemas/`) — **undocumented until now**
- #439 chore: config constants consolidation, value-equality sync enforced — **FRONTEND.md wording stale**
- #438 docs: scrub stale `make` references
- #437 retro: permission gates, review-permission-gates skill
- #436 feat: replace Makefile with Justfile

## Changes made

- **docs/FRONTEND.md** — Configuration section: drop the stale "must stay in sync with `scripts/config.py`" line; link to CODE_ORGANIZATION.md for the canonical add-a-constant workflow (avoids the two docs drifting again).
- **docs/FRONTEND.md** — new "API Route Validation" section covering `web/lib/schemas/` and `web/lib/validate.ts` from #440.
- **docs/CODE_ORGANIZATION.md** — Key File Locations table gains rows for `web/lib/validate.ts`, `web/lib/schemas/`, and `web/lib/arb-progress.ts`.

## Schema check

`migrations/` ends at `021_drop_player_stats_raw_columns.sql` — unchanged since the last audit. `docs/generated/db-schema.md` still matches the 17 `CREATE TABLE` statements in `schema.sql`. No schema drift.

## Other spot checks

- All routes in FRONTEND.md are present under `web/app/` ✓
- Components table matches `web/components/` ✓
- `just` recipes referenced in COMMANDS.md and TESTING.md exist in `Justfile` (including the new `test-web-file`) ✓
- Skills listed in CLAUDE.md Documentation Map all exist under `.claude/commands/` ✓

## Items flagged for human follow-up

None this cycle.

## Test plan

- [x] `git diff` reviewed; edits are scoped to two docs
- [ ] No code changes, so existing `just check-docs` coverage is sufficient

https://claude.ai/code/session_01M6jAMobSE1N2ixAdNoGMzf