### PR TITLE
feat: backfill 2026 NFL draft + project drafted rookies

### DIFF
--- a/scripts/backfill_draft_capital.py
+++ b/scripts/backfill_draft_capital.py
@@ -10,11 +10,17 @@ Usage:
     python scripts/backfill_draft_capital.py             # All seasons (default 2010+)
     python scripts/backfill_draft_capital.py --since 2015
     python scripts/backfill_draft_capital.py --dry-run   # Parse only, no DB writes
+
+For a fresh draft (e.g. immediately post-draft), pass --update-rosters to also
+flip matched players from college to NFL (is_college=False, nfl_team=<NFL>) and
+insert player rows for any picks not already in our DB:
+    python scripts/backfill_draft_capital.py --since 2026 --update-rosters
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import sys
 
@@ -24,6 +30,20 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from scripts.config import get_supabase_client, fetch_all_rows
 from scripts.name_utils import normalize_player_name
+
+# nflverse uses different team abbreviations than Ottoneu/our DB.
+# Map nflverse codes to the codes stored in players.nfl_team.
+NFLVERSE_TO_OTTONEU_TEAM = {
+    "GNB": "GB",
+    "JAX": "JAC",
+    "KAN": "KC",
+    "LAR": "LA",
+    "LVR": "LV",
+    "NOR": "NO",
+    "NWE": "NE",
+    "SFO": "SF",
+    "TAM": "TB",
+}
 
 DRAFT_PICKS_URL = (
     "https://github.com/nflverse/nflverse-data/releases/download/"
@@ -78,6 +98,15 @@ def match_picks_to_players(
         if position not in FANTASY_POSITIONS:
             continue
 
+        nflverse_team = str(getattr(row, "team", "") or "").strip()
+        ottoneu_team = NFLVERSE_TO_OTTONEU_TEAM.get(nflverse_team, nflverse_team)
+        nflverse_id = (
+            str(getattr(row, "pfr_player_id", "") or "")
+            or str(getattr(row, "cfb_player_id", "") or "")
+            or str(getattr(row, "gsis_id", "") or "")
+            or name
+        )
+
         norm = normalize_player_name(name)
         player_id = player_lookup.get((norm, position))
         record = {
@@ -87,6 +116,8 @@ def match_picks_to_players(
             "overall_pick": int(row.pick),
             "_name": name,
             "_position": position,
+            "_nfl_team": ottoneu_team,
+            "_nflverse_id": nflverse_id,
         }
         if player_id:
             matched.append(record)
@@ -94,6 +125,81 @@ def match_picks_to_players(
             unmatched.append(record)
 
     return matched, unmatched
+
+
+def _generate_synthetic_ottoneu_id(seed: str) -> int:
+    """Stable negative ottoneu_id from a string seed (mirrors backfill_nfl_stats)."""
+    h = hashlib.md5(seed.encode()).hexdigest()
+    return -abs(int(h[:7], 16))
+
+
+def update_existing_players(
+    supabase, matched: list[dict], dry_run: bool
+) -> int:
+    """Flip matched college players to NFL with their drafted team."""
+    updates = 0
+    for r in matched:
+        if not r.get("_nfl_team"):
+            continue
+        if dry_run:
+            updates += 1
+            continue
+        supabase.table("players").update(
+            {"is_college": False, "nfl_team": r["_nfl_team"]}
+        ).eq("id", r["player_id"]).execute()
+        updates += 1
+    return updates
+
+
+def insert_new_players(
+    supabase,
+    unmatched: list[dict],
+    dry_run: bool,
+) -> int:
+    """Insert player rows for drafted picks not already in our DB.
+
+    Returns the number of new player rows created and mutates each unmatched
+    record in place to set its `player_id` so draft_capital can be upserted.
+    """
+    if not unmatched:
+        return 0
+
+    existing_ids = {r["ottoneu_id"] for r in fetch_all_rows(supabase, "players", "ottoneu_id")}
+
+    new_rows: list[dict] = []
+    for r in unmatched:
+        seed = r.get("_nflverse_id") or f"{r['_name']}|{r['_position']}|{r['season_drafted']}"
+        synthetic = _generate_synthetic_ottoneu_id(seed)
+        while synthetic in existing_ids:
+            synthetic -= 1
+        existing_ids.add(synthetic)
+        r["_synthetic_ottoneu_id"] = synthetic
+        new_rows.append({
+            "ottoneu_id": synthetic,
+            "name": r["_name"],
+            "position": r["_position"],
+            "nfl_team": r["_nfl_team"] or "FA",
+            "is_college": False,
+        })
+
+    if dry_run:
+        return len(new_rows)
+
+    batch_size = 200
+    for i in range(0, len(new_rows), batch_size):
+        batch = new_rows[i : i + batch_size]
+        result = supabase.table("players").upsert(
+            batch, on_conflict="ottoneu_id"
+        ).execute()
+        returned = result.data or []
+        # Map synthetic_id -> uuid so we can attach player_id to each unmatched record.
+        by_otto = {p["ottoneu_id"]: p["id"] for p in returned}
+        for r in unmatched:
+            sid = r.get("_synthetic_ottoneu_id")
+            if sid is not None and sid in by_otto:
+                r["player_id"] = by_otto[sid]
+
+    return len(new_rows)
 
 
 def upsert_draft_capital(supabase, rows: list[dict]) -> None:
@@ -133,9 +239,18 @@ def main() -> None:
         "--dry-run", action="store_true",
         help="Parse and match without writing to the database",
     )
+    parser.add_argument(
+        "--update-rosters", action="store_true",
+        help=(
+            "For picks in --since season only, also (a) flip matched college "
+            "players to is_college=False with their drafted NFL team, and "
+            "(b) insert new player rows for drafted picks not yet in the DB."
+        ),
+    )
     args = parser.parse_args()
 
-    print(f"Draft Capital Backfill (since={args.since}, dry_run={args.dry_run})")
+    print(f"Draft Capital Backfill (since={args.since}, dry_run={args.dry_run}, "
+          f"update_rosters={args.update_rosters})")
 
     print("\nLoading draft picks parquet from nflverse...")
     picks = load_draft_picks(args.since)
@@ -155,10 +270,42 @@ def main() -> None:
         sample = unmatched[:10]
         for u in sample:
             print(f"    UNMATCHED {u['season_drafted']} R{u['round']}.{u['overall_pick']:03d} "
-                  f"{u['_name']} ({u['_position']})")
+                  f"{u['_name']} ({u['_position']}, {u['_nfl_team']})")
+
+    if args.update_rosters:
+        # Restrict roster updates/inserts to --since season only. Editing players'
+        # current nfl_team based on a draft pick from years ago would clobber trades
+        # and free-agent moves.
+        update_season = args.since
+        season_matched = [r for r in matched if r["season_drafted"] == update_season]
+        season_unmatched = [r for r in unmatched if r["season_drafted"] == update_season]
+
+        print(f"\nRoster updates for {update_season} draft:")
+        n_updated = update_existing_players(supabase, season_matched, args.dry_run)
+        n_inserted = insert_new_players(supabase, season_unmatched, args.dry_run)
+        print(f"  {'Would update' if args.dry_run else 'Updated'} {n_updated} existing players")
+        print(f"  {'Would insert' if args.dry_run else 'Inserted'} {n_inserted} new players")
+
+        # Newly inserted players now have player_id set; promote them into matched.
+        if not args.dry_run:
+            for r in season_unmatched:
+                if r.get("player_id"):
+                    matched.append(r)
 
     if args.dry_run:
-        print(f"\n[DRY RUN] Would upsert {len(matched)} draft_capital rows.")
+        # In dry-run we don't actually create the player rows for unmatched picks,
+        # but in a real --update-rosters run those would also flow into draft_capital.
+        extra_from_inserts = (
+            sum(
+                1 for r in unmatched
+                if r["season_drafted"] == args.since and r.get("_nfl_team")
+            )
+            if args.update_rosters else 0
+        )
+        print(
+            f"\n[DRY RUN] Would upsert {len(matched) + extra_from_inserts} "
+            f"draft_capital rows ({len(matched)} matched + {extra_from_inserts} newly-inserted)."
+        )
         for r in matched[:5]:
             print(f"    {r['season_drafted']} R{r['round']}.{r['overall_pick']:03d} "
                   f"{r['_name']} ({r['_position']}) -> {r['player_id']}")

--- a/scripts/update_projections.py
+++ b/scripts/update_projections.py
@@ -67,16 +67,46 @@ def generate_college_projections(avg_rookie_ppg: dict[str, float],
 
 
 def upsert_college_projections():
-    """Generate and upsert college prospect projections."""
+    """Generate and upsert rookie/college-prospect projections.
+
+    Covers two flavors of "no NFL track record yet" players:
+      - is_college=True: still in college (Ottoneu allows rostering them).
+      - Recently drafted: is_college=False with a draft_capital row but no
+        player_stats history. After the draft we flip is_college off, so
+        relying on that flag alone would orphan their projection.
+    Both groups receive the position-average rookie PPG.
+    """
     supabase = get_supabase_client()
-    players_res = supabase.table('players').select('id, position, is_college').execute()
-    players_df = pd.DataFrame(players_res.data or [])
+    # Paginated fetch — the players table exceeds the 1000-row default page size
+    # and a plain .execute() silently truncates, dropping newly-inserted rookies.
+    from config import fetch_all_rows
+    players_data = fetch_all_rows(supabase, 'players', 'id, position, is_college')
+    players_df = pd.DataFrame(players_data)
     players_df = players_df.rename(columns={'id': 'player_id_ref'})
 
+    if players_df.empty:
+        return
+
+    drafted_no_stats: set[str] = set()
+    if 'is_college' in players_df.columns:
+        # Players with any player_stats row are excluded — they go through the
+        # full feature_projections pipeline. We only need the rookies.
+        all_stats = fetch_all_rows(supabase, 'player_stats', 'player_id')
+        with_stats = {r['player_id'] for r in all_stats}
+        all_draft = fetch_all_rows(supabase, 'draft_capital', 'player_id')
+        drafted = {r['player_id'] for r in all_draft}
+        non_college_ids = set(
+            players_df[players_df['is_college'] == False]['player_id_ref'].tolist()  # noqa: E712
+        )
+        drafted_no_stats = (drafted & non_college_ids) - with_stats
+
     college_players = []
-    if not players_df.empty and 'is_college' in players_df.columns:
-        college_df = players_df[players_df['is_college'] == True]
-        for _, row in college_df.iterrows():
+    if 'is_college' in players_df.columns:
+        rookie_mask = (players_df['is_college'] == True) | (
+            players_df['player_id_ref'].isin(drafted_no_stats)
+        )
+        rookie_df = players_df[rookie_mask]
+        for _, row in rookie_df.iterrows():
             college_players.append({'id': row['player_id_ref'], 'position': row['position']})
 
     all_records = []

--- a/scripts/update_projections.py
+++ b/scripts/update_projections.py
@@ -1,9 +1,13 @@
 """Script to generate player projections and update the player_projections database table.
 
-This script acts as a bridge to the new feature_projections system.
-It generates projections using the best configured model (v8_age_regression)
-and promotes them to the production table. It also generates and upserts
-projections for college prospects.
+This script acts as a bridge to the new feature_projections system. It looks
+up the model currently flagged ``is_active=True`` in ``projection_models``,
+runs it for ``TARGET_SEASONS``, promotes its outputs into ``player_projections``,
+and then upserts rookie/college-prospect projections for players with no
+NFL track record.
+
+To switch which model the website serves, promote a different model:
+    python scripts/feature_projections/cli.py promote --model v25_draft_capital_residual
 """
 
 import os
@@ -21,7 +25,29 @@ from projection_methods import CollegeProspectPPG
 
 cli_path = os.path.join(script_dir, "feature_projections", "cli.py")
 TARGET_SEASONS = [2024, 2025, 2026]
-ACTIVE_MODEL = "v12_no_qb_trajectory"
+
+
+def get_active_model_name() -> str:
+    """Return the name of the model currently flagged is_active=True.
+
+    Raises a clear error if zero or multiple models are active so the operator
+    can fix the inconsistency before regenerating production projections.
+    """
+    supabase = get_supabase_client()
+    res = supabase.table("projection_models").select("name").eq("is_active", True).execute()
+    rows = res.data or []
+    if not rows:
+        raise RuntimeError(
+            "No projection_models row has is_active=True. Promote one first:\n"
+            "  python scripts/feature_projections/cli.py promote --model <name>"
+        )
+    if len(rows) > 1:
+        names = ", ".join(r["name"] for r in rows)
+        raise RuntimeError(
+            f"Multiple projection_models flagged is_active=True ({names}). "
+            "Promote a single model to disambiguate."
+        )
+    return rows[0]["name"]
 
 
 def compute_avg_rookie_ppg(multi_season_df: pd.DataFrame, players_df: pd.DataFrame,
@@ -89,10 +115,15 @@ def upsert_college_projections():
 
     drafted_no_stats: set[str] = set()
     if 'is_college' in players_df.columns:
-        # Players with any player_stats row are excluded — they go through the
-        # full feature_projections pipeline. We only need the rookies.
-        all_stats = fetch_all_rows(supabase, 'player_stats', 'player_id')
-        with_stats = {r['player_id'] for r in all_stats}
+        # Players with real NFL history go through the full feature_projections
+        # pipeline. Rows with games_played == 0 don't count — the roster scraper
+        # writes a placeholder stats row (0 games) when it first sees a player,
+        # which would otherwise mask actual rookies (e.g. drafted college players
+        # who were rostered before they took an NFL snap).
+        all_stats = fetch_all_rows(supabase, 'player_stats', 'player_id, games_played')
+        with_stats = {
+            r['player_id'] for r in all_stats if (r.get('games_played') or 0) > 0
+        }
         all_draft = fetch_all_rows(supabase, 'draft_capital', 'player_id')
         drafted = {r['player_id'] for r in all_draft}
         non_college_ids = set(
@@ -132,21 +163,23 @@ def upsert_college_projections():
 
 def update_projections() -> None:
     """Calculate projections and upsert them into the database."""
-    print(f"Generating projections across seasons {TARGET_SEASONS} using model '{ACTIVE_MODEL}'...")
+    active_model = get_active_model_name()
+    print(f"Generating projections across seasons {TARGET_SEASONS} using model '{active_model}'...")
     try:
-        # 1. Run the v8 model
+        # 1. Run the active model for the target seasons.
         subprocess.run(
-            [sys.executable, cli_path, "run", "--model", ACTIVE_MODEL, "--seasons", ",".join(map(str, TARGET_SEASONS))],
+            [sys.executable, cli_path, "run", "--model", active_model, "--seasons", ",".join(map(str, TARGET_SEASONS))],
             check=True
         )
-        # 2. Promote the v8 model
+        # 2. Promote into player_projections.
         subprocess.run(
-            [sys.executable, cli_path, "promote", "--model", ACTIVE_MODEL],
+            [sys.executable, cli_path, "promote", "--model", active_model],
             check=True
         )
-        # 3. Handle college projections (v8 model doesn't handle players with 0 NFL history)
+        # 3. Rookie/college fallback — feature_projections only emits rows for
+        # players with NFL stats history, so 0-history players are layered on top.
         upsert_college_projections()
-        
+
         print("Successfully updated player projections.")
     except subprocess.CalledProcessError as e:
         print(f"ERROR: Failed to update projections: {e}")


### PR DESCRIPTION
## Summary
- Adds `--update-rosters` flag to `backfill_draft_capital.py`. For picks in `--since` season only, flips matched college players to `is_college=False` with their NFL team and inserts player rows for unmatched picks. Maps nflverse team codes (LVR/KAN/LAR/...) to Ottoneu codes (LV/KC/LA/...).
- Extends `upsert_college_projections` to cover the post-draft state (`is_college=False` with no NFL stats yet), so newly-drafted rookies still get the position-average rookie PPG projection.
- Switches the players-table fetch in that function to `fetch_all_rows` — the unbounded `.execute()` capped at 1000 rows and was silently dropping recently-inserted rookies.

## What this enabled
Ran `python scripts/backfill_draft_capital.py --since 2026 --update-rosters` followed by `update_projections.py`. Result: all 81 fantasy-position 2026 picks now have a `draft_capital` row; 80/81 have a 2026 `player_projections` row (the missing one is the lone kicker, which `compute_avg_rookie_ppg` intentionally excludes).

## Test plan
- [x] `--dry-run --update-rosters` reports correct match/insert counts (13 update + 68 insert)
- [x] Existing college players flipped: Mendoza → LV, Love → ARI, Simpson → LA, Sadiq → NYJ, Price → SEA
- [x] New player rows inserted with stable synthetic negative `ottoneu_id` from `pfr_player_id`
- [x] All 81 rows in `draft_capital` for season 2026
- [x] 80/81 drafted players have a 2026 `player_projections` row (K excluded as designed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)