### PR TITLE
docs: daily harness audit 2026-05-02

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,8 +23,9 @@ Python Scripts (scripts/)
 
 Uses a worker-based job queue. `scripts/enqueue.py` inserts jobs into the `scraper_jobs` table in Supabase. `scripts/worker.py` polls the queue, dispatches tasks, and manages a shared Playwright browser.
 
-Three task types:
+Four task types (defined in `scripts/tasks/__init__.py`):
 - `pull_nfl_stats` — sync, loads snap counts via `nfl_data_py`
+- `pull_player_stats` — sync, loads multi-season aggregated stats from the nflverse-data `stats_player` parquet release (used for backfill/historical pulls)
 - `scrape_roster` — async, scrapes one position from Ottoneu search page
 - `scrape_player_card` — async, scrapes FA transaction history for real salary
 

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -12,6 +12,8 @@
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| Arb-progress helpers | `web/lib/arb-progress.ts` | Pure transforms for `/arb-progress` server component (allocations, raises, team spending) |
+| API input validation | `web/lib/validate.ts` + `web/lib/schemas/` | `parseJson` helper + Zod schemas for API route bodies (returns typed result or 400 with Zod issues) |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -29,6 +29,7 @@ python scripts/enqueue.py batch                      # Enqueue full pipeline (NF
 python scripts/enqueue.py roster --position QB       # Enqueue single position scrape
 python scripts/enqueue.py player --ottoneu-id 6771 --name "Josh Allen" --player-uuid <uuid>  # Enqueue single player card scrape
 python scripts/enqueue.py nfl-stats                  # Enqueue NFL stats pull only
+python scripts/enqueue.py player-stats --seasons 2022 2023 2024  # Enqueue historical player_stats pull (nflverse parquet)
 python scripts/enqueue.py status                     # Show recent job statuses
 python scripts/worker.py                             # Process pending scraper jobs (exit when done)
 python scripts/worker.py --poll                      # Process jobs continuously (for scheduling)


### PR DESCRIPTION
## Summary

Daily harness-doc audit. The `git log --since="25 hours ago"` window was empty (last commit on `main` was 2026-04-19), so this is a lighter sweep against everything merged since the previous audit (#435). All checks below; only three small drift items needed edits.

## Commits reviewed (since #435 / 6dd371c)

- baac1ca — retro: add `test-web-file` Justfile recipe (#445)
- f2fd15f — test: add unit coverage to auth/session/data/scoring/vorp/surplus (#444)
- 8f50cbc — refactor: split `arb-progress` server component into `web/lib/arb-progress.ts` + presentational components (#443)
- 6dd3f53 — feat: standardize player UI components across all tables (#442)
- 5659e4f — feat: add Zod validation layer for API route inputs at `web/lib/validate.ts` + `web/lib/schemas/` (#440)
- 4787602 — refactor: make `DataTable` generic (#441)
- 14a441a — chore: consolidate config constants and enforce value-equality sync (#439)
- 899454e — docs: scrub stale make references missed by Justfile migration (#438)
- f1e5cbb — retro: register `review-permission-gates` skill (#437)
- 81ffe2c — feat: replace Makefile with Justfile (#436)

## Changes made

- **`docs/ARCHITECTURE.md`** — Data Pipeline section said "three task types" but `scripts/tasks/__init__.py` defines four (`ALL_TASK_TYPES = [PULL_NFL_STATS, PULL_PLAYER_STATS, SCRAPE_ROSTER, SCRAPE_PLAYER_CARD]`). Added `pull_player_stats` (sync, nflverse-data `stats_player` parquet, used for backfill/historical pulls).
- **`docs/COMMANDS.md`** — Added `python scripts/enqueue.py player-stats --seasons …` to the Backend section. The subparser exists in `scripts/enqueue.py` but wasn't listed alongside the other enqueue verbs.
- **`docs/CODE_ORGANIZATION.md`** — Added two Key File Locations rows:
  - `web/lib/arb-progress.ts` — pure transforms extracted from `arb-progress/page.tsx` in #443.
  - `web/lib/validate.ts` + `web/lib/schemas/` — Zod request-body validation layer introduced in #440.

## Schema doc (HIGHEST PRIORITY)

Cross-referenced `docs/generated/db-schema.md` against `migrations/` (001–021) and `schema.sql`:
- 17 tables in doc, 17 `CREATE TABLE` statements in `schema.sql`. ✓
- `player_stats` columns match post-migration-021 reality (raw NFL stat columns dropped). ✓
- `nfl_stats` columns include `passing_attempts`, `completions` (017), and `recent_team` (018). ✓
- `arbitration_allocation_details` (020) is documented. ✓

**No drift.**

## Other checks (clean)

- All file paths referenced in CLAUDE.md / AGENTS.md / docs Documentation Map exist.
- All 13 skill files in `.claude/commands/` match the list in CLAUDE.md.
- All routes in `docs/FRONTEND.md` match directories under `web/app/`.
- All `just` recipes in `docs/COMMANDS.md` (incl. `test-web-file`) match `Justfile`.

## Items flagged for human follow-up

None. Doc set is in good shape after the recent flurry of merges; the active maintainers' own retro PRs (#437, #438, #445) caught most drift before this audit landed.

## Test plan

- [x] `git diff` reviewed — three additive doc changes, no removals.
- [ ] CI doc-freshness check passes (`just check-docs`).

https://claude.ai/code/session_01Bba1oNSJctvnyNTcvqkqkb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bba1oNSJctvnyNTcvqkqkb)_