### PR TITLE
docs: daily harness audit 2026-04-30

### DIFF
--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -12,6 +12,7 @@
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| API validation | `web/lib/validate.ts` + `web/lib/schemas/` | Zod-based request-body validation for API routes (`parseJson` helper + per-route schemas) |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |
@@ -65,3 +66,21 @@ if repo_root not in sys.path:
 - **`repo_root`** (project root) — resolves `from scripts.feature_projections.features import ...`
 
 Both are required. Only adding `script_dir` causes `ModuleNotFoundError: No module named 'scripts'`. See scripts/feature_projections/cli.py for the canonical example.
+
+## API Route Input Validation (`web/lib/validate.ts`, `web/lib/schemas/`)
+
+API route handlers under `web/app/api/` validate request bodies through a shared Zod-based helper instead of hand-rolled checks:
+
+```typescript
+import { parseJson } from "@/lib/validate";
+import { CreatePlanSchema } from "@/lib/schemas/arbitration-plan";
+
+const parsed = await parseJson(req, CreatePlanSchema);
+if (!parsed.ok) return parsed.response;  // 400 with Zod issues array
+const { name, notes } = parsed.data;     // typed via z.infer
+```
+
+- `web/lib/validate.ts` — `parseJson(req, schema)` returns `{ ok: true, data }` or `{ ok: false, response }` (400 with `issues` array on malformed JSON or schema failure).
+- `web/lib/schemas/` — one file per resource (`web/lib/schemas/arbitration-plan.ts`, `web/lib/schemas/surplus-adjustment.ts`, `web/lib/schemas/user.ts`). Each exports the schema and a `z.infer`-derived input type.
+
+When adding a new POST/PATCH/PUT route, add a schema in `web/lib/schemas/` rather than inlining `if (typeof x !== "string") …` checks in the route file.


### PR DESCRIPTION
## Summary

Daily harness-doc audit covering 11 commits merged since the last audit (#435 on 2026-04-19).

## Commits reviewed

- baac1ca retro: add `test-web-file` recipe (#445)
- f2fd15f test: add unit coverage to auth/session/data/scoring/vorp/surplus (#444)
- 8f50cbc refactor: split arb-progress server component (#443)
- 6dd3f53 feat: standardize player UI components across all tables (#442)
- 5659e4f feat: add Zod validation layer for API route inputs (#440)
- 4787602 refactor: make DataTable generic; drop wildcard index signatures (#441)
- 14a441a chore: consolidate config constants and enforce value-equality sync (#439)
- 899454e docs: scrub stale make references missed by Justfile migration (#438)
- f1e5cbb retro: permission gates, coverage flags, mcp dir creation, review-permission-gates skill (#437)
- 81ffe2c feat: replace Makefile with Justfile (#436)
- efd52e8 fix: null-guard arbitration plan lookups (#429)

## Changes made

**`docs/CODE_ORGANIZATION.md`** — document the Zod validation layer added in #440:
- New row in the Key File Locations table for `web/lib/validate.ts` + `web/lib/schemas/`
- New "API Route Input Validation" section with the `parseJson(req, schema)` usage pattern, the three current schema files, and guidance to add a schema rather than hand-rolling type checks when introducing a POST/PATCH/PUT route.

This was the only meaningful drift. Other PRs in the window either (a) updated docs as part of the change (#436 Justfile → COMMANDS/TESTING, #437 retro skill → CLAUDE/AGENTS, #438 stale make refs, #439 config sync → CODE_ORGANIZATION, #442 player components → FRONTEND, #445 `test-web-file` → COMMANDS/TESTING) or (b) were internal refactors with no doc impact (#441 generic DataTable, #443 arb-progress component split, #444 test coverage additions, #429 null guard).

## Schema check

- `migrations/` directory unchanged since last audit (last addition: `021_drop_player_stats_raw_columns.sql`, predates #435).
- `docs/generated/db-schema.md` matches `schema.sql`: 17 tables, all listed correctly.
- No drift to fix.

## Items flagged for human follow-up

- `python scripts/check_docs_freshness.py` continues to warn about three pre-existing bare-basename references in `CODE_ORGANIZATION.md` prose (`data.ts`, `config.py`, `config.ts`) and two orphan files under `docs/superpowers/` (build-system migration plan/spec from #436). These are pre-existing — not introduced or made worse by this audit — and unclear whether the orphans should be linked from AGENTS.md or deleted now that the migration is complete.

## Test plan

- [ ] `python scripts/check_docs_freshness.py` issue count unchanged from baseline (5 pre-existing warnings)
- [ ] `just check-arch` passes

https://claude.ai/code/session_01UwaMCcx7sP4oexJLPDdpui

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwaMCcx7sP4oexJLPDdpui)_