### PR TITLE
Single source of truth for active projection model

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,13 +90,14 @@ All API route bodies are validated through Zod schemas in `web/lib/schemas/` (on
 
 ## Feature Projection System (`scripts/feature_projections/`)
 
-Generates season-long player PPG projections from historical data using a combination of targeted features. The active production model (`v14_qb_starter`) uses:
-1. `weighted_ppg_no_qb_trajectory` baseline (recency-weighted PPG, without snap trajectory for QB/K)
-2. `age_curve` adjustment (career arc expectations)
-3. `regression_to_mean` (pulling extreme outliers toward positional averages)
-4. `qb_backup_penalty` (15% PPG penalty for non-starter QBs to deflate small-sample heroics)
+Generates season-long player PPG projections from historical data using a combination of targeted features.
 
-Model history: v1–v7 proved that cumulatively stacking features (stat efficiency, usage share) introduced noise. v8–v12 refined the core three features. v13 tested QB volume trends (no improvement). v14 added the backup penalty using manual starter designations — the key insight was that the starter data's value is in *penalizing backups*, not *boosting starters*.
+**Single source of truth:** the `projection_models` table — exactly one row has `is_active=TRUE` at any time. The web UI surfaces it via `fetchActiveProjectionModel()` (`web/lib/data.ts`) and the `<ActiveModelCard>` component, which renders the live model name, version, description, and feature list on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy`. Don't hardcode model names in UI copy — they drift the moment a new model is promoted.
+
+To check the live active model:
+```sql
+SELECT name, version, features FROM projection_models WHERE is_active = TRUE;
+```
 
 ### Projection Pipeline
 
@@ -134,10 +135,17 @@ Features are registered in `features/__init__.py` via `FEATURE_REGISTRY` (maps s
 The web frontend reads from `player_projections`, NOT `model_projections`. After validating a new model via backtesting, promote it:
 
 ```bash
-venv/bin/python scripts/feature_projections/promote.py v14_qb_starter
+venv/bin/python scripts/feature_projections/promote.py <model_name>
 ```
 
-This copies all projections to `player_projections`, clears `is_active` from all other models, and sets the promoted model as active. **This is a production data change** — the web app will immediately reflect the new projections.
+What promotion does, in order, for each season the new model has projections for:
+1. **Deletes all non-`college_prospect` rows** in `player_projections` for that season — this clears ghost rows from previously-active models that the new model didn't project (without it, players the prior model covered but the new one doesn't would silently retain stale projections forever).
+2. **Upserts the new model's projections** keyed on `(player_id, season)`.
+3. Clears `is_active` on every other model and sets it on the promoted one.
+
+`college_prospect` rows (no-NFL-history fallback for drafted rookies / college prospects) are preserved across promotions — `update_projections.py` recomputes them on every full pipeline run.
+
+**Production-side note:** `update_projections.py` reads `is_active` dynamically, then runs the active model and calls `promote.py` itself, so a new active model is automatically picked up on the next pipeline run. After a manual `promote.py <model_name>` invocation, run `update_projections.py` if you also want the rookie/college fallback regenerated against the new active model. **This is a production data change** — the web app reflects the change on the next request.
 
 **Important dependency:** All internal models (v1–v6) share the `weighted_ppg` base feature. Changing `WeightedPPGFeature.RECENCY_WEIGHTS` requires regenerating projections for **every** internal model via `cli.py run`, not just re-running backtests. The `--run-backtest` flag on `accuracy_report.py` only re-backtests existing projections — it does not regenerate them.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -62,7 +62,7 @@ python scripts/feature_projections/diagnostics.py --output docs/generated/player
 python scripts/feature_projections/cli.py segment-analysis                                         # Segmented accuracy analysis (all segments, default models/seasons)
 python scripts/feature_projections/cli.py segment-analysis --segments experience,age_bucket         # Specific segments only
 python scripts/feature_projections/cli.py segment-analysis --models v8_age_regression --seasons 2024,2025  # Custom models/seasons
-python scripts/feature_projections/promote.py v14_qb_starter                                           # Promote model to production player_projections table
+python scripts/feature_projections/promote.py <model_name>                                             # Promote a model to production (clears stale rows + upserts new + flips is_active)
 
 # Projection Development Workflow (two-step process)
 # Step 1: Generate projections for the model (required after any feature code change)
@@ -77,9 +77,9 @@ python scripts/feature_projections/cli.py backtest --model <name> --test-seasons
 python scripts/feature_projections/train_model.py --model v20_learned_usage --seasons 2022,2023,2024
 # Step 1-2: Same as above (run → backtest)
 
-# Model Iteration Tools
-python scripts/feature_projections/hypothesis_test.py --base-model v14_qb_starter --scale-feature age_curve=1.5 --seasons 2022,2023,2024,2025  # Quick weight experiment
-python scripts/feature_projections/hypothesis_test.py --base-model v14_qb_starter --remove-feature qb_backup_penalty --seasons 2022,2023,2024,2025  # Feature removal test
+# Model Iteration Tools (substitute --base-model with whatever currently has is_active=TRUE)
+python scripts/feature_projections/hypothesis_test.py --base-model <model_name> --scale-feature age_curve=1.5 --seasons 2022,2023,2024,2025  # Quick weight experiment
+python scripts/feature_projections/hypothesis_test.py --base-model <model_name> --remove-feature qb_backup_penalty --seasons 2022,2023,2024,2025  # Feature removal test
 python scripts/feature_projections/feature_analysis.py --model v20_learned_usage --seasons 2022,2023,2024  # Feature correlation, VIF, importance
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025  # Residual distribution, heteroscedasticity, persistent errors
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025 --output docs/generated/residual-analysis.md  # Write markdown report

--- a/scripts/feature_projections/promote.py
+++ b/scripts/feature_projections/promote.py
@@ -63,6 +63,26 @@ def promote_model(model_name: str) -> int:
 
     print(f"Promoting {len(records)} projections from model '{model_name}' to player_projections...")
 
+    # Idempotency: clear ghost rows from previously-active models before upserting.
+    # Without this, a player projected by the prior active model but NOT by the new
+    # one keeps the stale row forever (upsert is keyed on player_id+season, so it
+    # only overwrites rows the new model actually generates). College/rookie
+    # fallback rows are preserved — update_projections.py layers them on after
+    # promotion using projection_method='college_prospect'.
+    seasons_to_clear = sorted({rec["season"] for rec in records})
+    for season in seasons_to_clear:
+        deleted = (
+            supabase.table("player_projections")
+            .delete()
+            .eq("season", season)
+            .neq("projection_method", "college_prospect")
+            .execute()
+        )
+        print(
+            f"  Cleared {len(deleted.data or [])} prior-model rows "
+            f"for season {season} (kept college_prospect rows)"
+        )
+
     # Batch upsert to player_projections
     batch_size = 500
     for i in range(0, len(records), batch_size):

--- a/web/app/arbitration/page.tsx
+++ b/web/app/arbitration/page.tsx
@@ -21,6 +21,7 @@ import { getSupabaseAdmin } from "@/lib/supabase";
 import { getAuthenticatedUser } from "@/lib/auth";
 import DataTable from "@/components/DataTable";
 import ArbitrationTeams from "./ArbitrationTeams";
+import ActiveModelCard from "@/components/ActiveModelCard";
 import ModeToggle, { ValueMode } from "@/components/ModeToggle";
 import {
   playerNameCol,
@@ -197,26 +198,17 @@ export default async function ArbitrationPage({ searchParams }: Props) {
           )}
         </header>
 
-        {/* Projection Methodology (only in projected mode) */}
+        {/* Projection Methodology — driven by projection_models.is_active */}
         {isProjected && (
-          <div className="bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg p-5">
-            <h2 className="text-sm font-semibold text-blue-900 dark:text-blue-200 mb-1">
-              Projection Methodology
-            </h2>
-            <p className="text-sm text-blue-800 dark:text-blue-300">
-              <strong>v8 model (age_regression):</strong> games-weighted, recency-weighted
-              average over {historicalSeasons.join(", ")} seasons (weights:{" "}
-              <code className="text-xs bg-blue-100 dark:bg-blue-900 px-1 rounded">
-                50% / 30% / 20%
-              </code>
-              , each scaled by{" "}
-              <code className="text-xs bg-blue-100 dark:bg-blue-900 px-1 rounded">
-                games_played / 17
-              </code>
-              ) + positional age curve + regression to positional mean.
-              College prospects use positional rookie PPG averages.
-            </p>
-          </div>
+          <ActiveModelCard
+            variant="blue"
+            footer={
+              <p className="text-xs text-blue-800/80 dark:text-blue-300/80 pt-1">
+                Built from {historicalSeasons.join(", ")} history. College
+                prospects fall back to positional rookie PPG averages.
+              </p>
+            }
+          />
         )}
 
         {/* Budget Info */}

--- a/web/app/projection-accuracy/ProjectionAccuracyClient.tsx
+++ b/web/app/projection-accuracy/ProjectionAccuracyClient.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { BacktestPlayer, Position, POSITIONS, ProjectionModel } from "@/lib/types";
-import { calculateMetrics, PositionMetrics } from "./metrics";
+import { PositionMetrics } from "./metrics";
 import AccuracyScatterChart from "./AccuracyScatterChart";
 import FeatureBreakdown from "./FeatureBreakdown";
 import DataTable from "@/components/DataTable";
@@ -154,18 +154,7 @@ export default function ProjectionAccuracyClient({
     setShowCompareDropdown(false);
   };
 
-  const rookiePlayers = players.filter(
-    (p) => p.projection_method === "rookie_trajectory"
-  );
-  const rookieMetrics = calculateMetrics(rookiePlayers, "Rookies");
-
   const filteredPlayers = players.filter(
-    (p) =>
-      selectedPositions.includes(p.position as Position) &&
-      p.games_played >= minGames
-  );
-
-  const filteredRookies = rookiePlayers.filter(
     (p) =>
       selectedPositions.includes(p.position as Position) &&
       p.games_played >= minGames
@@ -591,86 +580,6 @@ export default function ProjectionAccuracyClient({
           }
         />
       </section>
-
-      {/* Rookie breakdown — only show for legacy mode */}
-      {!selectedModelId && rookiePlayers.length > 0 && (
-        <section className="border border-amber-200 dark:border-amber-800 rounded-lg p-5 space-y-4">
-          <div>
-            <h2 className="text-xl font-semibold text-slate-900 dark:text-white flex items-center gap-2">
-              Rookie Projections
-              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
-                Rookie
-              </span>
-            </h2>
-            <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-              Players projected using <strong>RookieTrajectoryPPG</strong> (one
-              prior season). Projection = prior-season PPG × H2/H1 snap
-              trajectory, clamped ±50%.
-            </p>
-          </div>
-
-          {/* Rookie summary metrics */}
-          <div className="grid grid-cols-2 sm:grid-cols-5 gap-4">
-            <SummaryCard
-              label="Rookies Backtested"
-              value={String(rookieMetrics.count)}
-            />
-            <SummaryCard
-              label="MAE"
-              value={rookieMetrics.mae.toFixed(2)}
-            />
-            <SummaryCard
-              label="Bias"
-              value={
-                (rookieMetrics.bias >= 0 ? "+" : "") +
-                rookieMetrics.bias.toFixed(2)
-              }
-              variant={
-                Math.abs(rookieMetrics.bias) < 0.2
-                  ? "default"
-                  : rookieMetrics.bias > 0
-                  ? "positive"
-                  : "negative"
-              }
-            />
-            <SummaryCard
-              label="R²"
-              value={rookieMetrics.r2.toFixed(2)}
-              variant={
-                rookieMetrics.r2 >= 0.5
-                  ? "positive"
-                  : rookieMetrics.r2 >= 0.25
-                  ? "default"
-                  : "negative"
-              }
-            />
-            <SummaryCard
-              label="RMSE"
-              value={rookieMetrics.rmse.toFixed(2)}
-            />
-          </div>
-
-          {/* Rookie player table */}
-          <DataTable
-            columns={PLAYER_COLUMNS}
-            data={filteredRookies}
-            highlightRules={[
-              {
-                key: "error",
-                op: "gte",
-                value: 3,
-                className: "bg-green-50 dark:bg-green-950",
-              },
-              {
-                key: "error",
-                op: "lte",
-                value: -3,
-                className: "bg-red-50 dark:bg-red-950",
-              },
-            ]}
-          />
-        </section>
-      )}
     </div>
   );
 }

--- a/web/app/projection-accuracy/page.tsx
+++ b/web/app/projection-accuracy/page.tsx
@@ -1,6 +1,7 @@
 import { fetchBacktestData, fetchAvailableModels, fetchModelBacktestData } from "@/lib/analysis";
 import { calculateMetricsByPosition } from "./metrics";
 import { POSITIONS, BacktestPlayer, ProjectionModel } from "@/lib/types";
+import ActiveModelCard from "@/components/ActiveModelCard";
 import ProjectionAccuracyClient from "./ProjectionAccuracyClient";
 
 export const revalidate = 3600;
@@ -65,49 +66,38 @@ export default async function ProjectionAccuracyPage({ searchParams }: Props) {
             Projection Accuracy — {targetSeason}
           </h1>
           <p className="text-slate-500 dark:text-slate-400 mt-2">
-            Backtesting composite projections: WeightedAveragePPG for veterans
-            (2+ seasons) and RookieTrajectoryPPG for first-year players.
-            Projections built from prior seasons compared to actual {targetSeason} results.
+            Backtest of the active projection model — projections built from
+            prior seasons are compared against actual {targetSeason} results.
+            Pick a different model below to compare alternatives.
           </p>
         </header>
 
-        {/* Methodology */}
-        <section className="bg-slate-50 dark:bg-slate-900 rounded-lg p-5 border border-slate-200 dark:border-slate-800 space-y-3 text-sm text-slate-700 dark:text-slate-300">
-          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
-            Methodology
-          </h2>
-          <p>
-            For each target season, prior seasons are used as projection inputs.
-            Players with <strong>2+ seasons</strong> of history use{" "}
-            <strong>WeightedAveragePPG</strong> (recency weights 0.50 / 0.30 /
-            0.20, games-scaled). Players with <strong>exactly 1 prior season</strong>{" "}
-            use <strong>RookieTrajectoryPPG</strong> (season PPG × H2/H1 snap
-            trajectory factor, clamped ±50%). Rookies are broken out separately
-            at the bottom. The resulting projection is compared to the player&apos;s
-            actual PPG in the target season.
-          </p>
-          <ul className="list-disc list-inside space-y-1">
-            <li>
-              <strong>Error</strong> = Actual PPG − Projected PPG (positive =
-              outperformed)
-            </li>
-            <li>
-              <strong>MAE</strong> — mean absolute error (lower is better)
-            </li>
-            <li>
-              <strong>Bias</strong> — mean signed error (positive = model
-              under-projects)
-            </li>
-            <li>
-              <strong>R²</strong> — proportion of variance explained (higher is
-              better, capped at 0)
-            </li>
-            <li>
-              <strong>RMSE</strong> — root mean squared error (penalises large
-              misses)
-            </li>
-          </ul>
-        </section>
+        {/* Active model — driven by projection_models.is_active */}
+        <ActiveModelCard
+          footer={
+            <ul className="list-disc list-inside space-y-1 pt-1">
+              <li>
+                <strong>Error</strong> = Actual PPG − Projected PPG (positive =
+                outperformed)
+              </li>
+              <li>
+                <strong>MAE</strong> — mean absolute error (lower is better)
+              </li>
+              <li>
+                <strong>Bias</strong> — mean signed error (positive = model
+                under-projects)
+              </li>
+              <li>
+                <strong>R²</strong> — proportion of variance explained (higher
+                is better)
+              </li>
+              <li>
+                <strong>RMSE</strong> — root mean squared error (penalises large
+                misses)
+              </li>
+            </ul>
+          }
+        />
 
         {players.length === 0 ? (
           <p className="text-slate-500 dark:text-slate-400">

--- a/web/app/projections/ProjectionsClient.tsx
+++ b/web/app/projections/ProjectionsClient.tsx
@@ -29,15 +29,8 @@ interface Props {
   projectionYear: number;
 }
 
-/** Rookie/College badge components for the player name cell. */
+/** College fallback badge for players with no NFL track record. */
 function ProjectionBadges({ method }: { method: string }) {
-  if (method === "rookie_trajectory") {
-    return (
-      <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
-        Rookie
-      </span>
-    );
-  }
   if (method === "college_prospect") {
     return (
       <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300">

--- a/web/app/projections/page.tsx
+++ b/web/app/projections/page.tsx
@@ -5,6 +5,7 @@ import {
   getHistoricalSeasonsForYear,
   SEASON,
 } from "@/lib/analysis";
+import ActiveModelCard from "@/components/ActiveModelCard";
 import ProjectionsClient from "./ProjectionsClient";
 
 export const revalidate = 3600;
@@ -47,7 +48,7 @@ export default async function ProjectionsPage({ searchParams }: Props) {
       observed_ppg: p.observed_ppg,
       projected_ppg: p.ppg,
       ppg_delta: p.ppg - p.observed_ppg,
-      projection_method: p.projection_method ?? "weighted_average_ppg",
+      projection_method: p.projection_method ?? "",
     }))
     .sort((a, b) => b.projected_ppg - a.projected_ppg);
 
@@ -77,49 +78,27 @@ export default async function ProjectionsPage({ searchParams }: Props) {
           </p>
         </header>
 
-        {/* Methodology */}
-        <section className="bg-slate-50 dark:bg-slate-900 rounded-lg p-5 border border-slate-200 dark:border-slate-800 space-y-3 text-sm text-slate-700 dark:text-slate-300">
-          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
-            Methodology (v8 — age_regression)
-          </h2>
-          <p>
-            Three additive features combined into a single projected PPG:
-          </p>
-          <ul className="list-disc list-inside space-y-1">
-            <li>
-              <strong>Weighted PPG:</strong> Games-weighted, recency-weighted
-              average across {historicalSeasons.join(", ")} with weights{" "}
-              <strong>0.50 / 0.30 / 0.20</strong> (most recent to oldest).
-              Each season is scaled by{" "}
-              <code className="bg-slate-200 dark:bg-slate-800 px-1.5 py-0.5 rounded text-xs">
-                games / 17
-              </code>{" "}
-              to discount injury-shortened years.
-            </li>
-            <li>
-              <strong>Age curve:</strong> Small adjustment (±2%) based on
-              positional age curves — players near their peak age get a boost;
-              older players get a slight discount.
-            </li>
-            <li>
-              <strong>Regression to mean:</strong> Pulls outlier projections
-              toward the positional average PPG, reducing overconfidence in
-              extreme single-season performances.
-            </li>
-            <li>
-              <strong>College Prospect (shown as{" "}
-              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300">
-                College
-              </span>):</strong>{" "}
-              Average PPG of first-year NFL players at the same position.
-            </li>
-          </ul>
-          <p className="text-xs text-slate-500 dark:text-slate-400 pt-1">
-            <strong>{SEASON} PPG</strong> — actual {SEASON} season stats &nbsp;·&nbsp;{" "}
-            <strong>Proj {projectionYear}</strong> — model output built from {historicalSeasons.join(", ")} history &nbsp;·&nbsp;{" "}
-            <strong>Δ</strong> — Proj minus {SEASON} PPG
-          </p>
-        </section>
+        {/* Methodology — driven by projection_models.is_active */}
+        <ActiveModelCard
+          footer={
+            <>
+              <p className="text-sm text-slate-700 dark:text-slate-300">
+                Built from {historicalSeasons.join(", ")} history. Players with
+                no NFL track record (drafted rookies and college prospects) use
+                a separate{" "}
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300">
+                  College
+                </span>{" "}
+                fallback set to the position-average rookie PPG.
+              </p>
+              <p className="text-xs text-slate-500 dark:text-slate-400 pt-1">
+                <strong>{SEASON} PPG</strong> — actual {SEASON} season stats &nbsp;·&nbsp;{" "}
+                <strong>Proj {projectionYear}</strong> — model output for {projectionYear} &nbsp;·&nbsp;{" "}
+                <strong>Δ</strong> — Proj minus {SEASON} PPG
+              </p>
+            </>
+          }
+        />
 
         <ProjectionsClient initialData={rows} projectionYear={projectionYear} />
       </div>

--- a/web/app/vegas-lines/page.tsx
+++ b/web/app/vegas-lines/page.tsx
@@ -71,8 +71,10 @@ export default async function VegasLinesPage({ searchParams }: Props) {
             </h1>
             <p className="text-slate-500 dark:text-slate-400 mt-1 text-sm">
               Per-team season implied total points and Pythagorean expected
-              wins, aggregated from nflverse game lines. Used as a feature in
-              the <code>v27_vegas_full_refit</code> projection model.
+              wins, aggregated from nflverse game lines. Available as the
+              <code className="ml-1">implied_team_total_raw</code> feature for
+              projection models — see <a href="/projections" className="underline">/projections</a>{" "}
+              for which model is currently active.
             </p>
           </div>
           <SeasonSelector currentSeason={targetSeason} seasons={seasons} />

--- a/web/components/ActiveModelCard.tsx
+++ b/web/components/ActiveModelCard.tsx
@@ -1,0 +1,80 @@
+import { fetchActiveProjectionModel } from "@/lib/data";
+
+interface Props {
+  /** Optional intro sentence rendered above the model summary. */
+  children?: React.ReactNode;
+  /** Optional additional notes rendered after the feature list. */
+  footer?: React.ReactNode;
+  /** Visual variant — slate matches /projections, blue matches /arbitration projected mode. */
+  variant?: "slate" | "blue";
+}
+
+/**
+ * Server component that renders methodology metadata for whichever projection
+ * model is currently flagged is_active=TRUE in projection_models.
+ *
+ * This is the single source of truth for "which model is the site serving"
+ * across /projections, /arbitration projected mode, and /projection-accuracy.
+ * Promote a different model via scripts/feature_projections/promote.py and
+ * every consumer updates on the next render.
+ */
+export default async function ActiveModelCard({ children, footer, variant = "slate" }: Props) {
+  const model = await fetchActiveProjectionModel();
+
+  const wrapperClass =
+    variant === "blue"
+      ? "bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg p-5 space-y-2"
+      : "bg-slate-50 dark:bg-slate-900 rounded-lg p-5 border border-slate-200 dark:border-slate-800 space-y-3 text-sm text-slate-700 dark:text-slate-300";
+
+  const headingClass =
+    variant === "blue"
+      ? "text-sm font-semibold text-blue-900 dark:text-blue-200"
+      : "text-lg font-semibold text-slate-900 dark:text-white";
+
+  const bodyClass =
+    variant === "blue"
+      ? "text-sm text-blue-800 dark:text-blue-300"
+      : "text-sm text-slate-700 dark:text-slate-300";
+
+  const codeClass =
+    variant === "blue"
+      ? "text-xs bg-blue-100 dark:bg-blue-900 px-1 rounded"
+      : "text-xs bg-slate-200 dark:bg-slate-800 px-1.5 py-0.5 rounded";
+
+  if (!model) {
+    return (
+      <section className={wrapperClass}>
+        <h2 className={headingClass}>Projection model</h2>
+        <p className={bodyClass}>
+          No active projection model is configured. Promote one with{" "}
+          <code className={codeClass}>
+            venv/bin/python scripts/feature_projections/promote.py &lt;model_name&gt;
+          </code>
+          .
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className={wrapperClass}>
+      <h2 className={headingClass}>
+        Projection model: <code className={codeClass}>{model.name}</code> (v{model.version})
+      </h2>
+      {children}
+      {model.description && <p className={bodyClass}>{model.description}</p>}
+      {model.features.length > 0 && (
+        <p className={bodyClass}>
+          <strong>Features:</strong>{" "}
+          {model.features.map((f, i) => (
+            <span key={f}>
+              <code className={codeClass}>{f}</code>
+              {i < model.features.length - 1 ? " · " : ""}
+            </span>
+          ))}
+        </p>
+      )}
+      {footer}
+    </section>
+  );
+}

--- a/web/lib/data.ts
+++ b/web/lib/data.ts
@@ -369,3 +369,44 @@ export async function fetchPlayerProjection(
     projection_method: data.projection_method,
   };
 }
+
+// ─── Active Projection Model ──────────────────────────────────────────────────
+
+export interface ActiveProjectionModel {
+  id: string;
+  name: string;
+  version: number;
+  description: string | null;
+  features: string[];
+}
+
+/**
+ * Fetch the projection model currently flagged is_active=TRUE.
+ *
+ * Single source of truth for "which model is the site serving right now".
+ * Methodology blurbs across /projections, /arbitration, /projection-accuracy
+ * read from this so they stay in sync with what `promote.py` last set.
+ */
+export async function fetchActiveProjectionModel(): Promise<ActiveProjectionModel | null> {
+  const { data, error } = await supabase
+    .from("projection_models")
+    .select("id, name, version, description, features")
+    .eq("is_active", true)
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  const features = Array.isArray(data.features)
+    ? (data.features as string[])
+    : typeof data.features === "string"
+      ? (JSON.parse(data.features) as string[])
+      : [];
+
+  return {
+    id: data.id,
+    name: data.name,
+    version: data.version,
+    description: data.description ?? null,
+    features,
+  };
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -208,7 +208,7 @@ export interface BacktestPlayer {
   abs_error: number;
   seasons_used: string;       // pre-serialized: "2022, 2023, 2024"
   games_played: number;
-  projection_method: string;  // "rookie_trajectory" | "weighted_average_ppg" | "model"
+  projection_method: string;  // active model name (e.g. "v25_draft_capital_residual"), "college_prospect", or "model" for ad-hoc backtests
   feature_values?: Record<string, number | null> | null;
 }
 


### PR DESCRIPTION
## Summary
- Methodology blurbs on /projections, /arbitration (projected mode), and /projection-accuracy were hardcoded to `v8 — age_regression / 0.50/0.30/0.20`, while `projection_models.is_active` points to `v25_draft_capital_residual`. They now read from the DB via a new `<ActiveModelCard />` server component fed by `fetchActiveProjectionModel()` in `web/lib/data.ts`.
- `scripts/feature_projections/promote.py` upserted on `(player_id, season)`, so any player projected by a prior active model but not by the new one kept its stale row forever. As of this audit, 21 ghost rows from `v12_no_qb_trajectory` (e.g. Saquon Barkley, Travis Kelce) were still serving for season 2026. Promote now deletes non-`college_prospect` rows for each promoted season before upserting — promotion is idempotent and self-healing. Re-ran promote on `v25_draft_capital_residual` with the new code; the ghosts are gone.
- Dead code cleanup: dropped never-matching `rookie_trajectory` Rookie badge in `ProjectionsClient`, dropped the `rookie_trajectory`-gated section in `ProjectionAccuracyClient`, dropped the stale `?? "weighted_average_ppg"` fallback, fixed the misleading `projection_method` type comment, and stopped hardcoding a model name in the /vegas-lines footnote.
- Docs: `ARCHITECTURE.md` and `COMMANDS.md` no longer name a specific active model; `ARCHITECTURE.md` documents the new promote.py guarantees.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — only pre-existing warnings
- [x] `npx jest` — 22 suites, 223 tests pass
- [x] DB query confirms only `v25_draft_capital_residual` + `college_prospect` rows remain in `player_projections`
- [ ] Smoke /projections, /arbitration?mode=projected, /projection-accuracy, /vegas-lines in the browser to confirm the model name renders dynamically and no layout regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)