### PR TITLE
feat: seed 2026 preseason win totals (implied_total nullable)

### DIFF
--- a/docs/exec-plans/projection-accuracy-improvement.md
+++ b/docs/exec-plans/projection-accuracy-improvement.md
@@ -246,6 +246,32 @@ the new feature is sparse *and* the dataset is small. Once at least one
 is worth retrying — the joint fit can recover bias that a frozen base
 keeps trapped (v25 bias -0.627 → v27 -0.041).
 
+### Graceful degradation when Vegas data is missing
+
+Sportsbook **win totals** are published in March/April but per-game
+spread/total lines (which `implied_total` is derived from) require the
+NFL schedule, typically released in mid-May. For a few weeks every
+spring `team_vegas_lines` may carry `win_total` while `implied_total`
+is `NULL`. A 2026 row was seeded on 2026-05-07 with this shape.
+
+The `implied_team_total_raw` feature is **centered** against each
+season's league mean (so the average value is ≈ 0). When inference
+encounters a player on a team with no `implied_total`, the feature
+returns `None`, the learned combiner substitutes `0.0` in the feature
+vector, the scaler normalizes that to roughly `-mean/scale ≈ 0`, and
+the position-conditional vegas coefficients add a near-zero PPG delta.
+**v27 with no `implied_total` collapses to roughly v23 behavior**
+(full refit minus the vegas signal): ALL MAE 2.535 / R² 0.557 /
+bias -0.437.
+
+So if you need season-projection accuracy *before* the schedule drops
+each spring, v27 stays the right active model — its preseason output
+without vegas is still better than v25 (2.551). Once
+`backfill_vegas_lines.py` runs after schedule release and populates
+`implied_total`, v27 picks up its full -0.093 MAE edge automatically
+(`run --model v27_vegas_full_refit --seasons {season}` re-projects
+with the now-present feature).
+
 ---
 
 ## Key Files

--- a/migrations/025_team_vegas_lines_implied_nullable.sql
+++ b/migrations/025_team_vegas_lines_implied_nullable.sql
@@ -1,0 +1,16 @@
+-- Migration 025: Allow team_vegas_lines.implied_total to be null.
+--
+-- Preseason win totals are published in March/April of each year, but
+-- per-game spread/total lines (which the Pythagorean implied total is
+-- derived from) require the NFL schedule. The schedule is typically
+-- released in mid-May, so for a few weeks every spring we can know
+-- win_total without yet being able to compute implied_total. Relaxing
+-- this constraint lets us seed those rows on the win_total side and
+-- backfill implied_total later when nflverse picks up the schedule.
+--
+-- The implied_team_total_raw projection feature already returns None
+-- when a (team, season) row lacks implied_total — those samples
+-- contribute zero through the learned ridge. GH #378 follow-up.
+
+ALTER TABLE team_vegas_lines
+  ALTER COLUMN implied_total DROP NOT NULL;

