### PR TITLE
docs: daily harness audit 2026-04-23

### DIFF
--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -12,6 +12,9 @@
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| Arb progress | `web/lib/arb-progress.ts` | Pure transforms for `/arb-progress` (no DB/React) |
+| API validation | `web/lib/validate.ts` | `parseJson(req, schema)` helper for Zod-validated API inputs |
+| Zod schemas | `web/lib/schemas/` | Request-body schemas consumed by API routes via `parseJson` |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |
@@ -43,6 +46,21 @@ When adding a new shared key, update three places:
 Drift is caught mechanically by architecture tests:
 - `scripts/tests/test_architecture.py::TestConfigSync` — asserts every `config.json` key is consumed in both `config.py` and `config.ts`, and that neither references a nonexistent key.
 - `web/__tests__/lib/architecture.test.ts::Config JSON Sync` — asserts the TypeScript module's *exported values* match `config.json` (not just key presence).
+
+## API Route Input Validation
+
+API routes that accept a JSON body validate it through `parseJson` from `web/lib/validate.ts` against a Zod schema in `web/lib/schemas/`. On failure the helper returns a 400 response with the Zod `issues` array; on success the body is returned with inferred types.
+
+```typescript
+import { parseJson } from "@/lib/validate";
+import { CreatePlanSchema } from "@/lib/schemas/arbitration-plan";
+
+const parsed = await parseJson(req, CreatePlanSchema);
+if (!parsed.ok) return parsed.response;
+const data = parsed.data; // z.infer<typeof CreatePlanSchema>
+```
+
+Add new schemas alongside `arbitration-plan.ts`, `surplus-adjustment.ts`, `user.ts` — one schema file per resource.
 
 ## Path Setup for New Python Scripts
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -59,7 +59,11 @@ Shared type definitions in `web/lib/types.ts`:
 
 ## Analysis Logic
 
-Analysis math is ported to `web/lib/analysis.ts` (TS equivalent of `scripts/analysis_utils.py`). Arbitration simulation logic lives in `web/lib/arb-logic.ts`.
+Analysis math is ported to `web/lib/analysis.ts` (TS equivalent of `scripts/analysis_utils.py`). Arbitration simulation logic lives in `web/lib/arb-logic.ts`. Pure transforms feeding the `/arb-progress` page (status, allocations, raises, completion summary) live in `web/lib/arb-progress.ts` and are rendered by the sub-components under `web/app/arb-progress/` (`TeamStatusGrid`, `AllocationsSection`, `TeamSpendingSection`, `TeamRaisesSummary`, `CompletionSummary`).
+
+## API Routes
+
+Route handlers under `web/app/api/` validate JSON bodies with `parseJson(req, schema)` from `web/lib/validate.ts`, using Zod schemas from `web/lib/schemas/`. See [CODE_ORGANIZATION.md § API Route Input Validation](CODE_ORGANIZATION.md#api-route-input-validation) for the pattern.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Daily harness-doc audit for 2026-04-23. No commits merged to `main` in the last 25 hours (last activity 2026-04-19), so this is a lighter sweep for drift that slipped past the previous audit.

### Commits reviewed
None merged in the 25h window. Cross-checked against the batch that landed on 2026-04-19 after the previous audit (`#440` Zod validation layer, `#443` arb-progress split, `#442` player UI components, `#441` generic DataTable, `#444` unit coverage, `#445` `test-web-file` recipe).

### Drift found and fixed
- **Zod API validation layer undocumented.** `web/lib/validate.ts` (`parseJson`) and `web/lib/schemas/{arbitration-plan,surplus-adjustment,user}.ts` are used by four API routes but had no doc coverage. Agents adding new API routes would not have known to follow the pattern.
  - `docs/CODE_ORGANIZATION.md`: added rows for `validate.ts`, `schemas/`, and a new "API Route Input Validation" section with the canonical snippet.
  - `docs/FRONTEND.md`: added a short "API Routes" section pointing to the CODE_ORGANIZATION.md pattern.
- **`/arb-progress` split undocumented.** `web/lib/arb-progress.ts` (pure transforms) and the sub-components (`TeamStatusGrid`, `AllocationsSection`, `TeamSpendingSection`, `TeamRaisesSummary`, `CompletionSummary`) weren't called out.
  - `docs/CODE_ORGANIZATION.md`: added "Arb progress" row.
  - `docs/FRONTEND.md`: extended Analysis Logic section.

### Schema check
`docs/generated/db-schema.md` reconciled against `schema.sql` and `migrations/` — all 17 tables match, latest migration is `021_drop_player_stats_raw_columns.sql` (already reflected). No drift.

### Other checks
- Skill list in `CLAUDE.md` Documentation Map matches `.claude/commands/*.md` exactly.
- `docs/COMMANDS.md` `just test-web-file` recipe matches `Justfile`.
- All referenced doc paths exist.

### Flagged for human follow-up
None.

## Test plan
- [ ] `just check-docs` / `scripts/check_docs_freshness.py` passes on CI
- [ ] Markdown anchor link `CODE_ORGANIZATION.md#api-route-input-validation` renders correctly on GitHub

https://claude.ai/code/session_017dFJ8XesytyD45ppnqYqjn

---
_Generated by [Claude Code](https://claude.ai/code/session_017dFJ8XesytyD45ppnqYqjn)_