### PR TITLE
feat: Vegas lines review page

### DIFF
--- a/web/app/vegas-lines/SeasonSelector.tsx
+++ b/web/app/vegas-lines/SeasonSelector.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+interface Props {
+  currentSeason: number;
+  seasons: readonly number[];
+}
+
+export default function SeasonSelector({ currentSeason, seasons }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handleChange = (season: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("season", String(season));
+    router.push(`?${params.toString()}`);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <label htmlFor="season-select" className="text-sm text-slate-500 dark:text-slate-400">
+        Season:
+      </label>
+      <select
+        id="season-select"
+        value={currentSeason}
+        onChange={(e) => handleChange(Number(e.target.value))}
+        className="px-3 py-1.5 rounded-md text-sm font-medium border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+      >
+        {seasons.map((s) => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/web/app/vegas-lines/page.tsx
+++ b/web/app/vegas-lines/page.tsx
@@ -1,0 +1,229 @@
+import { fetchAvailableSeasons, fetchVegasLinesForSeason } from "@/lib/vegas-lines";
+import { DIVISIONS, TEAM_NAME_BY_CODE } from "@/lib/nfl-divisions";
+import SeasonSelector from "./SeasonSelector";
+
+export const revalidate = 3600;
+
+interface Props {
+  searchParams: Promise<{ season?: string }>;
+}
+
+function formatNumber(value: number, fractionDigits = 1): string {
+  return value.toLocaleString("en-US", {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
+}
+
+export default async function VegasLinesPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const seasons = await fetchAvailableSeasons();
+
+  if (seasons.length === 0) {
+    return (
+      <main className="min-h-screen bg-white dark:bg-black p-8">
+        <div className="max-w-7xl mx-auto">
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+            Preseason Vegas Lines
+          </h1>
+          <p className="text-slate-500 dark:text-slate-400 mt-4">
+            No data available. Run{" "}
+            <code className="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-xs">
+              venv/bin/python scripts/backfill_vegas_lines.py
+            </code>{" "}
+            to populate the <code>team_vegas_lines</code> table.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const requested = Number(params.season);
+  const targetSeason = seasons.includes(requested) ? requested : seasons[0];
+
+  const rows = await fetchVegasLinesForSeason(targetSeason);
+  const lineByTeam = new Map(rows.map((r) => [r.team, r]));
+
+  const totalsForLeagueMean = rows.map((r) => r.implied_total);
+  const leagueMean =
+    totalsForLeagueMean.length > 0
+      ? totalsForLeagueMean.reduce((sum, v) => sum + v, 0) / totalsForLeagueMean.length
+      : null;
+
+  const knownCodes = new Set(
+    DIVISIONS.flatMap((d) => d.teams.map((t) => t.code)),
+  );
+  const unknownTeams = rows.filter((r) => !knownCodes.has(r.team));
+
+  const afcDivisions = DIVISIONS.filter((d) => d.conference === "AFC");
+  const nfcDivisions = DIVISIONS.filter((d) => d.conference === "NFC");
+
+  return (
+    <main className="min-h-screen bg-white dark:bg-black p-8">
+      <div className="max-w-7xl mx-auto space-y-6">
+        <header className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+              Preseason Vegas Lines — {targetSeason}
+            </h1>
+            <p className="text-slate-500 dark:text-slate-400 mt-1 text-sm">
+              Per-team season implied total points and Pythagorean expected
+              wins, aggregated from nflverse game lines. Used as a feature in
+              the <code>v27_vegas_full_refit</code> projection model.
+            </p>
+          </div>
+          <SeasonSelector currentSeason={targetSeason} seasons={seasons} />
+        </header>
+
+        {leagueMean !== null && (
+          <section className="rounded-lg border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 px-4 py-3 text-sm text-slate-600 dark:text-slate-400">
+            <span className="font-medium text-slate-900 dark:text-white">
+              League average implied total:
+            </span>{" "}
+            {formatNumber(leagueMean, 1)} points · {rows.length} teams ·
+            sum-of-game-implied-points across the regular season.
+          </section>
+        )}
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          <ConferenceSection
+            label="AFC"
+            divisions={afcDivisions}
+            lineByTeam={lineByTeam}
+            leagueMean={leagueMean}
+          />
+          <ConferenceSection
+            label="NFC"
+            divisions={nfcDivisions}
+            lineByTeam={lineByTeam}
+            leagueMean={leagueMean}
+          />
+        </div>
+
+        {unknownTeams.length > 0 && (
+          <section className="rounded-lg border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950 px-4 py-3 text-sm text-amber-900 dark:text-amber-200">
+            <strong>Unmapped teams:</strong>{" "}
+            {unknownTeams.map((u) => u.team).join(", ")}. Update{" "}
+            <code>web/lib/nfl-divisions.ts</code> if a relocation has occurred.
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function ConferenceSection({
+  label,
+  divisions,
+  lineByTeam,
+  leagueMean,
+}: {
+  label: string;
+  divisions: typeof DIVISIONS;
+  lineByTeam: Map<string, { implied_total: number; win_total: number | null }>;
+  leagueMean: number | null;
+}) {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xs font-bold uppercase tracking-widest text-slate-500 dark:text-slate-400">
+        {label}
+      </h2>
+      <div className="space-y-4">
+        {divisions.map((division) => (
+          <DivisionCard
+            key={`${division.conference}-${division.direction}`}
+            label={`${division.conference} ${division.direction}`}
+            teams={division.teams}
+            lineByTeam={lineByTeam}
+            leagueMean={leagueMean}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function DivisionCard({
+  label,
+  teams,
+  lineByTeam,
+  leagueMean,
+}: {
+  label: string;
+  teams: readonly { code: string; name: string }[];
+  lineByTeam: Map<string, { implied_total: number; win_total: number | null }>;
+  leagueMean: number | null;
+}) {
+  const sorted = [...teams].sort((a, b) => {
+    const aWins = lineByTeam.get(a.code)?.win_total ?? -Infinity;
+    const bWins = lineByTeam.get(b.code)?.win_total ?? -Infinity;
+    return bWins - aWins;
+  });
+
+  return (
+    <div className="rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 overflow-hidden">
+      <div className="px-4 py-2 border-b border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900">
+        <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+          {label}
+        </h3>
+      </div>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <th className="px-4 py-2 text-left font-medium">Team</th>
+            <th className="px-4 py-2 text-right font-medium">Implied Total</th>
+            <th className="px-4 py-2 text-right font-medium">Win Total</th>
+            <th className="px-4 py-2 text-right font-medium">vs League</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((team) => {
+            const line = lineByTeam.get(team.code);
+            const delta =
+              line && leagueMean !== null
+                ? line.implied_total - leagueMean
+                : null;
+            return (
+              <tr
+                key={team.code}
+                className="border-t border-slate-100 dark:border-slate-900"
+              >
+                <td className="px-4 py-2">
+                  <div className="font-medium text-slate-900 dark:text-white">
+                    {TEAM_NAME_BY_CODE[team.code] ?? team.name}
+                  </div>
+                  <div className="text-xs text-slate-500 dark:text-slate-400">
+                    {team.code}
+                  </div>
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-slate-900 dark:text-white">
+                  {line ? formatNumber(line.implied_total, 1) : "—"}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-slate-900 dark:text-white">
+                  {line && line.win_total !== null
+                    ? formatNumber(line.win_total, 1)
+                    : "—"}
+                </td>
+                <td
+                  className={`px-4 py-2 text-right font-mono ${
+                    delta === null
+                      ? "text-slate-400"
+                      : delta > 0
+                        ? "text-emerald-600 dark:text-emerald-400"
+                        : delta < 0
+                          ? "text-rose-600 dark:text-rose-400"
+                          : "text-slate-500"
+                  }`}
+                >
+                  {delta === null
+                    ? "—"
+                    : `${delta >= 0 ? "+" : ""}${formatNumber(delta, 1)}`}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/components/Navigation.tsx
+++ b/web/components/Navigation.tsx
@@ -30,6 +30,7 @@ const PRIVATE_GROUPS = [
       { href: "/projected-salary", label: "Projected Salary" },
       { href: "/projections", label: "Projections" },
       { href: "/projection-accuracy", label: "Proj. Accuracy" },
+      { href: "/vegas-lines", label: "Vegas Lines" },
     ],
   },
   {

--- a/web/lib/nfl-divisions.ts
+++ b/web/lib/nfl-divisions.ts
@@ -1,0 +1,109 @@
+/**
+ * NFL division mapping. Used to group teams on the vegas-lines page so
+ * preseason expectations are easy to compare against divisional rivals.
+ *
+ * Codes match nflverse / `team_vegas_lines.team` (modern 32-team set,
+ * 2016+). Teams that have moved cities (OAK→LV, SD→LAC, STL→LA) appear
+ * under their current code only.
+ */
+
+export type Conference = "AFC" | "NFC";
+export type DivisionDirection = "East" | "North" | "South" | "West";
+
+export interface DivisionEntry {
+  conference: Conference;
+  direction: DivisionDirection;
+  teams: readonly TeamEntry[];
+}
+
+export interface TeamEntry {
+  code: string;
+  name: string;
+}
+
+export const DIVISIONS: readonly DivisionEntry[] = [
+  {
+    conference: "AFC",
+    direction: "East",
+    teams: [
+      { code: "BUF", name: "Bills" },
+      { code: "MIA", name: "Dolphins" },
+      { code: "NE", name: "Patriots" },
+      { code: "NYJ", name: "Jets" },
+    ],
+  },
+  {
+    conference: "AFC",
+    direction: "North",
+    teams: [
+      { code: "BAL", name: "Ravens" },
+      { code: "CIN", name: "Bengals" },
+      { code: "CLE", name: "Browns" },
+      { code: "PIT", name: "Steelers" },
+    ],
+  },
+  {
+    conference: "AFC",
+    direction: "South",
+    teams: [
+      { code: "HOU", name: "Texans" },
+      { code: "IND", name: "Colts" },
+      { code: "JAX", name: "Jaguars" },
+      { code: "TEN", name: "Titans" },
+    ],
+  },
+  {
+    conference: "AFC",
+    direction: "West",
+    teams: [
+      { code: "DEN", name: "Broncos" },
+      { code: "KC", name: "Chiefs" },
+      { code: "LAC", name: "Chargers" },
+      { code: "LV", name: "Raiders" },
+    ],
+  },
+  {
+    conference: "NFC",
+    direction: "East",
+    teams: [
+      { code: "DAL", name: "Cowboys" },
+      { code: "NYG", name: "Giants" },
+      { code: "PHI", name: "Eagles" },
+      { code: "WAS", name: "Commanders" },
+    ],
+  },
+  {
+    conference: "NFC",
+    direction: "North",
+    teams: [
+      { code: "CHI", name: "Bears" },
+      { code: "DET", name: "Lions" },
+      { code: "GB", name: "Packers" },
+      { code: "MIN", name: "Vikings" },
+    ],
+  },
+  {
+    conference: "NFC",
+    direction: "South",
+    teams: [
+      { code: "ATL", name: "Falcons" },
+      { code: "CAR", name: "Panthers" },
+      { code: "NO", name: "Saints" },
+      { code: "TB", name: "Buccaneers" },
+    ],
+  },
+  {
+    conference: "NFC",
+    direction: "West",
+    teams: [
+      { code: "ARI", name: "Cardinals" },
+      { code: "LA", name: "Rams" },
+      { code: "SEA", name: "Seahawks" },
+      { code: "SF", name: "49ers" },
+    ],
+  },
+];
+
+export const TEAM_NAME_BY_CODE: Record<string, string> = Object.fromEntries(
+  DIVISIONS.flatMap((d) => d.teams.map((t) => [t.code, t.name])),
+);

--- a/web/lib/vegas-lines.ts
+++ b/web/lib/vegas-lines.ts
@@ -1,0 +1,46 @@
+/**
+ * Server-only fetchers for the `team_vegas_lines` table that powers the
+ * preseason Vegas lines review page. Implied totals + Pythagorean win
+ * totals are sourced from nflverse `games.csv` by the
+ * `scripts/backfill_vegas_lines.py` job.
+ */
+
+import { supabase } from "./supabase";
+
+export interface TeamVegasLine {
+  team: string;
+  season: number;
+  implied_total: number;
+  win_total: number | null;
+}
+
+export async function fetchAvailableSeasons(): Promise<number[]> {
+  const { data, error } = await supabase
+    .from("team_vegas_lines")
+    .select("season")
+    .order("season", { ascending: false });
+
+  if (error) {
+    console.error("fetchAvailableSeasons error", error);
+    return [];
+  }
+  const seasons = new Set<number>();
+  for (const row of data ?? []) seasons.add(row.season);
+  return Array.from(seasons).sort((a, b) => b - a);
+}
+
+export async function fetchVegasLinesForSeason(
+  season: number,
+): Promise<TeamVegasLine[]> {
+  const { data, error } = await supabase
+    .from("team_vegas_lines")
+    .select("team, season, implied_total, win_total")
+    .eq("season", season)
+    .order("team", { ascending: true });
+
+  if (error) {
+    console.error(`fetchVegasLinesForSeason(${season}) error`, error);
+    return [];
+  }
+  return data ?? [];
+}

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -11,6 +11,7 @@ export const PROTECTED_ROUTES = [
   "/arbitration-planner",
   "/projections",
   "/projection-accuracy",
+  "/vegas-lines",
 ];
 
 export const ADMIN_ROUTES = ["/admin"];

--- a/web/types/supabase.ts
+++ b/web/types/supabase.ts
@@ -237,6 +237,44 @@ export type Database = {
           },
         ]
       }
+      draft_capital: {
+        Row: {
+          created_at: string
+          id: string
+          overall_pick: number
+          player_id: string
+          round: number
+          season_drafted: number
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          overall_pick: number
+          player_id: string
+          round: number
+          season_drafted: number
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          overall_pick?: number
+          player_id?: string
+          round?: number
+          season_drafted?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "draft_capital_player_id_fkey"
+            columns: ["player_id"]
+            isOneToOne: true
+            referencedRelation: "players"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       league_prices: {
         Row: {
           created_at: string
@@ -322,6 +360,7 @@ export type Database = {
       }
       nfl_stats: {
         Row: {
+          air_yards_share: number | null
           completions: number | null
           created_at: string
           defense_snaps: number | null
@@ -338,6 +377,8 @@ export type Database = {
           pat_made: number | null
           player_id: string
           ppg: number | null
+          racr: number | null
+          receiving_air_yards: number | null
           receiving_tds: number | null
           receiving_yards: number | null
           recent_team: string | null
@@ -347,12 +388,15 @@ export type Database = {
           rushing_yards: number | null
           season: number
           st_snaps: number | null
+          target_share: number | null
           targets: number | null
           total_points: number | null
           total_snaps: number | null
           updated_at: string
+          wopr: number | null
         }
         Insert: {
+          air_yards_share?: number | null
           completions?: number | null
           created_at?: string
           defense_snaps?: number | null
@@ -369,6 +413,8 @@ export type Database = {
           pat_made?: number | null
           player_id: string
           ppg?: number | null
+          racr?: number | null
+          receiving_air_yards?: number | null
           receiving_tds?: number | null
           receiving_yards?: number | null
           recent_team?: string | null
@@ -378,12 +424,15 @@ export type Database = {
           rushing_yards?: number | null
           season: number
           st_snaps?: number | null
+          target_share?: number | null
           targets?: number | null
           total_points?: number | null
           total_snaps?: number | null
           updated_at?: string
+          wopr?: number | null
         }
         Update: {
+          air_yards_share?: number | null
           completions?: number | null
           created_at?: string
           defense_snaps?: number | null
@@ -400,6 +449,8 @@ export type Database = {
           pat_made?: number | null
           player_id?: string
           ppg?: number | null
+          racr?: number | null
+          receiving_air_yards?: number | null
           receiving_tds?: number | null
           receiving_yards?: number | null
           recent_team?: string | null
@@ -409,10 +460,12 @@ export type Database = {
           rushing_yards?: number | null
           season?: number
           st_snaps?: number | null
+          target_share?: number | null
           targets?: number | null
           total_points?: number | null
           total_snaps?: number | null
           updated_at?: string
+          wopr?: number | null
         }
         Relationships: [
           {
@@ -465,91 +518,49 @@ export type Database = {
       player_stats: {
         Row: {
           created_at: string
-          fg_made_0_39: number | null
-          fg_made_40_49: number | null
-          fg_made_50_plus: number | null
           games_played: number | null
           h1_games: number | null
           h1_snaps: number | null
           h2_games: number | null
           h2_snaps: number | null
           id: string
-          interceptions: number | null
-          passing_tds: number | null
-          passing_yards: number | null
-          pat_made: number | null
           player_id: string
           ppg: number | null
           pps: number | null
-          receiving_tds: number | null
-          receiving_yards: number | null
-          receptions: number | null
-          rushing_attempts: number | null
-          rushing_tds: number | null
-          rushing_yards: number | null
           season: number
           snaps: number | null
-          targets: number | null
           total_points: number | null
           updated_at: string
         }
         Insert: {
           created_at?: string
-          fg_made_0_39?: number | null
-          fg_made_40_49?: number | null
-          fg_made_50_plus?: number | null
           games_played?: number | null
           h1_games?: number | null
           h1_snaps?: number | null
           h2_games?: number | null
           h2_snaps?: number | null
           id?: string
-          interceptions?: number | null
-          passing_tds?: number | null
-          passing_yards?: number | null
-          pat_made?: number | null
           player_id: string
           ppg?: number | null
           pps?: number | null
-          receiving_tds?: number | null
-          receiving_yards?: number | null
-          receptions?: number | null
-          rushing_attempts?: number | null
-          rushing_tds?: number | null
-          rushing_yards?: number | null
           season: number
           snaps?: number | null
-          targets?: number | null
           total_points?: number | null
           updated_at?: string
         }
         Update: {
           created_at?: string
-          fg_made_0_39?: number | null
-          fg_made_40_49?: number | null
-          fg_made_50_plus?: number | null
           games_played?: number | null
           h1_games?: number | null
           h1_snaps?: number | null
           h2_games?: number | null
           h2_snaps?: number | null
           id?: string
-          interceptions?: number | null
-          passing_tds?: number | null
-          passing_yards?: number | null
-          pat_made?: number | null
           player_id?: string
           ppg?: number | null
           pps?: number | null
-          receiving_tds?: number | null
-          receiving_yards?: number | null
-          receptions?: number | null
-          rushing_attempts?: number | null
-          rushing_tds?: number | null
-          rushing_yards?: number | null
           season?: number
           snaps?: number | null
-          targets?: number | null
           total_points?: number | null
           updated_at?: string
         }
@@ -738,6 +749,36 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      team_vegas_lines: {
+        Row: {
+          created_at: string
+          id: string
+          implied_total: number
+          season: number
+          team: string
+          updated_at: string
+          win_total: number | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          implied_total: number
+          season: number
+          team: string
+          updated_at?: string
+          win_total?: number | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          implied_total?: number
+          season?: number
+          team?: string
+          updated_at?: string
+          win_total?: number | null
+        }
+        Relationships: []
       }
       transactions: {
         Row: {


### PR DESCRIPTION
## Summary

Adds a new `/vegas-lines` page for reviewing the preseason Vegas implied team totals that feed the v27 projection model. Lets you spot-check that the underlying data looks right by season.

- **Season dropdown** with every season present in `team_vegas_lines` (2016–2025 today).
- **Two-column AFC/NFC layout, eight division cards** (AFC/NFC × East/North/South/West).
- **Within each division** teams are sorted by Pythagorean win total descending — divisional favorites bubble to the top.
- **Per-team row** shows implied total, win total, and a centered `vs League` delta (green/red so outliers stand out).
- **Future-proof**: an "Unmapped teams" warning surfaces if `team_vegas_lines.team` ever contains a code not in the static division map (catches relocations).
- Linked from the **Projections** nav dropdown; added to `PROTECTED_ROUTES` so it shares auth with the other projection pages.
- Regenerated `web/types/supabase.ts` so the typed Supabase client recognizes `team_vegas_lines` and `draft_capital` (the previous PR's schema additions).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on all changed files
- [x] `npm test` — 223/223 web tests pass
- [x] Unauthenticated GET `/vegas-lines` returns 307 → `/login`
- [ ] Visual smoke check: load each season 2016–2025 and verify divisions are populated and totals look reasonable
- [ ] Check responsive layout on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)