### PR TITLE
docs: daily harness audit 2026-04-27

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Comprehensive database and analytics platform for Ottoneu Fantasy Football Leagu
 - **Git workflow:** See [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md) for branch and PR requirements
 - **Domain rules:** See [docs/references/ottoneu-rules.md](docs/references/ottoneu-rules.md) for scoring, roster, salary cap, and arbitration
 - **Environment:** See [docs/references/environment-variables.md](docs/references/environment-variables.md) for `.env` setup
-- **Market Projections:** See [docs/exec-plans/market-projections.md](docs/exec-plans/market-projections.md) for the market-based projection system implementation plan
+- **Market Projections (DEFERRED):** See [docs/exec-plans/market-projections.md](docs/exec-plans/market-projections.md) — deprioritized 2026-03-17, retained as a future direction.
 
 ## Documentation Map
 
@@ -37,7 +37,7 @@ docs/
 ├── TESTING.md                         # Python + web test setup and CI
 ├── exec-plans/
 │   ├── [feature-projections.md](docs/exec-plans/feature-projections.md)         # Feature-based player projection system
-│   ├── [market-projections.md](docs/exec-plans/market-projections.md)          # Market-based projection system implementation plan
+│   ├── [market-projections.md](docs/exec-plans/market-projections.md)          # Market-based projection system (DEFERRED)
 │   ├── [projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md)  # 4-phase accuracy improvement roadmap
 │   └── [qb-usage-share.md](docs/exec-plans/qb-usage-share.md)              # QB Usage Share findings and next steps
 ├── generated/

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -12,6 +12,7 @@
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| API validation | `web/lib/validate.ts` | Shared `parseJson(req, ZodSchema)` helper for API route inputs (returns 400 with Zod issues on failure) |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |


### PR DESCRIPTION
## Summary

Daily harness documentation audit. No commits in the last 25 hours (most recent merge was on 2026-04-19, 8 days ago); did a lighter sweep for drift and found two real issues.

## Commits reviewed

`git log --since="25 hours ago" origin/main` returned zero commits. Audit cross-referenced docs against the most recent merges (all 2026-04-19, after the previous daily audit at PR #435):

- #436 Replace Makefile with Justfile
- #437 retro: permission gates, review-permission-gates skill
- #438 docs: scrub stale make references
- #439 chore: consolidate config constants
- #440 feat: add Zod validation layer for API route inputs
- #441 refactor: make DataTable generic
- #442 feat: standardize player UI components across all tables
- #443 refactor: split arb-progress server component
- #444 test: add unit coverage to auth/session/data/scoring/vorp/surplus
- #445 retro: add test-web-file recipe for single-file Jest runs

## Changes made

1. **`AGENTS.md` market-projections drift** — Two references described `docs/exec-plans/market-projections.md` as the active "implementation plan", but the doc itself has been marked DEFERRED since 2026-03-17 and `CLAUDE.md` already reflects this. Updated both AGENTS.md callouts (Quick Reference + Documentation Map) to match.
2. **`docs/CODE_ORGANIZATION.md` missing entry** — `web/lib/validate.ts` was added in #440 but not documented in the Key File Locations table. Added a row pointing at the `parseJson(req, ZodSchema)` helper so agents touching API routes find it.

## Schema audit

Cross-referenced `docs/generated/db-schema.md` against `schema.sql` and `migrations/` (highest migration is `021_drop_player_stats_raw_columns.sql`, no new migrations since the previous audit). Schema doc is accurate: 17 tables match, `player_stats` raw NFL columns correctly noted as removed in migration 021, `nfl_stats` column list matches reality including `passing_attempts`, `completions`, `recent_team`. No drift.

## Other checks (clean)

- All skill files referenced in CLAUDE.md Documentation Map exist in `.claude/commands/`.
- All `just` recipes referenced in `docs/COMMANDS.md` exist in `Justfile`.
- Routes table in `docs/FRONTEND.md` matches `web/app/` directory listing.
- Page paths in AGENTS.md "Projection Model Update Requirements" still resolve.
- No residual `make <target>` references in harness docs (only the verb).

## Items flagged for human follow-up

None.

## Test plan

- [x] `git diff` reviewed — only doc edits.
- [x] No code changes; tests not required.

https://claude.ai/code/session_019y8eghQNBMPK79LjniqnfU

---
_Generated by [Claude Code](https://claude.ai/code/session_019y8eghQNBMPK79LjniqnfU)_