### PR TITLE
docs: daily harness audit 2026-05-06

### DIFF
--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -17,7 +17,7 @@ Seventeen tables, all with UUID primary keys.
 | `arbitration_plans` | Named arbitration budget allocation plans per user (FK -> `users`) | `(league_id, name, user_id)` |
 | `arbitration_plan_allocations` | Per-player dollar allocations within a plan (FK -> `arbitration_plans`, `players`) | `(plan_id, player_id)` |
 | `scraper_jobs` | Persistent job queue with status tracking, dependencies, and retry logic | -- |
-| `projection_models` | Registry of versioned projection models (internal feature-based v1–v21+ and external sources) | `(name, version)` |
+| `projection_models` | Registry of versioned projection models (internal feature-based v1–v22+ and external sources) | `(name, version)` |
 | `model_projections` | Per-model projected PPG with raw feature values (FK -> `projection_models`, `players`) | `(model_id, player_id, season)` |
 | `backtest_results` | Cached accuracy metrics per model × season × position (FK -> `projection_models`) | `(model_id, season, position)` |
 | `arbitration_progress` | Scraped player allocation data from Ottoneu arbitration page | -- |


### PR DESCRIPTION
## Summary

Daily harness-doc audit covering merges since 2026-05-05.

### Commits reviewed
- **#473** `feat: advanced receiving metrics from nflverse (#375)` — adds migration 022 (`target_share`, `air_yards_share`, `wopr`, `racr`, `receiving_air_yards` on `nfl_stats`), new `advanced_receiving.py` feature module, and the `v22_advanced_receiving` learned-ridge model. The authoring PR already updated `docs/generated/db-schema.md` (new columns), `docs/generated/experiment-log.md`, `docs/generated/projection-accuracy.md`, and `docs/exec-plans/projection-accuracy-improvement.md`.

### Changes in this PR
- `docs/generated/db-schema.md`: bump the `projection_models` row description from "v1–v21+" to "v1–v22+" so the model-registry summary matches the code in `scripts/feature_projections/model_config.py`.

### Schema verification
- `migrations/022_add_advanced_receiving_stats.sql` columns are all present in `db-schema.md` line 64. No drift.
- All 22 migrations accounted for, no orphan files.

### Items flagged for human follow-up (pre-existing drift, not introduced by #473)
1. **`docs/ARCHITECTURE.md:93`** still calls `v14_qb_starter` "the active production model." Since `v20_learned_usage` was marked `BEST` in #370 (and v22 is now the latest improvement), this claim is likely stale. Verifying which model has `is_active=true` in `projection_models` would be needed before updating.
2. **`docs/ARCHITECTURE.md:99`** model-history paragraph stops at v14. v15–v22 (snap_trend, rookie_growth, usage_level variants, learned ridge, tiered regression, advanced receiving) are not summarized.
3. **`AGENTS.md:122`** says `v12_no_qb_trajectory` is the "current active model" — older than the ARCHITECTURE.md claim. Both should converge once production active model is verified.

### Test plan
- [x] `git diff` reviewed — single one-line edit
- [x] No code or config touched
- [x] No referenced file paths broken


---
_Generated by [Claude Code](https://claude.ai/code/session_015BSFqirxPDqbfugeRJUkpb)_