### PR TITLE
docs: daily harness audit 2026-04-25

### DIFF
--- a/.claude/commands/projection-accuracy.md
+++ b/.claude/commands/projection-accuracy.md
@@ -7,14 +7,14 @@ Follow these steps to generate a projection accuracy comparison table:
 1. **If a new model was just added**, first run it for ALL backtest seasons before running the report.
    Missing seasons show as `—` in the table and corrupt the combined averages.
    ```
-   source venv/bin/activate && python scripts/feature_projections/cli.py run --model <new_model> --seasons 2022,2023,2024,2025
+   just project <new_model> 2022,2023,2024,2025
    ```
 
-2. Activate the virtual environment and run backtests for all models, then generate the report
-`source venv/bin/activate && python scripts/feature_projections/accuracy_report.py --run-backtest --seasons 2022,2023,2024,2025`
+2. Run backtests for all models, then generate the report
+`just accuracy-report --run-backtest --seasons 2022,2023,2024,2025`
 
 3. The report is saved to `docs/generated/projection-accuracy.md` and printed to stdout.
    Include the full markdown table in any task output or PR description when this relates to a projection model change.
 
 4. When comparing a specific pair of models (e.g., after adding a new model), you can also run:
-`source venv/bin/activate && python scripts/feature_projections/cli.py compare --models v1_baseline_weighted_ppg,<new_model> --season 2024`
+`just compare v1_baseline_weighted_ppg,<new_model> 2024`

--- a/.claude/commands/run-analyses.md
+++ b/.claude/commands/run-analyses.md
@@ -4,5 +4,5 @@ description: Run the full analysis suite
 Follow these steps to run the full analysis suite:
 
 // turbo
-1. Run all analysis scripts
-`source venv/bin/activate && python scripts/run_all_analyses.py`
+1. Run all analysis scripts via `just`
+`just analyze`

--- a/.claude/commands/run-scraper.md
+++ b/.claude/commands/run-scraper.md
@@ -4,5 +4,5 @@ description: Run the full scraping pipeline to update data
 Follow these steps to run the scraping pipeline:
 
 // turbo
-1. Run the Ottoneu scraper
-`source venv/bin/activate && python scripts/ottoneu_scraper.py`
+1. Run the full scrape pipeline via `just`
+`just scrape`

--- a/.claude/commands/run-tests.md
+++ b/.claude/commands/run-tests.md
@@ -4,9 +4,8 @@ description: Run all tests (Python and Web)
 Follow these steps to run all tests:
 
 // turbo
-1. Run Python tests
-`source venv/bin/activate && python -m pytest`
+1. Run all tests (Python + web) via `just`
+`just test`
 
-// turbo
-2. Run Web tests
-`cd web && npm test`
+To run a single web test file (no coverage):
+`just test-web-file <path>`  # e.g. just test-web-file __tests__/lib/session.test.ts

--- a/.claude/commands/start-dev.md
+++ b/.claude/commands/start-dev.md
@@ -3,5 +3,5 @@ description: Start the Next.js development server
 ---
 Follow these steps to start the dev server:
 
