### PR TITLE
docs: daily harness audit 2026-05-01

### DIFF
--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -12,6 +12,7 @@
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| API input validation | `web/lib/validate.ts` + `web/lib/schemas/` | `parseJson(req, Schema)` helper plus per-resource Zod schemas (`user`, `arbitration-plan`, `surplus-adjustment`); used by every mutating API route |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -61,6 +61,21 @@ Shared type definitions in `web/lib/types.ts`:
 
 Analysis math is ported to `web/lib/analysis.ts` (TS equivalent of `scripts/analysis_utils.py`). Arbitration simulation logic lives in `web/lib/arb-logic.ts`.
 
+## API Request Validation
+
+Mutating API routes (`web/app/api/**/route.ts`) validate JSON bodies via the shared `parseJson` helper in `web/lib/validate.ts`, paired with a Zod schema from `web/lib/schemas/`:
+
+```typescript
+import { parseJson } from "@/lib/validate";
+import { CreatePlanSchema } from "@/lib/schemas/arbitration-plan";
+
+const parsed = await parseJson(req, CreatePlanSchema);
+if (!parsed.ok) return parsed.response; // 400 with Zod issues[]
+const data = parsed.data;               // typed via z.infer
+```
+
+`parseJson` returns either `{ ok: true, data }` (typed) or `{ ok: false, response }` (a 400 carrying Zod's `issues` array). New mutating routes should add a schema under `web/lib/schemas/` rather than hand-rolling `if (!body.x)` checks.
+
 ## Configuration
 
 Frontend constants in `web/lib/config.ts` — **must stay in sync with `scripts/config.py`**.


### PR DESCRIPTION
## Summary

Daily audit of harness documentation. One drift item found and fixed: the Zod-based API request validation layer added in #432/#440 (commit `5659e4f`) was wired into every mutating API route but never made it into the harness docs, so a new agent touching an API route had no signal that the `parseJson` + Zod-schema pattern was the established convention.

## Commits reviewed

`git log --since="25 hours ago" origin/main` returned **0 commits** today, so this was a lighter sweep covering the post-audit window since the previous run (#435, 2026-04-19 10:26 PT). Commits inspected:

- `baac1ca` retro: add `test-web-file` recipe — already in `COMMANDS.md` / `TESTING.md`. ✓
- `f2fd15f` test: add unit coverage to auth/session/data/scoring/vorp/surplus — pure test additions, no doc impact. ✓
- `8f50cbc` refactor: split arb-progress server component — internal page-level refactor, no harness-doc surface. ✓
- `6dd3f53` feat: standardize player UI components — `FRONTEND.md` already updated in that PR. ✓
- `5659e4f` feat: **Zod validation layer for API route inputs** — **NOT documented anywhere**. Fixed here.
- `4787602` refactor: make `DataTable` generic — `FRONTEND.md` description ("Generic sortable table with type safety…") already matches. ✓
- `14a441a` chore: consolidate config constants — `CODE_ORGANIZATION.md` updated in that PR. ✓
- `899454e` docs: scrub stale make references — already merged. ✓
- `81ffe2c` feat: replace Makefile with Justfile — `COMMANDS.md` already migrated. ✓

## Changes made

- **`docs/CODE_ORGANIZATION.md`** — added `web/lib/validate.ts` + `web/lib/schemas/` to the key-file table, calling out the per-resource schemas (`user`, `arbitration-plan`, `surplus-adjustment`).
- **`docs/FRONTEND.md`** — added an "API Request Validation" section showing the `parseJson(req, Schema)` usage pattern and naming `web/lib/schemas/` as the home for new schemas, so future agents add a Zod schema instead of hand-rolling `if (!body.x)` checks.

## Schema doc

`docs/generated/db-schema.md` still matches reality:
- doc says "Seventeen tables" → `schema.sql` has 17 `CREATE TABLE` statements ✓
- highest migration is `021_drop_player_stats_raw_columns.sql`, already reflected in the `player_stats` columns note ✓
- no new migration files since the last audit ✓

## Other checks

- All paths in CLAUDE.md / AGENTS.md Documentation Maps resolve. ✓
- All scripts referenced in `COMMANDS.md` exist under `scripts/`. ✓
- All 13 skills listed in CLAUDE.md exist under `.claude/commands/`. ✓
- All `web/app/` routes match the table in `FRONTEND.md`. ✓

## Items flagged for human follow-up

None. `docs/superpowers/{plans,specs}/` contains the 2026-04-19 build-system planning artifacts; not surfaced in the Documentation Map but they read as one-off design notes rather than ongoing harness docs, so leaving as-is.

## Test plan

- [ ] Verify no regressions in `just check-docs` (docs-only change; no code paths touched)

https://claude.ai/code/session_01A6ViG3zm1WQPYyPXngyvpQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6ViG3zm1WQPYyPXngyvpQ)_