### PR TITLE
docs: daily harness audit 2026-04-24

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Universal instructions for AI coding agents working on this repository.
 
 Comprehensive database and analytics platform for Ottoneu Fantasy Football League 309 (12-team Superflex Half PPR). Python scripts scrape player data and NFL stats into a Supabase PostgreSQL database. A Next.js frontend provides interactive analytics and visualizations.
 
-**Tech stack:** Python 3.9+ · Next.js 16 · React 19 · TypeScript · Tailwind CSS 4 · Supabase (PostgreSQL) · Playwright · pandas · Recharts
+**Tech stack:** Python 3.9+ · Next.js 16 · React 19 · TypeScript · Tailwind CSS 4 · Supabase (PostgreSQL) · Playwright · pandas · Recharts · Zod (API input validation)
 
 **Package Manager:** Always use `npm` for frontend dependencies and scripts. Do not use `pnpm`, `yarn`, or `bun`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,7 @@ Python Scripts (scripts/)
 
 ## Tech Stack
 
-- **Frontend:** Next.js 16, React 19, TypeScript, Tailwind CSS 4, Recharts
+- **Frontend:** Next.js 16, React 19, TypeScript, Tailwind CSS 4, Recharts, Zod (API input validation)
 - **Backend:** Python 3.9+, Playwright (scraping), pandas, nfl_data_py
 - **Database:** Supabase (PostgreSQL)
 - **Environment:** `.env` (root, for Python) and `web/.env.local` (for Next.js) hold Supabase credentials
@@ -83,6 +83,10 @@ User accounts with email/password login stored in the `users` table. Passwords a
   - Admin routes (`/admin`) require `isAdmin`
 - **User-scoped data:** `surplus_adjustments` and `arbitration_plans` are scoped to `user_id` — each user sees only their own data
 - **Admin panel** (`/admin`) allows admins to create users, toggle projections access, and delete users
+
+### API Input Validation
+
+All mutating API routes (`/api/admin/users`, `/api/arbitration-plans/*`, `/api/surplus-adjustments`) validate request bodies via Zod schemas in `web/lib/schemas/`. The shared `parseJson(req, schema)` helper in `web/lib/validate.ts` returns either typed data or a 400 response with a Zod `issues` array — routes never parse `req.json()` directly for validated inputs.
 
 ## Feature Projection System (`scripts/feature_projections/`)
 

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -12,6 +12,11 @@
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| Arb progress transforms | `web/lib/arb-progress.ts` | Pure transforms used by `/arb-progress` server component (no DB/React) |
+| API input validation | `web/lib/validate.ts` | `parseJson(req, schema)` Zod helper shared across API routes |
+| Zod schemas | `web/lib/schemas/` | Input schemas per API surface (`user`, `surplus-adjustment`, `arbitration-plan`) |
+| Column factories | `web/components/columns.tsx` | Composable `DataTable` column builders that inject atomic components |
+| Static column defs | `web/lib/columns.ts` | Plain (non-React) column arrays kept for backward compatibility |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -17,7 +17,7 @@ Seventeen tables, all with UUID primary keys.
 | `arbitration_plans` | Named arbitration budget allocation plans per user (FK -> `users`) | `(league_id, name, user_id)` |
 | `arbitration_plan_allocations` | Per-player dollar allocations within a plan (FK -> `arbitration_plans`, `players`) | `(plan_id, player_id)` |
 | `scraper_jobs` | Persistent job queue with status tracking, dependencies, and retry logic | -- |
-| `projection_models` | Registry of versioned projection models (internal v1–v6 and external sources) | `(name, version)` |
+| `projection_models` | Registry of versioned projection models (internal v1–v20+ and external sources) | `(name, version)` |
 | `model_projections` | Per-model projected PPG with raw feature values (FK -> `projection_models`, `players`) | `(model_id, player_id, season)` |
 | `backtest_results` | Cached accuracy metrics per model × season × position (FK -> `projection_models`) | `(model_id, season, position)` |
 | `arbitration_progress` | Scraped player allocation data from Ottoneu arbitration page | -- |


### PR DESCRIPTION
## Summary

Daily sweep of harness documentation against commits merged since the last audit (PR #435, 2026-04-19). Focus: db-schema accuracy and new shared frontend modules introduced in the past week.

## Commits reviewed (since #435)

- #436 / #438 — Makefile → Justfile migration (docs already updated in-PR)
- #437 — retro: permission gates, `review-permission-gates` skill (docs already updated in-PR)
- #439 — consolidate config constants, enforce value-equality sync (docs already updated in-PR)
- #440 — Zod validation layer for API route inputs *(new `web/lib/validate.ts`, `web/lib/schemas/`)*
- #441 — DataTable generic; drop wildcard index signatures
- #442 — standardize player UI components (FRONTEND.md already updated in-PR)
- #443 — split `arb-progress` server component *(new `web/lib/arb-progress.ts`)*
- #444 — unit coverage for auth/session/data/scoring/vorp/surplus
- #445 — `just test-web-file` recipe (docs already updated in-PR)

## Changes

- **`docs/generated/db-schema.md`** — `projection_models` row said "internal v1–v6"; the registry now goes through `v20_learned_usage`. Widened to "v1–v20+".
- **`docs/ARCHITECTURE.md`** — added Zod to the tech stack and a new *API Input Validation* subsection pointing at `web/lib/validate.ts` and `web/lib/schemas/`. Neither was mentioned anywhere in `docs/` before this.
- **`docs/CODE_ORGANIZATION.md`** — added key-file rows for the five modules introduced in the past week that agents will touch: `web/lib/arb-progress.ts`, `web/lib/validate.ts`, `web/lib/schemas/`, `web/components/columns.tsx`, `web/lib/columns.ts`.
- **`AGENTS.md`** — added Zod to the tech stack one-liner (kept in sync with ARCHITECTURE.md).

## Verified still accurate (no edits needed)

- `migrations/` top is still `021_drop_player_stats_raw_columns.sql` — no new migrations since last audit, schema table count (17) still correct.
- `CLAUDE.md` Documentation Map skill list matches `.claude/commands/` directory contents.
- `docs/FRONTEND.md` already describes `PlayerName`, `PositionBadge`, `StatValue`, and the `components/columns.tsx` factory system (updated in #442).
- `docs/COMMANDS.md` and `docs/TESTING.md` already cover the Justfile recipes and `just test-web-file`.

## Flagged for human follow-up

- None this round.

https://claude.ai/code/session_01CqvFYvbRayKGsKqimDf3Zx

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqvFYvbRayKGsKqimDf3Zx)_