-1. Start the development server
-`cd web && npm run dev`
+1. Start the Next.js dev server on localhost:3000 via `just`
+`just dev`

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -10,8 +10,11 @@
 | TS types | `web/lib/types.ts` | All shared TypeScript interfaces (`CorePlayer → RosteredPlayer → StatsPlayer → Player`) |
 | Data layer | `web/lib/data.ts` | **Unified data access** — all Supabase fetching goes through here |
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
-| Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
+| Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `web/lib/data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| Arb progress | `web/lib/arb-progress.ts` | Pure transforms for the `/arb-progress` page (no DB/network/React) |
+| Validation | `web/lib/validate.ts` | `parseJson(req, schema)` helper — validates API JSON bodies via Zod |
+| API schemas | `web/lib/schemas/` | Zod schemas for API route inputs (arbitration plans, surplus adjustments, users) |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |
@@ -41,7 +44,7 @@ When adding a new shared key, update three places:
 3. `web/lib/config.ts` — add `export const CONSTANT = config.KEY`
 
 Drift is caught mechanically by architecture tests:
-- `scripts/tests/test_architecture.py::TestConfigSync` — asserts every `config.json` key is consumed in both `config.py` and `config.ts`, and that neither references a nonexistent key.
+- `scripts/tests/test_architecture.py::TestConfigSync` — asserts every `config.json` key is consumed in both `scripts/config.py` and `web/lib/config.ts`, and that neither references a nonexistent key.
 - `web/__tests__/lib/architecture.test.ts::Config JSON Sync` — asserts the TypeScript module's *exported values* match `config.json` (not just key presence).
 
 ## Path Setup for New Python Scripts

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -59,7 +59,22 @@ Shared type definitions in `web/lib/types.ts`:
 
 ## Analysis Logic
 
-Analysis math is ported to `web/lib/analysis.ts` (TS equivalent of `scripts/analysis_utils.py`). Arbitration simulation logic lives in `web/lib/arb-logic.ts`.
+Analysis math is ported to `web/lib/analysis.ts` (TS equivalent of `scripts/analysis_utils.py`). Arbitration simulation logic lives in `web/lib/arb-logic.ts`. Pure transforms for the `/arb-progress` page (team status, allocation rows, completion summary) live in `web/lib/arb-progress.ts` — the page component orchestrates these into a view.
+
+## API Input Validation
+
+API routes that accept JSON bodies validate inputs against Zod schemas via the shared helper:
+
+```typescript
+import { parseJson } from "@/lib/validate";
+import { ArbitrationPlanCreateSchema } from "@/lib/schemas/arbitration-plan";
+
+const parsed = await parseJson(req, ArbitrationPlanCreateSchema);
+if (!parsed.ok) return parsed.response; // returns 400 with Zod issues
+const data = parsed.data; // typed as z.infer<typeof Schema>
+```
+
+Schemas live in `web/lib/schemas/` (one file per resource). Add tests under `web/__tests__/lib/schemas/`.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Daily audit of harness docs (root, `docs/`, `.claude/commands/`). Last audit was #435 on 2026-04-19.

### Commits reviewed (since #435)

| PR | Subject |
|----|---------|
| #436 | feat: replace Makefile with Justfile |
| #437 | retro: permission gates, coverage flags, mcp dir creation, review-permission-gates skill |
| #438 | docs: scrub stale make references missed by Justfile migration |
| #439 | chore: consolidate config constants and enforce value-equality sync |
| #440 | feat: add Zod validation layer for API route inputs |
| #441 | refactor: make DataTable generic; drop wildcard index signatures |
| #442 | feat: standardize player UI components across all tables |
| #443 | refactor: split arb-progress server component |
| #444 | test: add unit coverage to auth/session/data/scoring/vorp/surplus |
| #445 | retro: add test-web-file recipe for single-file Jest runs |

### Changes

**`docs/CODE_ORGANIZATION.md`**
- Added `web/lib/arb-progress.ts`, `web/lib/validate.ts`, and `web/lib/schemas/` to the file location table — these were introduced in #440 / #443 and weren't documented.
- Replaced bare-path references (`data.ts`, `config.py`, `config.ts`) with full paths so `scripts/check_docs_freshness.py` stops emitting false positives. Before: 3 warnings; after: 0.

**`docs/FRONTEND.md`**
- Added an "API Input Validation" section covering the `parseJson` + Zod schema pattern (`#440`) with a code sample.
- Noted the `/arb-progress` page split — pure transforms in `web/lib/arb-progress.ts`, page composes them.

**`.claude/commands/`** (skill files)
- `run-tests.md`, `run-scraper.md`, `run-analyses.md`, `start-dev.md`, `projection-accuracy.md` were still using raw `source venv/bin/activate && python …` incantations from before the Makefile→Justfile migration in #436. Switched all five to `just` recipes (`just test`, `just scrape`, `just analyze`, `just dev`, `just project`, `just accuracy-report`, `just compare`). AGENTS.md mandates `just` over direct python to keep the agent allowlist minimal.
- `run-tests.md` now also documents `just test-web-file <path>` (added in #445) for single-file Jest runs.

### Schema check (highest priority per audit brief)

- Latest migration: `migrations/021_drop_player_stats_raw_columns.sql` (no new migrations since the previous audit).
- Cross-checked `docs/generated/db-schema.md` against `schema.sql`: 17 tables, table list and `player_stats` / `nfl_stats` / `players` columns all match. No drift; no edits needed.

### Items flagged for human follow-up

- `docs/superpowers/plans/2026-04-19-build-system-just.md` and `docs/superpowers/specs/2026-04-19-build-system-design.md` are flagged as orphans by `check_docs_freshness.py` (not referenced from `AGENTS.md` / `CLAUDE.md`). They look like one-off planning artifacts from #436; consider either linking them from a "superpowers / design history" pointer in CLAUDE.md or deleting them now that the Justfile is shipped.

## Test plan

- [x] `python3 scripts/check_docs_freshness.py` — `CODE_ORGANIZATION.md paths` now `[OK]`; only the two pre-existing `superpowers/` orphans remain (called out above).
- [ ] Eyeball the rendered PR diff for the FRONTEND.md code block.


---
_Generated by [Claude Code](https://claude.ai/code/session_013Gpv6Qa7dfnW6ksf4rQnTK)_