### PR TITLE
chore: gitignore .claude/plans and .claude/projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,10 @@
 # VS Code
 .vscode/
 
-# Claude Code worktrees
+# Claude Code local state
 .claude/worktrees/
+.claude/plans/
+.claude/projects/
 
 # Python / Backend
 venv/


### PR DESCRIPTION
## Summary
- Add `.claude/plans/` and `.claude/projects/` to `.gitignore` alongside the existing `.claude/worktrees/` entry — these are local Claude Code state dirs that kept showing up as untracked.
- Cleanup-only PR; no source code touched.

Companion local cleanup (not in this PR, files were never tracked):
- Removed stale `PROJECTION_ARCHITECTURE.md` from repo root (Mar 28; called `v17_rookie_growth` the best model — current registry is on v27).
- Removed orphan `scripts/feature_projections/trained_models/v24_learned_elite.json` — `model_config.py` skips from v23 → v25, so this file was never wired in.
- Removed `.claude/plans/composed-mapping-seal-agent-*.md` (old per-session plan) and `.claude/projects/` (stray local memory copy).

## Test plan
- [x] `git status` is clean after the change
- [x] No tracked files were touched besides `.gitignore`