### PR TITLE
docs: daily harness audit 2026-05-07

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,9 @@ Jobs support dependencies, retries (up to 3 attempts), and batch grouping. `otto
 
 ### NFL Stats (separate from Ottoneu data)
 
-`nfl_stats` stores pure NFL statistical data from nflverse-data (2010–present), kept separate from the Ottoneu fantasy data in `player_stats`. Backfilled via `scripts/backfill_nfl_stats.py` or the `Backfill NFL Stats` GitHub Action.
+`nfl_stats` stores pure NFL statistical data from nflverse-data (2010–present), kept separate from the Ottoneu fantasy data in `player_stats`. Backfilled via `scripts/backfill_nfl_stats.py` or the `Backfill NFL Stats` GitHub Action. Advanced receiving metrics (`target_share`, `air_yards_share`, `wopr`, `racr`, `receiving_air_yards` — added in migration 022) are populated for 2018+ via the same backfill from nflverse `stats_player`.
+
+Static draft-pick metadata lives in the `draft_capital` table (one row per drafted player, sourced from the nflverse `draft_picks` parquet via `scripts/backfill_draft_capital.py`, migration 023). It powers the `draft_capital_raw` feature for rookie/early-career projections.
 
 - **`player_stats`** = Ottoneu fantasy data (total_points, ppg, pps, snaps from scraping)
 - **`nfl_stats`** = Real NFL stats (passing_yards, rushing_tds, snap counts, etc. from nflverse)
@@ -105,10 +107,12 @@ model_config.py  →  runner.py  →  model_projections table  →  promote.py  
     (defines)        (computes)       (stores)                   (copies)        (production, used by web)
 ```
 
