### PR TITLE
docs: daily harness audit 2026-05-04

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,6 +64,7 @@ All web data fetching goes through `web/lib/data.ts` — the single source of tr
 - **Type hierarchy:** `CorePlayer → RosteredPlayer → StatsPlayer → Player` — each layer adds data from a different source (players table → league_prices → player_stats).
 - **Calculations are TypeScript-only:** VORP, surplus, arbitration, and projected salary are computed in `web/lib/` and are the canonical implementations.
 - **Scoring formula:** `web/lib/scoring.ts` provides `calculateFantasyPoints()` — the Ottoneu Half PPR formula as a pure function of raw NFL stats.
+- **API input validation:** Write-side routes parse JSON via `parseJson()` (`web/lib/validate.ts`) against Zod schemas in `web/lib/schemas/`. Invalid bodies short-circuit with a 400 before any DB call. See [docs/FRONTEND.md](FRONTEND.md#api-input-validation).
 
 ### Key Metrics
 

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -12,6 +12,8 @@
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| Arb-progress transforms | `web/lib/arb-progress.ts` | Pure transforms used by the `/arb-progress` page (no DB/network) |
+| API input validation | `web/lib/validate.ts` + `web/lib/schemas/` | `parseJson()` helper + Zod schemas for write-side API routes |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -50,6 +50,21 @@ const columns = [...corePlayerCols({ hoverDataMap }), salaryCol(), ppgCol("Proj 
 
 Static column arrays (no React components) remain in `web/lib/columns.ts` for backward compatibility.
 
+## API Input Validation
+
+Write-side API routes (`web/app/api/**/route.ts`) validate JSON bodies with Zod before touching the database. The shared helper `parseJson()` in `web/lib/validate.ts` returns either typed data or a 400 `NextResponse` with `issues[]`.
+
+```typescript
+import { parseJson } from "@/lib/validate";
+import { CreatePlanSchema } from "@/lib/schemas/arbitration-plan";
+
+const parsed = await parseJson(req, CreatePlanSchema);
+if (!parsed.ok) return parsed.response;
+const data = parsed.data; // typed as z.infer<typeof CreatePlanSchema>
+```
+
+Schemas live in `web/lib/schemas/` (one file per resource: `arbitration-plan.ts`, `surplus-adjustment.ts`, `user.ts`). Add a new schema file when adding a new write endpoint — do not inline schemas in route handlers.
+
 ## TypeScript Types
 
 Shared type definitions in `web/lib/types.ts`:


### PR DESCRIPTION
## Summary

Daily harness-doc audit. The previous audit (#435) ran on 2026-04-19; ten PRs landed after it on the same day, none today. This pass closes the documentation gap left by the Zod validation layer (#440) and the `arb-progress` server-component split (#443).

## Commits reviewed (since #435)

- #436 feat: replace Makefile with Justfile
- #437 retro: permission gates, coverage flags, mcp dir creation, review-permission-gates skill
- #438 docs: scrub stale make references missed by Justfile migration
- #439 chore: consolidate config constants and enforce value-equality sync
- #440 feat: add Zod validation layer for API route inputs
- #441 refactor: make DataTable generic; drop wildcard index signatures
- #442 feat: standardize player UI components across all tables
- #443 refactor: split arb-progress server component
- #444 test: add unit coverage to auth/session/data/scoring/vorp/surplus
- #445 retro: add test-web-file recipe for single-file Jest runs

## Changes made

- **`docs/CODE_ORGANIZATION.md`** — added rows for `web/lib/arb-progress.ts` (pure transforms for `/arb-progress`) and `web/lib/validate.ts` + `web/lib/schemas/` (Zod input validation) to the Key File Locations table.
- **`docs/FRONTEND.md`** — new "API Input Validation" section documenting the `parseJson()` helper pattern and the schemas-per-resource convention. All write-side routes under `web/app/api/` now use this; agents extending those routes need to know.
- **`docs/ARCHITECTURE.md`** — added a bullet under "Web Data Access Layer" linking to the FRONTEND.md section so the validation boundary is discoverable from the architecture doc.

## Schema doc

`docs/generated/db-schema.md` is current. No new migrations since #413/migration 021. Table count (17) and the `player_stats` raw-column-removal note both still match `schema.sql` and `migrations/`.

## Other checks

- All skill files referenced in `CLAUDE.md`'s Documentation Map exist in `.claude/commands/`.
- `Justfile` recipes referenced in `docs/COMMANDS.md` and `docs/TESTING.md` (including `test-web-file`) all resolve.
- `python scripts/check_docs_freshness.py` reports the same 5 pre-existing warnings before and after these edits — no new drift introduced.

## Flagged for human follow-up

The freshness check reports two orphan files not linked from `AGENTS.md` or `CLAUDE.md`:

- `docs/superpowers/plans/2026-04-19-build-system-just.md`
- `docs/superpowers/specs/2026-04-19-build-system-design.md`

These were added in #436 (Justfile migration). Worth deciding whether to link them from the docs map or move/delete them — out of scope for this audit since the call is editorial.

## Test plan

- [ ] `python scripts/check_docs_freshness.py` shows no new warnings vs main
- [ ] Links in the new FRONTEND.md anchor (`#api-input-validation`) and the ARCHITECTURE.md cross-link render correctly on GitHub

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Lc3rfNhLxRqeUkRWg7qX)_