### PR TITLE
docs: daily harness audit 2026-04-29

### DIFF
--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -12,6 +12,8 @@
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| API input schemas | `web/lib/schemas/` | Zod schemas for API route request bodies (admin/users, arbitration-plans, surplus-adjustments) |
+| Request validation | `web/lib/validate.ts` | `parseJson(req, schema)` helper — parses and validates request bodies, returns typed data or a 400 response |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -30,6 +30,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | Component | Purpose |
 |-----------|---------|
 | `Navigation.tsx` | Shared nav bar across all pages |
+| `GlobalPlayerSearch` | Header-wide player search (focus with `/`, navigates to `/players/[ottoneu_id]`) |
 | `DataTable` | Generic sortable table with type safety and highlight rules |
 | `SummaryCard` | Metric display cards with variant styles (default, positive, negative) |
 | `PositionFilter` | Position selection buttons with multi-select support |


### PR DESCRIPTION
## Summary

Daily audit of harness docs (CLAUDE.md, AGENTS.md, docs/**, .claude/commands/**). No new commits on `origin/main` in the last 25 hours, so this was a lighter sweep for drift.

## Commits reviewed

Last audit was #435 on 2026-04-19. Reviewed all merges since:

- #445 retro: add test-web-file recipe — already documented in COMMANDS.md and TESTING.md
- #444 test: add unit coverage — internal, no doc impact
- #443 refactor: split arb-progress server component — internal, no doc impact
- #442 feat: standardize player UI components — already documented in FRONTEND.md
- #440 feat: **add Zod validation layer for API route inputs** — new `web/lib/schemas/` and `web/lib/validate.ts` not in CODE_ORGANIZATION.md ⚠️
- #441 refactor: make DataTable generic — already documented (DataTable entry in FRONTEND.md)
- #439 chore: consolidate config constants — already documented in CODE_ORGANIZATION.md
- #438 docs: scrub stale make references — done
- #437/#436 retro / Justfile migration — already reflected in COMMANDS.md / TESTING.md
- #410 (older) feat: **add global player search to header** — `GlobalPlayerSearch` component not in FRONTEND.md ⚠️

## Schema doc check

- No new migrations (still at `021_drop_player_stats_raw_columns.sql`).
- `docs/generated/db-schema.md` table list (17 tables) cross-checked against `schema.sql` — all tables present, columns and FK descriptions match.

## Changes made

- **`docs/CODE_ORGANIZATION.md`** — added `web/lib/schemas/` (Zod input schemas) and `web/lib/validate.ts` (`parseJson` helper) to the key file locations table.
- **`docs/FRONTEND.md`** — added `GlobalPlayerSearch` (header-wide player search, `/` to focus) to the reusable components table.

## Items flagged for human follow-up

None blocking. Minor optional items:

- `web/components/PlayerSearch.tsx`, `PositionTierBreakdown.tsx`, `ProjectionYearSelector.tsx`, `ModeToggle.tsx`, `NavigationWrapper.tsx` are page-specific or trivial wrappers — left undocumented intentionally to keep FRONTEND.md focused on cross-page reusables. Flag if you want them included.
- `docs/superpowers/{plans,specs}/2026-04-19-build-system-*.md` are work artifacts from the completed Justfile migration. They aren't referenced from the doc map. Consider archiving or noting in CLAUDE.md/AGENTS.md doc map if they are intended to persist.

## Test plan

- [x] `git diff` reviewed — only doc table additions, no structural changes
- [x] Verified `web/lib/schemas/` and `web/lib/validate.ts` exist on disk
- [x] Verified `GlobalPlayerSearch.tsx` `/` keybind and `/players/[ottoneu_id]` navigation behavior in source
- [x] `docs/generated/db-schema.md` cross-referenced against `schema.sql` (17 tables, no drift)

https://claude.ai/code/session_01WwjMGFLfHnzhbN7qrNHi2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwjMGFLfHnzhbN7qrNHi2o)_