-- `model_config.py` — model registry (name, version, features, weights, is_baseline)
+- `model_config.py` — model registry (name, version, features, weights, is_baseline, `combiner_type`). Each model declares one of three combiners: `additive` (default — base PPG + weighted feature deltas), `learned` (Ridge regression with interactions, e.g. v20+/v22/v23), or `residual` (two-stage: a frozen base model + a tiny secondary Ridge fit to its residuals on a filtered training subset, e.g. v25 — see #376 follow-up).
 - `qb_starters.py` — loads manual QB starter designations from `data/qb_starters.json`, resolves names to player IDs
-- `runner.py` — fetches historical player_stats + nfl_stats, loads QB starters, runs combiner, batch upserts
-- `combiner.py` — base feature PPG + weighted sum of adjustment feature deltas
+- `runner.py` — fetches historical player_stats + nfl_stats, loads QB starters, runs the appropriate combiner, batch upserts. For `residual` models it evaluates the union of base + residual features and reuses the embedded base parameters.
+- `combiner.py` — additive combiner: base feature PPG + weighted sum of adjustment feature deltas
+- `learned_combiner.py` — learned (`combine_features_learned` / `predict`) and residual (`combine_features_residual` / `predict_residual`) combiners. The base model's `predict()` drops feature_values keys it wasn't trained on so a residual's superset of features doesn't break shape.
+- `train_model.py` — `train_ridge_loso` for full-refit learned models; `train_ridge_residual` loads the base model JSON, computes residuals on its predictions, applies a `training_filter` (e.g. `max_seasons_since_draft=3`), and fits a secondary Ridge with `fit_intercept=False` so samples whose residual features are all zero contribute exactly zero.
 - `backtest.py` — compares projected_ppg to actual actuals (MAE, RMSE per model)
 - `accuracy_report.py` — side-by-side model comparison table across all seasons (no `--models` filter; always runs all models)
 - `promote.py` — copies a model's projections to the production `player_projections` table and sets it as active

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -84,6 +84,11 @@ python scripts/feature_projections/feature_analysis.py --model v20_learned_usage
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025  # Residual distribution, heteroscedasticity, persistent errors
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025 --output docs/generated/residual-analysis.md  # Write markdown report
 
+# Backfills
+python scripts/backfill_nfl_stats.py                 # Backfill nfl_stats from nflverse-data (2010+); also populates advanced receiving (target_share, air_yards_share, wopr, racr) for 2018+
+python scripts/backfill_draft_capital.py             # Backfill NFL draft pick metadata from nflverse `draft_picks` parquet into `draft_capital` (used by the draft_capital_raw feature for rookie/early-career projections)
+python scripts/backfill_draft_capital.py --since 2015 --dry-run  # Backfill from a custom season; --dry-run parses without writing
+
 # Utilities
 python scripts/check_db.py                           # Verify database contents
 streamlit run scripts/visualize_app.py               # Streamlit dashboard


### PR DESCRIPTION
## Summary

Daily sweep of harness docs against the three commits merged in the last 24h. Special-attention check on `docs/generated/db-schema.md` against the migration set passed cleanly — both new tables/columns from #475/#476 were already documented by those PRs.

### Commits reviewed

- **#475** `feat: draft capital feature for rookie projections` — adds migration 023, `scripts/backfill_draft_capital.py`, the `draft_capital_raw` feature, and `v23_draft_capital`.
- **#476** `feat: two-stage residual model for draft capital (v25)` — introduces `combiner_type="residual"`, `train_ridge_residual`, residual paths in `learned_combiner.py`, and `v25_draft_capital_residual`.
- **#477** `docs: refresh projection model eval for v22/v23/v25` — refreshed `experiment-log.md` and `projection-accuracy-improvement.md` Current Accuracy + Lessons Learned + Key Files.

### Schema doc audit

- `migrations/022_add_advanced_receiving_stats.sql` (target_share, air_yards_share, wopr, racr, receiving_air_yards on `nfl_stats`) — already documented in `docs/generated/db-schema.md`.
- `migrations/023_create_draft_capital.sql` (new `draft_capital` table) — already documented; table count of "Eighteen tables" still matches (18 rows confirmed).
- No newer migrations beyond 023.

### Changes made

- **`docs/ARCHITECTURE.md`**
  - "NFL Stats" subsection: added a sentence pinning the migration-022 advanced-receiving columns to the `backfill_nfl_stats.py` paragraph, and a new paragraph for the static `draft_capital` table fed by `backfill_draft_capital.py`.
  - "Projection Pipeline" file list: documented `combiner_type` (`additive` | `learned` | `residual`), added bullets for `learned_combiner.py` and `train_model.py`, and noted that the runner evaluates the union of base + residual features for residual models.
- **`docs/COMMANDS.md`**: new "Backfills" section so `backfill_nfl_stats.py` and the new `backfill_draft_capital.py` (with `--since` / `--dry-run` flags) are discoverable from the command reference.

### Items flagged for human follow-up (not changed)

- **Active production model claim is inconsistent across docs.** `docs/ARCHITECTURE.md:93` calls `v14_qb_starter` "the active production model" with a 4-feature description (incl. `qb_backup_penalty`), but `scripts/update_projections.py:24` sets `ACTIVE_MODEL = "v12_no_qb_trajectory"` (3 features, no penalty), and `AGENTS.md:122` agrees that `v12_no_qb_trajectory` is "current active model". Pre-existing drift, unrelated to today's commits, and resolving it requires confirming what was actually last promoted to `player_projections` — left for a human pass. Resolution is probably to either (a) update `ARCHITECTURE.md` to match `v12` and the AGENTS.md note, or (b) update `ACTIVE_MODEL` to one of the newer models (v22/v25 are now well ahead on MAE) and re-run `update_projections.py`.
- **`schema.sql` is out of date.** The file is described as "auto-generated via Supabase MCP" but does not contain the `draft_capital` table or migration-022 columns. Not edited here because it's auto-generated; flagging so it can be regenerated next time the MCP runs.
- **`docs/exec-plans/feature-projections.md`** still describes only the v1–v6 + external models with status "Complete (Phases 1–3) | Phase 4 Deferred" and recommends promoting `v2_age_adjusted`. This appears intentionally frozen as the original Phase-1 runbook (the live state is tracked in `projection-accuracy-improvement.md` and `experiment-log.md`), but it could use a short pointer at the top to the current best model.

## Test plan

- [ ] CI doc-freshness checks (`just check-docs` / `just check-arch`) pass on the branch.
- [ ] Spot-check that all script paths added to `COMMANDS.md` (`scripts/backfill_draft_capital.py`) and `ARCHITECTURE.md` (`learned_combiner.py`, `train_model.py`) exist.

https://claude.ai/code/session_016gdAjsAGzXk24uJpnJ7Sig

---
_Generated by [Claude Code](https://claude.ai/code/session_016gdAjsAGzXk24uJpnJ7Sig)_