### PR TITLE
docs: daily harness audit 2026-04-28

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ These rules are mechanically enforced by structural tests in `scripts/tests/test
 - **Frontend layers:** `web/lib/` must NOT import from `web/components/`. Flow: types → config → lib → components → pages.
 - **Shared types:** Define interfaces in `web/lib/types.ts`, not in component files.
 - **No wildcard imports:** Use explicit named imports (`from module import X, Y`).
+- **API input validation:** Validate POST/PUT/PATCH JSON bodies in API routes using Zod schemas under `web/lib/schemas/` and the `parseJson()` helper in `web/lib/validate.ts`. Don't hand-roll body parsing in route handlers.
 - **Documentation exists:** All docs referenced in this file must exist and have content.
 
 Run `just check-arch` to validate these rules locally.

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -10,7 +10,8 @@
 | TS types | `web/lib/types.ts` | All shared TypeScript interfaces (`CorePlayer → RosteredPlayer → StatsPlayer → Player`) |
 | Data layer | `web/lib/data.ts` | **Unified data access** — all Supabase fetching goes through here |
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
-| Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
+| Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `web/lib/data.ts`) |
+| API validation | `web/lib/validate.ts`, `web/lib/schemas/` | Zod schemas + `parseJson()` helper used by API routes for input validation |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
@@ -41,7 +42,7 @@ When adding a new shared key, update three places:
 3. `web/lib/config.ts` — add `export const CONSTANT = config.KEY`
 
 Drift is caught mechanically by architecture tests:
-- `scripts/tests/test_architecture.py::TestConfigSync` — asserts every `config.json` key is consumed in both `config.py` and `config.ts`, and that neither references a nonexistent key.
+- `scripts/tests/test_architecture.py::TestConfigSync` — asserts every `config.json` key is consumed in both `scripts/config.py` and `web/lib/config.ts`, and that neither references a nonexistent key.
 - `web/__tests__/lib/architecture.test.ts::Config JSON Sync` — asserts the TypeScript module's *exported values* match `config.json` (not just key presence).
 
 ## Path Setup for New Python Scripts


### PR DESCRIPTION
## Summary

Daily harness documentation audit. No commits in the last 25 hours, but the previous audit (#435, 2026-04-19) preceded a batch of merges from the same day that added behaviors not yet reflected in agent docs. Did a lighter sweep focused on those.

## Commits reviewed (since the previous audit)

- #436 feat: replace Makefile with Justfile
- #437 retro: review-permission-gates skill
- #438 docs: scrub stale make references
- #439 chore: consolidate config constants and enforce value-equality sync
- #440 feat: add Zod validation layer for API route inputs (#432)
- #441 refactor: make DataTable generic; drop wildcard index signatures
- #442 feat: standardize player UI components across all tables
- #443 refactor: split arb-progress server component
- #444 test: add unit coverage to auth/session/data/scoring/vorp/surplus
- #445 retro: add test-web-file recipe for single-file Jest runs

## Changes

- **`docs/CODE_ORGANIZATION.md`**: Added a row for the new Zod validation layer (`web/lib/validate.ts`, `web/lib/schemas/`) introduced in #440. Replaced bare `data.ts` / `config.py` / `config.ts` references with full paths so `check_docs_freshness.py` no longer flags them as missing files (the regex matches bare backticked paths against the repo root).
- **`AGENTS.md`**: Added an Architectural Rule directing agents to validate API route bodies via the `parseJson()` helper + `web/lib/schemas/` rather than hand-rolling parsing.

## Schema check

- Latest migration is `migrations/021_drop_player_stats_raw_columns.sql` — already reflected in `docs/generated/db-schema.md` (line 58, table count = 17). No drift.
- All 17 tables in the schema doc match the migration history. No changes needed.

## Verification

- `python3 scripts/check_docs_freshness.py` — was 5 issues, now 2 (the orphan items below).
- All skills referenced in `CLAUDE.md` Documentation Map exist in `.claude/commands/`.
- All routes/components in `docs/FRONTEND.md` match `web/app/` and `web/components/`.
- Justfile recipes referenced in `docs/COMMANDS.md` all exist in the `Justfile`.

## Flagged for human follow-up

Two orphan files in `docs/superpowers/` are flagged by `check_docs_freshness.py`:

- `docs/superpowers/plans/2026-04-19-build-system-just.md`
- `docs/superpowers/specs/2026-04-19-build-system-design.md`

These are completed planning artifacts for the Justfile migration (#436). They aren't referenced in AGENTS.md or CLAUDE.md. Decide whether to delete them or add a link in the docs map — I left them untouched since deleting planning docs autonomously felt out of scope for an audit.

## Test plan

- [x] `python3 scripts/check_docs_freshness.py` runs clean apart from the two orphan superpowers docs flagged above
- [x] Zod validation row in CODE_ORGANIZATION.md points at files that exist (`web/lib/validate.ts`, `web/lib/schemas/`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GziKvybVVTxeAigjhSpD4e)_