### PR TITLE
docs: daily harness audit 2026-04-26

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,6 +84,10 @@ User accounts with email/password login stored in the `users` table. Passwords a
 - **User-scoped data:** `surplus_adjustments` and `arbitration_plans` are scoped to `user_id` — each user sees only their own data
 - **Admin panel** (`/admin`) allows admins to create users, toggle projections access, and delete users
 
+### API Request Validation
+
+Mutation routes under `web/app/api/` validate JSON bodies via Zod before touching the DB. Schemas live in `web/lib/schemas/` (per-resource: `arbitration-plan.ts`, `surplus-adjustment.ts`, `user.ts`) and the shared helper is `web/lib/validate.ts::parseJson(req, schema)`. On failure it returns a 400 with `{ error, issues }`; on success it returns typed `data`. New mutating endpoints should follow the same pattern instead of hand-parsing `req.json()`.
+
 ## Feature Projection System (`scripts/feature_projections/`)
 
 Generates season-long player PPG projections from historical data using a combination of targeted features. The active production model (`v14_qb_starter`) uses:

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -12,6 +12,8 @@
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| Arb progress | `web/lib/arb-progress.ts` | Pure transforms for the `/arb-progress` page (team status, allocations, raises) |
+| API validation | `web/lib/validate.ts` + `web/lib/schemas/` | Zod-based request body validation for API routes (`parseJson` helper + per-route schemas) |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |


### PR DESCRIPTION
## Summary

Daily harness-doc audit covering merges since the 2026-04-19 audit (`6dd371c..baac1ca`, 10 PRs).

## Commits Reviewed

| PR | Subject | Doc-impacting? |
|----|---------|----------------|
| #436 | feat: replace Makefile with Justfile | already documented (COMMANDS.md, TESTING.md, AGENTS.md) |
| #437 | retro: review-permission-gates skill, allowlist, mcp dir creation | already documented (CLAUDE.md skill list, AGENTS.md) |
| #438 | docs: scrub stale make references | self-documenting |
| #439 | chore: consolidate config constants | already documented (CODE_ORGANIZATION.md) |
| #440 | feat: add Zod validation layer for API route inputs | **needed docs** — added `validate.ts` + `lib/schemas/` |
| #441 | refactor: make DataTable generic | covered by existing FRONTEND.md DataTable description |
| #442 | feat: standardize player UI components | already documented (FRONTEND.md) |
| #443 | refactor: split arb-progress server component | **needed docs** — added `lib/arb-progress.ts` |
| #444 | test: unit coverage for auth/session/data/scoring/vorp/surplus | covered by general `web/__tests__/` mention |
| #445 | retro: add test-web-file recipe | already documented (COMMANDS.md, TESTING.md) |

## Schema Doc Check

- Latest migration is `021_drop_player_stats_raw_columns.sql` (no new migrations since last audit).
- `docs/generated/db-schema.md` already reflects 17 tables and the trimmed `player_stats` columns from migration 021. **No drift; no edits needed.**

## Changes Made

- **`docs/CODE_ORGANIZATION.md`** — added two rows to the key file locations table:
  - `web/lib/arb-progress.ts` — pure transforms for the `/arb-progress` page (introduced by #443).
  - `web/lib/validate.ts` + `web/lib/schemas/` — Zod request body validation layer (introduced by #440).
- **`docs/ARCHITECTURE.md`** — new "API Request Validation" subsection under *Authentication & Authorization* describing the `parseJson(req, schema)` + per-resource schema pattern, so future API routes follow the same convention instead of hand-parsing `req.json()`.

## Items Flagged for Human Follow-up

None — referenced file paths still exist, COMMANDS.md `just` recipes all map to live targets in `Justfile`, and every skill name in CLAUDE.md's Documentation Map has a corresponding file under `.claude/commands/`.

## Test plan

- [ ] `just check-docs` passes
- [ ] Render `docs/CODE_ORGANIZATION.md` and `docs/ARCHITECTURE.md` and confirm tables/sections render cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLWeDmLFkBR9qipxJK5ACT)_