### PR TITLE
docs: daily harness audit 2026-04-22

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,6 +65,10 @@ All web data fetching goes through `web/lib/data.ts` — the single source of tr
 - **Calculations are TypeScript-only:** VORP, surplus, arbitration, and projected salary are computed in `web/lib/` and are the canonical implementations.
 - **Scoring formula:** `web/lib/scoring.ts` provides `calculateFantasyPoints()` — the Ottoneu Half PPR formula as a pure function of raw NFL stats.
 
+### API Input Validation
+
+All mutating API routes validate request bodies through Zod schemas in `web/lib/schemas/` via the shared `parseJson(req, schema)` helper in `web/lib/validate.ts`. On failure the helper returns a 400 response carrying Zod's `issues` array; on success the route gets typed, parsed data. Do not hand-roll `if (!body.foo)` checks in new routes — add a schema and use `parseJson`.
+
 ### Key Metrics
 
 - **PPG** (Points Per Game) = total_points / games_played

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -12,6 +12,9 @@
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| Arb progress helpers | `web/lib/arb-progress.ts` | Pure transformations for `/arb-progress` (allocations, raises, spending) |
+| API input validation | `web/lib/validate.ts` | `parseJson(req, schema)` helper returning typed result or 400 response |
+| Request schemas | `web/lib/schemas/` | Zod schemas for API route inputs (user, arbitration-plan, surplus-adjustment) |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |


### PR DESCRIPTION
## Summary

Daily audit of harness documentation, focused on drift introduced by the 11 commits merged since the 2026-04-19 audit.

### Commits reviewed (since last audit)
- `baac1ca` retro: add test-web-file recipe for single-file Jest runs (#445)
- `f2fd15f` test: add unit coverage to auth/session/data/scoring/vorp/surplus (#444)
- `8f50cbc` refactor: split arb-progress server component (#443)
- `6dd3f53` feat: standardize player UI components across all tables (#442)
- `5659e4f` feat: add Zod validation layer for API route inputs (#440)
- `4787602` refactor: make DataTable generic; drop wildcard index signatures (#441)
- `14a441a` chore: consolidate config constants and enforce value-equality sync (#439)
- `899454e` docs: scrub stale make references missed by Justfile migration (#438)
- `f1e5cbb` retro: permission gates, coverage flags, mcp dir creation (#437)
- `81ffe2c` feat: replace Makefile with Justfile (#436)
- `6dd371c` docs: daily harness audit 2026-04-19 (#435)

### Changes made

- **`docs/CODE_ORGANIZATION.md`** — added three new rows to the key-file-locations table:
  - `web/lib/arb-progress.ts` (pure transformations extracted from the arb-progress page in #443)
  - `web/lib/validate.ts` (the shared `parseJson` helper from #440)
  - `web/lib/schemas/` (Zod request-body schemas from #440)
- **`docs/ARCHITECTURE.md`** — added a short "API Input Validation" subsection under the Web Data Access Layer, so agents adding mutating routes know to wire up a schema + `parseJson` rather than hand-rolling `if (!body.foo)` checks.

### Schema audit

- Latest migration `021_drop_player_stats_raw_columns.sql` is already reflected in `docs/generated/db-schema.md` (17-table count, migration 021 note, removed-column list). Spot-checked `player_stats` and `nfl_stats` columns in `schema.sql` against the doc — no drift.
- No new migrations since the last audit.

### Items flagged for human follow-up

- **`docs/superpowers/plans/` and `docs/superpowers/specs/`** are not listed in the Documentation Map in `CLAUDE.md` or `AGENTS.md`. Leaving alone — unclear whether those directories are meant to be agent-visible, but worth a human call if they should be indexed.
- **Zod** is now a frontend dependency but isn't called out in the tech-stack lines in `AGENTS.md`/`ARCHITECTURE.md`. Skipped adding it since those lists appear deliberately curated to foundational tools (Recharts, Tailwind, etc.) — flagging for human judgement.

## Test plan

- [x] `git diff` reviewed — only the two intended docs changed, 7 lines added total
- [x] Verified all referenced paths exist: `web/lib/arb-progress.ts`, `web/lib/validate.ts`, `web/lib/schemas/{user,arbitration-plan,surplus-adjustment}.ts`
- [ ] Human reviewer confirms the flagged items above don't need action

https://claude.ai/code/session_01TghU2B7xRHZCfXegQDjZP3