### PR TITLE
docs: daily harness audit 2026-05-05

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,6 +84,10 @@ User accounts with email/password login stored in the `users` table. Passwords a
 - **User-scoped data:** `surplus_adjustments` and `arbitration_plans` are scoped to `user_id` — each user sees only their own data
 - **Admin panel** (`/admin`) allows admins to create users, toggle projections access, and delete users
 
+## API Input Validation
+
+All API route bodies are validated through Zod schemas in `web/lib/schemas/` (one file per resource: `arbitration-plan.ts`, `surplus-adjustment.ts`, `user.ts`). Routes call `parseJson(req, Schema)` from `web/lib/validate.ts`, which returns either `{ ok: true, data }` (typed via `z.infer`) or `{ ok: false, response }` — a 400 carrying Zod's `issues` array. Schemas enforce email normalization, the bcrypt 72-byte password ceiling, plan name/notes bounds, non-negative integer allocations, and finite (no NaN/Infinity) numeric adjustments. Add new validation by defining a schema in `web/lib/schemas/` and replacing hand-rolled checks with the helper.
+
 ## Feature Projection System (`scripts/feature_projections/`)
 
 Generates season-long player PPG projections from historical data using a combination of targeted features. The active production model (`v14_qb_starter`) uses:

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -12,6 +12,8 @@
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
+| API input schemas | `web/lib/schemas/` | Zod schemas for API route bodies (admin/users, arbitration-plans, surplus-adjustments) |
+| Request validation | `web/lib/validate.ts` | `parseJson(req, schema)` helper — returns typed data or a 400 response with Zod issues |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -17,7 +17,7 @@ Seventeen tables, all with UUID primary keys.
 | `arbitration_plans` | Named arbitration budget allocation plans per user (FK -> `users`) | `(league_id, name, user_id)` |
 | `arbitration_plan_allocations` | Per-player dollar allocations within a plan (FK -> `arbitration_plans`, `players`) | `(plan_id, player_id)` |
 | `scraper_jobs` | Persistent job queue with status tracking, dependencies, and retry logic | -- |
-| `projection_models` | Registry of versioned projection models (internal v1–v6 and external sources) | `(name, version)` |
+| `projection_models` | Registry of versioned projection models (internal feature-based v1–v21+ and external sources) | `(name, version)` |
 | `model_projections` | Per-model projected PPG with raw feature values (FK -> `projection_models`, `players`) | `(model_id, player_id, season)` |
 | `backtest_results` | Cached accuracy metrics per model × season × position (FK -> `projection_models`) | `(model_id, season, position)` |
 | `arbitration_progress` | Scraped player allocation data from Ottoneu arbitration page | -- |


### PR DESCRIPTION
## Summary

Daily harness-doc audit. Strict 25-hour window had zero commits, so this sweep covers the ten PRs merged after the previous audit (#435 on 2026-04-19): #436–#445.

### Commits reviewed
- **#436 / #438** Replace Makefile with Justfile, scrub stale `make` references — already reflected in COMMANDS.md
- **#437** Retro: permission gates + new `review-permission-gates` skill — skill already in `.claude/commands/`
- **#439** Consolidate config constants and enforce value-equality sync — CODE_ORGANIZATION.md was updated in the PR itself
- **#440** Add Zod validation layer for API route inputs — **gap filled here**
- **#441** Make DataTable generic; drop wildcard index signatures — FRONTEND.md already describes the generic component
- **#442** Standardize player UI components across all tables — FRONTEND.md was updated in the PR itself
- **#443** Split `arb-progress` server component — no harness-doc impact
- **#444** Add unit coverage to auth/session/data/scoring/vorp/surplus — TESTING.md description still accurate
- **#445** Add `test-web-file` recipe for single-file Jest runs — already reflected in COMMANDS.md and TESTING.md

### Changes made
- `docs/generated/db-schema.md` — refresh the `projection_models` row description: codebase is at v21+, not "internal v1–v6"
- `docs/CODE_ORGANIZATION.md` — add rows for `web/lib/schemas/` and `web/lib/validate.ts` so the new Zod validation surface is documented alongside the other shared TS modules
- `docs/ARCHITECTURE.md` — add a brief "API Input Validation" section between Authentication and Feature Projection System describing the `parseJson(req, Schema)` + Zod pattern

### Schema verification
Cross-referenced `docs/generated/db-schema.md` against `schema.sql`. All seventeen tables, FK relationships, unique constraints, and column lists for `player_stats` / `nfl_stats` match. Migration 021 (drop raw NFL columns from `player_stats`) is reflected. No new migrations since the last audit.

### Items flagged for human follow-up
- **`ACTIVE_MODEL` drift** between `scripts/update_projections.py` (`v12_no_qb_trajectory`) and `docs/ARCHITECTURE.md` line 89 (currently claims `v14_qb_starter`). `AGENTS.md` line 122 agrees with the Python constant. Pre-existing drift not caused by this audit's commits — leaving alone since the live `is_active` flag in the DB could match either, and a guess could mislead. Recommend the maintainer confirm which model is actually promoted and align the doc.
- **Skill files using raw Python invocations** — `.claude/commands/run-tests.md`, `run-scraper.md`, `run-analyses.md`, `start-dev.md`, `projection-accuracy.md` still call `python ...` directly instead of `just ...`. AGENTS.md says "Always use `just <recipe>`". Out of scope for a daily audit but worth a follow-up sweep.

## Test plan
- [x] `git diff --stat` — three docs changed, +7/-1
- [ ] No code changes; CI doc-freshness check should pass

https://claude.ai/code/session_01HPL4SgqwaKdZEdpNBoZTX3

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPL4SgqwaKdZEdpNBoZTX3)_