### PR TITLE
feat: project drafted rookies from draft capital

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,7 +110,7 @@ model_config.py  →  runner.py  →  model_projections table  →  promote.py  
 - `qb_starters.py` — loads manual QB starter designations from `data/qb_starters.json`, resolves names to player IDs
 - `runner.py` — fetches historical player_stats + nfl_stats, loads QB starters, runs combiner, batch upserts
 - `combiner.py` — base feature PPG + weighted sum of adjustment feature deltas
-- `backtest.py` — compares projected_ppg to actual actuals (MAE, RMSE per model)
+- `backtest.py` — compares projected_ppg to actual actuals (MAE, RMSE per model). True rookies (no `player_stats` row with games > 0 in any season prior to the target) are excluded from accuracy metrics — the rookie projection path is shared across all models, so including them only adds correlated noise to cross-model comparisons.
 - `accuracy_report.py` — side-by-side model comparison table across all seasons (no `--models` filter; always runs all models)
 - `promote.py` — copies a model's projections to the production `player_projections` table and sets it as active
 - `sweep_recency_weights.py` — in-memory weight sweep for base feature tuning (no DB writes)
@@ -139,11 +139,13 @@ venv/bin/python scripts/feature_projections/promote.py <model_name>
 ```
 
 What promotion does, in order, for each season the new model has projections for:
-1. **Deletes all non-`college_prospect` rows** in `player_projections` for that season — this clears ghost rows from previously-active models that the new model didn't project (without it, players the prior model covered but the new one doesn't would silently retain stale projections forever).
+1. **Deletes all non-rookie-fallback rows** in `player_projections` for that season — this clears ghost rows from previously-active models that the new model didn't project (without it, players the prior model covered but the new one doesn't would silently retain stale projections forever). Rows tagged `college_prospect` or `rookie_draft_capital` are preserved.
 2. **Upserts the new model's projections** keyed on `(player_id, season)`.
 3. Clears `is_active` on every other model and sets it on the promoted one.
 
-`college_prospect` rows (no-NFL-history fallback for drafted rookies / college prospects) are preserved across promotions — `update_projections.py` recomputes them on every full pipeline run.
+Rookie fallback rows (no-NFL-history players) are preserved across promotions and recomputed by `update_projections.py` on every full pipeline run. Two flavors are produced:
+- `rookie_draft_capital` — drafted rookies with a `draft_capital` row, projected from a per-position OLS of historical year-1 PPG on log-scaled overall pick.
+- `college_prospect` — undrafted/college rookies (no `draft_capital`), projected as the position-mean rookie PPG.
 
 **Production-side note:** `update_projections.py` reads `is_active` dynamically, then runs the active model and calls `promote.py` itself, so a new active model is automatically picked up on the next pipeline run. After a manual `promote.py <model_name>` invocation, run `update_projections.py` if you also want the rookie/college fallback regenerated against the new active model. **This is a production data change** — the web app reflects the change on the next request.
 

--- a/scripts/feature_projections/backtest.py
+++ b/scripts/feature_projections/backtest.py
@@ -71,6 +71,14 @@ def backtest_model(
     players_data = fetch_all_rows(supabase, "players", "id, position")
     pos_map = {row["id"]: row["position"] for row in players_data}
 
+    # Fetch all qualifying player_stats rows once. Used to identify "true
+    # rookies" (no prior NFL games) so they can be excluded from accuracy —
+    # the rookie projection path is the same across all models, so including
+    # them would only add shared noise to cross-model comparisons.
+    all_stats = fetch_all_rows(
+        supabase, "player_stats", "player_id, games_played, season"
+    )
+
     all_results = {}
 
     for season in test_seasons:
@@ -101,12 +109,23 @@ def backtest_model(
             print(f"  No actual stats found for season {season}")
             continue
 
+        # Players with at least one qualifying NFL season prior to this one.
+        # Excludes true rookies from accuracy (see comment near all_stats fetch).
+        had_prior_stats: set[str] = {
+            r["player_id"]
+            for r in all_stats
+            if r.get("season") is not None
+            and int(r["season"]) < int(season)
+            and (r.get("games_played") or 0) > 0
+        }
+
         # Build paired data by position
         position_data: dict[str, tuple[list[float], list[float]]] = {
             pos: ([], []) for pos in POSITIONS
         }
         all_projected: list[float] = []
         all_actual: list[float] = []
+        rookies_skipped = 0
 
         for row in actuals_res.data:
             pid = row["player_id"]
@@ -114,6 +133,9 @@ def backtest_model(
             if games < min_games:
                 continue
             if pid not in proj_map:
+                continue
+            if pid not in had_prior_stats:
+                rookies_skipped += 1
                 continue
 
             actual_ppg = float(row["ppg"])
@@ -126,6 +148,9 @@ def backtest_model(
             if position and position in position_data:
                 position_data[position][0].append(projected_ppg)
                 position_data[position][1].append(actual_ppg)
+
+        if rookies_skipped:
+            print(f"  Excluded {rookies_skipped} true-rookie player(s) from accuracy")
 
         # Compute metrics
         season_results = {}

--- a/scripts/feature_projections/promote.py
+++ b/scripts/feature_projections/promote.py
@@ -66,21 +66,23 @@ def promote_model(model_name: str) -> int:
     # Idempotency: clear ghost rows from previously-active models before upserting.
     # Without this, a player projected by the prior active model but NOT by the new
     # one keeps the stale row forever (upsert is keyed on player_id+season, so it
-    # only overwrites rows the new model actually generates). College/rookie
-    # fallback rows are preserved — update_projections.py layers them on after
-    # promotion using projection_method='college_prospect'.
+    # only overwrites rows the new model actually generates). Rookie fallback
+    # rows are preserved — update_projections.py layers them on after promotion
+    # using projection_method='college_prospect' (no draft capital) or
+    # 'rookie_draft_capital' (drafted rookies, no NFL stats yet).
+    rookie_methods = ("college_prospect", "rookie_draft_capital")
     seasons_to_clear = sorted({rec["season"] for rec in records})
     for season in seasons_to_clear:
         deleted = (
             supabase.table("player_projections")
             .delete()
             .eq("season", season)
-            .neq("projection_method", "college_prospect")
+            .not_.in_("projection_method", list(rookie_methods))
             .execute()
         )
         print(
             f"  Cleared {len(deleted.data or [])} prior-model rows "
-            f"for season {season} (kept college_prospect rows)"
+            f"for season {season} (kept rookie fallback rows: {rookie_methods})"
         )
 
     # Batch upsert to player_projections

--- a/scripts/projection_methods.py
+++ b/scripts/projection_methods.py
@@ -12,7 +12,10 @@ Adding a new projection method = one new class, no pipeline changes needed.
 """
 
 from __future__ import annotations
-from typing import Optional, Protocol, TypedDict
+
+import math
+from collections import defaultdict
+from typing import Iterable, Optional, Protocol, TypedDict
 
 
 class SeasonData(TypedDict, total=False):
@@ -135,4 +138,68 @@ class CollegeProspectPPG:
         """
         if not position:
             return None
+        return self._avg_ppg.get(position)
+
+
+class RookieDraftCapitalPPG:
+    """Projection for true rookies (no NFL stats yet) using draft capital.
+
+    Fits a per-position OLS of year-1 PPG on a log-scaled overall pick score,
+    x = log(TOTAL_PICKS) − log(overall_pick), from historical rookies who
+    have a draft_capital row and a qualifying year-1 PPG. At projection
+    time, returns ``intercept + slope * x`` clamped to ≥ 0. Positions with
+    fewer than ``MIN_SAMPLES`` historical rookies (or rookies without a
+    ``draft_capital`` row, e.g. UDFAs and college players) fall back to a
+    supplied position-mean rookie PPG — same behavior as CollegeProspectPPG.
+    """
+
+    name = "rookie_draft_capital"
+    TOTAL_PICKS = 257
+    MIN_SAMPLES = 5
+
+    def __init__(
+        self,
+        coefficients: dict[str, tuple[float, float]],
+        avg_rookie_ppg_by_position: dict[str, float] | None = None,
+    ):
+        self._coef = coefficients
+        self._avg_ppg = avg_rookie_ppg_by_position or {}
+
+    @classmethod
+    def fit(
+        cls,
+        rookie_samples: Iterable[tuple[str, int, float]],
+    ) -> dict[str, tuple[float, float]]:
+        """Fit per-position OLS from (position, overall_pick, year1_ppg) tuples."""
+        import numpy as np
+
+        by_pos: dict[str, list[tuple[float, float]]] = defaultdict(list)
+        for pos, pick, ppg in rookie_samples:
+            if not pos or pick is None or int(pick) <= 0:
+                continue
+            x = math.log(cls.TOTAL_PICKS) - math.log(int(pick))
+            by_pos[pos].append((x, float(ppg)))
+
+        coef: dict[str, tuple[float, float]] = {}
+        for pos, pairs in by_pos.items():
+            if len(pairs) < cls.MIN_SAMPLES:
+                continue
+            x_arr = np.array([p[0] for p in pairs])
+            y_arr = np.array([p[1] for p in pairs])
+            slope, intercept = np.polyfit(x_arr, y_arr, 1)
+            coef[pos] = (float(intercept), float(slope))
+        return coef
+
+    def project_ppg(
+        self,
+        history: list[SeasonData],
+        position: str | None = None,
+        overall_pick: int | None = None,
+    ) -> Optional[float]:
+        if not position:
+            return None
+        if overall_pick is not None and int(overall_pick) > 0 and position in self._coef:
+            x = math.log(self.TOTAL_PICKS) - math.log(int(overall_pick))
+            intercept, slope = self._coef[position]
+            return max(0.0, intercept + slope * x)
         return self._avg_ppg.get(position)

--- a/scripts/tests/test_projection_methods.py
+++ b/scripts/tests/test_projection_methods.py
@@ -1,14 +1,17 @@
 """
 Unit tests for projection methods — WeightedAveragePPG, RookieTrajectoryPPG,
-and CollegeProspectPPG.
+CollegeProspectPPG, and RookieDraftCapitalPPG.
 
 These are pure functions with no DB or network dependencies.
 """
+import math
+
 import pytest
 from scripts.projection_methods import (
     CollegeProspectPPG,
-    WeightedAveragePPG,
+    RookieDraftCapitalPPG,
     RookieTrajectoryPPG,
+    WeightedAveragePPG,
 )
 
 
@@ -246,3 +249,67 @@ class TestCollegeProspectPPG:
 
     def test_method_name(self):
         assert self.method.name == "college_prospect"
+
+
+# ---------------------------------------------------------------------------
+# RookieDraftCapitalPPG
+# ---------------------------------------------------------------------------
+
+class TestRookieDraftCapitalPPG:
+    """Tests for the draft-capital-based rookie projection."""
+
+    def _x(self, pick: int) -> float:
+        return math.log(RookieDraftCapitalPPG.TOTAL_PICKS) - math.log(pick)
+
+    def test_method_name(self):
+        method = RookieDraftCapitalPPG({}, {})
+        assert method.name == "rookie_draft_capital"
+
+    def test_fit_skips_positions_below_min_samples(self):
+        # 4 RB samples, but MIN_SAMPLES is 5 — RB should be dropped.
+        samples = [("RB", 1, 12.0), ("RB", 32, 8.0), ("RB", 100, 4.0), ("RB", 200, 2.0)]
+        coef = RookieDraftCapitalPPG.fit(samples)
+        assert "RB" not in coef
+
+    def test_fit_recovers_linear_relation(self):
+        # y = 1 + 2*x exactly for picks {1, 16, 64, 128, 200}
+        picks = [1, 16, 64, 128, 200]
+        samples = [("WR", p, 1.0 + 2.0 * self._x(p)) for p in picks]
+        coef = RookieDraftCapitalPPG.fit(samples)
+        intercept, slope = coef["WR"]
+        assert intercept == pytest.approx(1.0, abs=1e-6)
+        assert slope == pytest.approx(2.0, abs=1e-6)
+
+    def test_fit_ignores_invalid_picks(self):
+        good = [("WR", p, 1.0 + 2.0 * self._x(p)) for p in [1, 16, 64, 128, 200]]
+        bad = [("WR", 0, 99.0), ("WR", -5, 99.0), ("", 10, 5.0)]
+        coef = RookieDraftCapitalPPG.fit(good + bad)
+        intercept, slope = coef["WR"]
+        assert intercept == pytest.approx(1.0, abs=1e-6)
+        assert slope == pytest.approx(2.0, abs=1e-6)
+
+    def test_project_uses_fit_when_pick_known(self):
+        method = RookieDraftCapitalPPG({"WR": (1.0, 2.0)}, {"WR": 5.0})
+        expected = 1.0 + 2.0 * self._x(32)
+        assert method.project_ppg([], position="WR", overall_pick=32) == pytest.approx(expected)
+
+    def test_project_clamps_negative_to_zero(self):
+        # Steep negative slope + high pick → negative prediction → clamp to 0.
+        method = RookieDraftCapitalPPG({"WR": (-100.0, 0.0)}, {})
+        assert method.project_ppg([], position="WR", overall_pick=1) == pytest.approx(0.0)
+
+    def test_project_falls_back_to_avg_when_no_pick(self):
+        method = RookieDraftCapitalPPG({"WR": (1.0, 2.0)}, {"WR": 5.5})
+        assert method.project_ppg([], position="WR", overall_pick=None) == pytest.approx(5.5)
+
+    def test_project_falls_back_to_avg_when_position_has_no_fit(self):
+        method = RookieDraftCapitalPPG({"WR": (1.0, 2.0)}, {"RB": 6.5})
+        assert method.project_ppg([], position="RB", overall_pick=10) == pytest.approx(6.5)
+
+    def test_project_returns_none_with_no_fit_and_no_avg(self):
+        method = RookieDraftCapitalPPG({}, {})
+        assert method.project_ppg([], position="QB", overall_pick=5) is None
+
+    def test_project_returns_none_when_position_missing(self):
+        method = RookieDraftCapitalPPG({"WR": (1.0, 2.0)}, {"WR": 5.0})
+        assert method.project_ppg([], position=None, overall_pick=5) is None

--- a/scripts/update_projections.py
+++ b/scripts/update_projections.py
@@ -10,6 +10,8 @@ To switch which model the website serves, promote a different model:
     python scripts/feature_projections/cli.py promote --model v25_draft_capital_residual
 """
 
+from __future__ import annotations
+
 import os
 import subprocess
 import sys
@@ -21,7 +23,7 @@ if script_dir not in sys.path:
     sys.path.append(script_dir)
 from config import get_supabase_client, MIN_GAMES
 from analysis_utils import fetch_multi_season_stats
-from projection_methods import CollegeProspectPPG
+from projection_methods import CollegeProspectPPG, RookieDraftCapitalPPG
 
 cli_path = os.path.join(script_dir, "feature_projections", "cli.py")
 TARGET_SEASONS = [2024, 2025, 2026]
@@ -71,23 +73,72 @@ def compute_avg_rookie_ppg(multi_season_df: pd.DataFrame, players_df: pd.DataFra
     return {pos: sum(ppgs) / len(ppgs) for pos, ppgs in rookie_ppgs.items() if ppgs}
 
 
+def compute_rookie_draft_samples(multi_season_df: pd.DataFrame, players_df: pd.DataFrame,
+                                  pick_by_player: dict[str, int],
+                                  min_games: int = MIN_GAMES) -> list[tuple[str, int, float]]:
+    """Build (position, overall_pick, year1_ppg) samples from historical rookies.
+
+    A "rookie sample" is a player whose only season in the window is their
+    first, who qualifies by min_games, has a known position, and has a
+    ``draft_capital`` row. Used to fit RookieDraftCapitalPPG's per-position OLS.
+    """
+    if multi_season_df.empty or players_df.empty or not pick_by_player:
+        return []
+    pos_map = dict(zip(players_df['player_id_ref'], players_df['position']))
+    samples: list[tuple[str, int, float]] = []
+    for player_id, group in multi_season_df.groupby('player_id'):
+        if len(group) != 1:
+            continue
+        row = group.iloc[0]
+        if int(row['games_played']) < min_games:
+            continue
+        pos = pos_map.get(str(player_id))
+        if not pos or pos == 'K':
+            continue
+        pick = pick_by_player.get(str(player_id))
+        if not pick or int(pick) <= 0:
+            continue
+        samples.append((pos, int(pick), float(row['ppg'])))
+    return samples
+
+
 def generate_college_projections(avg_rookie_ppg: dict[str, float],
-                                  college_players: list[dict], target_season: int) -> pd.DataFrame:
-    """Generate projections for college players using average rookie PPG."""
-    if not avg_rookie_ppg:
-        return pd.DataFrame()
+                                  college_players: list[dict], target_season: int,
+                                  rookie_method: RookieDraftCapitalPPG | None = None,
+                                  pick_by_player: dict[str, int] | None = None) -> pd.DataFrame:
+    """Generate projections for rookies (drafted + true college).
+
+    Drafted rookies (have an entry in ``pick_by_player``) are projected via
+    ``rookie_method`` using their overall pick and tagged
+    ``rookie_draft_capital``. Other rookies fall back to the position-mean
+    ``CollegeProspectPPG``. Rows without a usable projection are skipped.
+    """
     if not college_players:
         return pd.DataFrame()
-    method = CollegeProspectPPG(avg_rookie_ppg)
+    college_method = CollegeProspectPPG(avg_rookie_ppg) if avg_rookie_ppg else None
+    pick_by_player = pick_by_player or {}
     records = []
     for player in college_players:
-        projected = method.project_ppg([], position=player['position'])
-        if projected is not None:
+        pid = str(player['id'])
+        position = player['position']
+        pick = pick_by_player.get(pid)
+        projected: float | None = None
+        method_name: str | None = None
+
+        if rookie_method is not None and pick:
+            projected = rookie_method.project_ppg([], position=position, overall_pick=pick)
+            method_name = rookie_method.name
+
+        if projected is None and college_method is not None:
+            projected = college_method.project_ppg([], position=position)
+            method_name = college_method.name
+
+        if projected is not None and method_name is not None:
             records.append({
-                'player_id': str(player['id']),
+                'player_id': pid,
                 'season': target_season,
                 'projected_ppg': float(projected),
-                'projection_method': method.name,
+                'projection_method': method_name,
             })
     return pd.DataFrame(records)
 
@@ -114,6 +165,7 @@ def upsert_college_projections():
         return
 
     drafted_no_stats: set[str] = set()
+    pick_by_player: dict[str, int] = {}
     if 'is_college' in players_df.columns:
         # Players with real NFL history go through the full feature_projections
         # pipeline. Rows with games_played == 0 don't count — the roster scraper
@@ -124,8 +176,13 @@ def upsert_college_projections():
         with_stats = {
             r['player_id'] for r in all_stats if (r.get('games_played') or 0) > 0
         }
-        all_draft = fetch_all_rows(supabase, 'draft_capital', 'player_id')
+        all_draft = fetch_all_rows(supabase, 'draft_capital', 'player_id, overall_pick')
         drafted = {r['player_id'] for r in all_draft}
+        pick_by_player = {
+            r['player_id']: int(r['overall_pick'])
+            for r in all_draft
+            if r.get('overall_pick') is not None
+        }
         non_college_ids = set(
             players_df[players_df['is_college'] == False]['player_id_ref'].tolist()  # noqa: E712
         )
@@ -145,9 +202,23 @@ def upsert_college_projections():
         historical_seasons = list(range(season - 3, season))
         multi_season_df = fetch_multi_season_stats(historical_seasons)
         avg_rookie_ppg = compute_avg_rookie_ppg(multi_season_df, players_df)
-        if avg_rookie_ppg:
-            print(f"  Avg rookie PPG for {season}: {avg_rookie_ppg}")
-            college_df = generate_college_projections(avg_rookie_ppg, college_players, season)
+
+        rookie_method: RookieDraftCapitalPPG | None = None
+        samples = compute_rookie_draft_samples(multi_season_df, players_df, pick_by_player)
+        if samples:
+            coef = RookieDraftCapitalPPG.fit(samples)
+            if coef:
+                rookie_method = RookieDraftCapitalPPG(coef, avg_rookie_ppg)
+                print(f"  Rookie draft-capital fit for {season}: "
+                      f"{ {p: (round(a, 2), round(b, 2)) for p, (a, b) in coef.items()} }")
+
+        if avg_rookie_ppg or rookie_method is not None:
+            if avg_rookie_ppg:
+                print(f"  Avg rookie PPG for {season}: {avg_rookie_ppg}")
+            college_df = generate_college_projections(
+                avg_rookie_ppg, college_players, season,
+                rookie_method=rookie_method, pick_by_player=pick_by_player,
+            )
             if not college_df.empty:
                 all_records.extend(college_df.to_dict('records'))
 


### PR DESCRIPTION
## Summary
- Drafted rookies (have a `draft_capital` row, no NFL stats yet) now get a per-position projection that reflects where they were picked, instead of the position-mean rookie PPG. New `RookieDraftCapitalPPG` fits OLS of historical year-1 PPG on `log(257) − log(overall_pick)` and tags rows `rookie_draft_capital`. UDFA/college rookies (no draft capital) still fall back to `college_prospect`.
- Backtest now excludes true rookies (no prior `player_stats` row with games > 0) from accuracy metrics — the rookie path is shared across all models, so including them only adds correlated noise to cross-model comparisons.
- `promote.py` preserves both `college_prospect` and `rookie_draft_capital` rows across model promotions.

## Sample fits (real data)
For the 2026 window (history 2023–2025, 92 samples):
- QB: pick 1 ≈ 11.2 PPG, pick 200 ≈ 8.2
- RB: pick 1 ≈ 17.3, pick 200 ≈ 3.5
- WR: pick 1 ≈ 8.8, pick 200 ≈ 7.0
- TE: pick 1 ≈ 17.4, pick 200 ≈ 1.6

Predictions are clamped to ≥ 0; positions with fewer than 5 historical rookie samples fall back to the position-mean.

## Test plan
- [x] `venv/bin/python -m pytest scripts/tests/` — 792 passed, 25 skipped
- [x] 10 new unit tests for `RookieDraftCapitalPPG` (fit recovery, MIN_SAMPLES skip, invalid-pick handling, clamping, fallback paths) — module hits 100% coverage
- [x] Smoke check on real DB confirms sensible per-position fits and that `RookieDraftCapitalPPG.fit` skips positions with < 5 samples
- [ ] Run `scripts/update_projections.py` end-to-end after merge to refresh `player_projections` with the new `rookie_draft_capital` rows
- [ ] Re-run `accuracy_report.py --run-backtest` to regenerate model comparisons under the new rookie-exclusion filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)