### PR TITLE
docs: daily harness audit 2026-05-03

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,6 +64,7 @@ All web data fetching goes through `web/lib/data.ts` — the single source of tr
 - **Type hierarchy:** `CorePlayer → RosteredPlayer → StatsPlayer → Player` — each layer adds data from a different source (players table → league_prices → player_stats).
 - **Calculations are TypeScript-only:** VORP, surplus, arbitration, and projected salary are computed in `web/lib/` and are the canonical implementations.
 - **Scoring formula:** `web/lib/scoring.ts` provides `calculateFantasyPoints()` — the Ottoneu Half PPR formula as a pure function of raw NFL stats.
+- **API input validation:** Route handlers under `web/app/api/` validate JSON bodies via `parseJson(req, schema)` from `web/lib/validate.ts`, with per-resource Zod schemas in `web/lib/schemas/`. On failure the helper returns a 400 with Zod's `issues` array; on success it returns the typed, parsed data.
 
 ### Key Metrics
 

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -12,10 +12,13 @@
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| API validation | `web/lib/validate.ts` | `parseJson(req, schema)` helper used by every API route |
+| Zod schemas | `web/lib/schemas/` | Per-resource Zod request schemas (user, arbitration-plan, surplus-adjustment) |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |
 | Pages | `web/app/` | Next.js App Router pages |
+| API routes | `web/app/api/` | Next.js route handlers (admin, arbitration-plans, auth, surplus-adjustments) |
 | Feature projections | `scripts/feature_projections/` | Feature-based projection system (features, combiner, runner, backtest, CLI) |
 | Data files | `data/` | Manual config data (QB starters, etc.) |
 | CI/CD | `.github/workflows/` | GitHub Actions (tests, scraping, projections) |


### PR DESCRIPTION
## Summary

Daily audit of harness documentation. Last audit: 2026-04-19 (#435). Reviewed 10 commits merged after that audit on 2026-04-19 and surfaced one real gap: the Zod-based API input validation layer added in #440 was not mentioned in any harness doc.

### Commits reviewed (6dd371c..baac1ca)

- `baac1ca` retro: add `test-web-file` recipe (#445) — already documented in COMMANDS.md/TESTING.md
- `f2fd15f` test: unit coverage for auth/session/data/scoring/vorp/surplus (#444) — no doc impact
- `8f50cbc` refactor: split arb-progress server component (#443) — internal-only refactor; route already documented
- `6dd3f53` feat: standardize player UI components (#442) — FRONTEND.md already updated in that PR
- `5659e4f` feat: Zod validation layer for API routes (#440) — **gap, addressed below**
- `4787602` refactor: generic DataTable (#441) — FRONTEND.md already updated
- `14a441a` chore: consolidate config constants (#439) — CODE_ORGANIZATION.md already updated
- `899454e` docs: scrub stale make references (#438) — doc-only follow-up to Justfile migration
- `f1e5cbb` retro: review-permission-gates skill, etc. (#437) — already in CLAUDE.md skills list
- `81ffe2c` feat: replace Makefile with Justfile (#436) — COMMANDS.md/TESTING.md already updated

### Schema check

No new files in `migrations/` since the last audit (still 21 numbered migrations, latest `021_drop_player_stats_raw_columns.sql`). `docs/generated/db-schema.md` matches reality — no edits needed.

### Other checks (all clean)

- All file paths referenced in CLAUDE.md / AGENTS.md / docs exist on disk.
- All skills listed in CLAUDE.md's Documentation Map have a matching `.claude/commands/*.md` file (13/13).
- `docs/COMMANDS.md` `just` recipes match `Justfile` recipes; all `python scripts/...` paths resolve.
- All routes listed in FRONTEND.md exist under `web/app/`.

## Changes made

- **`docs/ARCHITECTURE.md`** — Added a bullet to the Web Data Access Layer section documenting the `parseJson(req, schema)` helper from `web/lib/validate.ts` and the per-resource Zod schemas in `web/lib/schemas/`.
- **`docs/CODE_ORGANIZATION.md`** — Added rows to the Key File Locations table for `web/lib/validate.ts`, `web/lib/schemas/`, and `web/app/api/` so agents can find the canonical API input validation pattern.

## Items flagged for human follow-up

None. All other deltas were already covered by the doc-aware PRs that introduced them.

## Test plan

- [ ] Doc-only change; CI doc freshness check should still pass.

https://claude.ai/code/session_017ptR9oPSuoCBKRXq3P2M8R

---
_Generated by [Claude Code](https://claude.ai/code/session_017ptR9oPSuoCBKRXq3P2M8R)_