--- a/scripts/seed_preseason_win_totals.py
+++ b/scripts/seed_preseason_win_totals.py
@@ -1,0 +1,119 @@
+"""Seed preseason Vegas win totals for an upcoming season.
+
+Sportsbook win totals are published in March/April but per-game lines
+(needed to derive ``implied_total``) require the NFL schedule. This
+script lets us populate ``team_vegas_lines`` with just ``win_total``
+in the spring; a later run of ``backfill_vegas_lines.py`` will fill
+in ``implied_total`` once nflverse picks up the schedule.
+
+The data is hand-curated from public sportsbook reporting since
+machine-readable preseason win totals require a paid odds API.
+GH #378 follow-up.
+
+Usage:
+    venv/bin/python scripts/seed_preseason_win_totals.py --season 2026
+    venv/bin/python scripts/seed_preseason_win_totals.py --season 2026 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from scripts.config import get_supabase_client
+
+
+# Preseason win totals consensus. Source: NFLTradeRumors aggregation of
+# DraftKings opening lines (Feb 2026); cross-checked against BetMGM and
+# CBS Sports reporting. 32 teams, sums to 277 (slight overround vs. the
+# 272 zero-vig fair value, typical for season-long markets).
+WIN_TOTALS_BY_SEASON: dict[int, dict[str, float]] = {
+    2026: {
+        "ARI": 4.5,
+        "ATL": 7.5,
+        "BAL": 11.5,
+        "BUF": 10.5,
+        "CAR": 7.5,
+        "CHI": 9.5,
+        "CIN": 9.5,
+        "CLE": 6.5,
+        "DAL": 9.5,
+        "DEN": 9.5,
+        "DET": 10.5,
+        "GB": 10.5,
+        "HOU": 9.5,
+        "IND": 7.5,
+        "JAX": 9.5,
+        "KC": 10.5,
+        "LA": 11.5,
+        "LAC": 10.5,
+        "LV": 5.5,
+        "MIA": 4.5,
+        "MIN": 8.5,
+        "NE": 9.5,
+        "NO": 7.5,
+        "NYG": 7.5,
+        "NYJ": 5.5,
+        "PHI": 10.5,
+        "PIT": 8.5,
+        "SEA": 10.5,
+        "SF": 10.5,
+        "TB": 8.5,
+        "TEN": 6.5,
+        "WAS": 7.5,
+    },
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed preseason win totals.")
+    parser.add_argument("--season", type=int, required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    totals = WIN_TOTALS_BY_SEASON.get(args.season)
+    if not totals:
+        available = sorted(WIN_TOTALS_BY_SEASON.keys())
+        print(
+            f"No preseason win totals encoded for {args.season}. "
+            f"Add them to WIN_TOTALS_BY_SEASON. Encoded: {available}"
+        )
+        sys.exit(1)
+
+    if len(totals) != 32:
+        print(f"Expected 32 teams for {args.season}, got {len(totals)}")
+        sys.exit(1)
+
+    payload = [
+        {
+            "team": team,
+            "season": args.season,
+            "implied_total": None,
+            "win_total": float(win_total),
+        }
+        for team, win_total in sorted(totals.items())
+    ]
+
+    total_wins = sum(totals.values())
+    print(f"Season {args.season}: {len(totals)} teams, sum of win totals = {total_wins:.1f}")
+    print(f"  (Fair value 272.0 for a 17-game season; ~5 above is normal sportsbook overround.)")
+
+    if args.dry_run:
+        print(f"\n[DRY RUN] Would upsert {len(payload)} rows. Sample:")
+        for p in payload[:6]:
+            print(f"  {p}")
+        return
+
+    supabase = get_supabase_client()
+    print(f"\nUpserting to team_vegas_lines...")
+    supabase.table("team_vegas_lines").upsert(
+        payload, on_conflict="team,season"
+    ).execute()
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/app/vegas-lines/page.tsx
+++ b/web/app/vegas-lines/page.tsx
@@ -44,11 +44,14 @@ export default async function VegasLinesPage({ searchParams }: Props) {
   const rows = await fetchVegasLinesForSeason(targetSeason);
   const lineByTeam = new Map(rows.map((r) => [r.team, r]));
 
-  const totalsForLeagueMean = rows.map((r) => r.implied_total);
+  const totalsForLeagueMean = rows
+    .map((r) => r.implied_total)
+    .filter((v): v is number => v !== null);
   const leagueMean =
     totalsForLeagueMean.length > 0
       ? totalsForLeagueMean.reduce((sum, v) => sum + v, 0) / totalsForLeagueMean.length
       : null;
+  const hasImpliedTotals = totalsForLeagueMean.length > 0;
 
   const knownCodes = new Set(
     DIVISIONS.flatMap((d) => d.teams.map((t) => t.code)),
@@ -75,13 +78,24 @@ export default async function VegasLinesPage({ searchParams }: Props) {
           <SeasonSelector currentSeason={targetSeason} seasons={seasons} />
         </header>
 
-        {leagueMean !== null && (
+        {hasImpliedTotals && leagueMean !== null ? (
           <section className="rounded-lg border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 px-4 py-3 text-sm text-slate-600 dark:text-slate-400">
             <span className="font-medium text-slate-900 dark:text-white">
               League average implied total:
             </span>{" "}
             {formatNumber(leagueMean, 1)} points · {rows.length} teams ·
             sum-of-game-implied-points across the regular season.
+          </section>
+        ) : (
+          <section className="rounded-lg border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950 px-4 py-3 text-sm text-amber-900 dark:text-amber-200">
+            <span className="font-medium">Implied totals not yet available for {targetSeason}.</span>{" "}
+            Win totals are sportsbook preseason consensus; per-game lines (and
+            therefore implied totals) populate once the NFL schedule is released
+            and nflverse picks it up. Run{" "}
+            <code className="px-1.5 py-0.5 rounded bg-amber-100 dark:bg-amber-900/40 text-xs">
+              venv/bin/python scripts/backfill_vegas_lines.py
+            </code>{" "}
+            after schedule release to backfill.
           </section>
         )}
 
@@ -112,6 +126,8 @@ export default async function VegasLinesPage({ searchParams }: Props) {
   );
 }
 
+type LineForTeam = { implied_total: number | null; win_total: number | null };
+
 function ConferenceSection({
   label,
   divisions,
@@ -120,7 +136,7 @@ function ConferenceSection({
 }: {
   label: string;
   divisions: typeof DIVISIONS;
-  lineByTeam: Map<string, { implied_total: number; win_total: number | null }>;
+  lineByTeam: Map<string, LineForTeam>;
   leagueMean: number | null;
 }) {
   return (
@@ -151,7 +167,7 @@ function DivisionCard({
 }: {
   label: string;
   teams: readonly { code: string; name: string }[];
-  lineByTeam: Map<string, { implied_total: number; win_total: number | null }>;
+  lineByTeam: Map<string, LineForTeam>;
   leagueMean: number | null;
 }) {
   const sorted = [...teams].sort((a, b) => {
@@ -180,7 +196,7 @@ function DivisionCard({
           {sorted.map((team) => {
             const line = lineByTeam.get(team.code);
             const delta =
-              line && leagueMean !== null
+              line && line.implied_total !== null && leagueMean !== null
                 ? line.implied_total - leagueMean
                 : null;
             return (
@@ -197,7 +213,9 @@ function DivisionCard({
                   </div>
                 </td>
                 <td className="px-4 py-2 text-right font-mono text-slate-900 dark:text-white">
-                  {line ? formatNumber(line.implied_total, 1) : "—"}
+                  {line && line.implied_total !== null
+                    ? formatNumber(line.implied_total, 1)
+                    : "—"}
                 </td>
                 <td className="px-4 py-2 text-right font-mono text-slate-900 dark:text-white">
                   {line && line.win_total !== null

--- a/web/lib/vegas-lines.ts
+++ b/web/lib/vegas-lines.ts
@@ -10,7 +10,7 @@ import { supabase } from "./supabase";
 export interface TeamVegasLine {
   team: string;
   season: number;
-  implied_total: number;
+  implied_total: number | null;
   win_total: number | null;
 }
 

--- a/web/types/supabase.ts
+++ b/web/types/supabase.ts
@@ -754,7 +754,7 @@ export type Database = {
         Row: {
           created_at: string
           id: string
-          implied_total: number
+          implied_total: number | null
           season: number
           team: string
           updated_at: string
@@ -763,7 +763,7 @@ export type Database = {
         Insert: {
           created_at?: string
           id?: string
-          implied_total: number
+          implied_total?: number | null
           season: number
           team: string
           updated_at?: string
@@ -772,7 +772,7 @@ export type Database = {
         Update: {
           created_at?: string
           id?: string
-          implied_total?: number
+          implied_total?: number | null
           season?: number
           team?: string
           updated_at?: string


### PR DESCRIPTION
## Summary

Sportsbook **win totals** are published in March/April but per-game lines (needed to derive `implied_total`) require the NFL schedule, which typically releases mid-May. For a few weeks each spring the natural state is `win_total` known, `implied_total` still missing. This PR makes that state representable and seeds it for 2026.

- **Migration 025** relaxes `team_vegas_lines.implied_total` to nullable.
- **`scripts/seed_preseason_win_totals.py`** upserts a hand-curated `team → win_total` map per season. Reusable for 2027+ — just add the next season's totals to `WIN_TOTALS_BY_SEASON`.
- **2026 numbers** are the DraftKings opening-line consensus (Feb 2026), cross-checked vs BetMGM and CBS Sports reporting. Sum of 277 wins matches the typical sportsbook overround above the 272 zero-vig fair value for a 17-game season.
- **Page** now renders 2026 with `—` placeholders for implied totals and surfaces an amber notice explaining when they will populate + the exact backfill command.

## Why v27 stays the active model

The `implied_team_total_raw` feature is centered against the season's league mean (~0 average). When inference encounters a team with no `implied_total`, the feature returns None, the learned combiner substitutes 0.0 in the feature vector, and after standardization the position-conditional vegas coefficients add a near-zero PPG delta. **v27 with no implied_total collapses to roughly v23 behavior** (full refit minus the vegas signal):

| Scenario | Best model | ALL MAE |
|---|---|---|
| Vegas present (2022-2025 backtest) | **v27** | 2.458 |
| Vegas missing (effective v27 ≈ v23) | v23 | 2.535 |
| No-vegas residual | v25 | 2.551 |

So v27 is still the right active model through the spring window. After schedule release, running:

```sh
venv/bin/python scripts/backfill_vegas_lines.py
venv/bin/python scripts/feature_projections/cli.py run --model v27_vegas_full_refit --seasons 2026
venv/bin/python scripts/feature_projections/cli.py promote --model v27_vegas_full_refit
```

auto-restores the full -0.093 MAE edge — no model swap needed. Documented in the new `Graceful degradation when Vegas data is missing` section of `docs/exec-plans/projection-accuracy-improvement.md`.

## Test plan

- [x] Migration applied successfully
- [x] Seed script: 32 rows for 2026 (sum = 277.0, expected ~277)
- [x] DB shows `(season=2026, teams=32, with_implied=0, with_wins=32)`
- [x] `npx tsc --noEmit` clean after types regen
- [x] `npx eslint` clean
- [ ] Visual: load `/vegas-lines?season=2026` and confirm `—` placeholders + amber notice render
- [ ] Visual: confirm 2025 still renders normally (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)