### PR TITLE
docs: daily harness audit 2026-05-08

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -84,6 +84,12 @@ python scripts/feature_projections/feature_analysis.py --model v20_learned_usage
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025  # Residual distribution, heteroscedasticity, persistent errors
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025 --output docs/generated/residual-analysis.md  # Write markdown report
 
+# Backfills / Seeds
+python scripts/backfill_nfl_stats.py --seasons 2024              # Backfill nflverse stats (snap counts, advanced receiving) for given seasons
+python scripts/backfill_draft_capital.py --since 2010            # Load nflverse draft_picks → draft_capital table
+python scripts/backfill_vegas_lines.py --since 2016              # Load implied totals + Pythagorean win totals from nflverse games.csv → team_vegas_lines
+python scripts/seed_preseason_win_totals.py --season 2026        # Seed hand-curated preseason win totals (implied_total NULL until schedule release)
+
 # Utilities
 python scripts/check_db.py                           # Verify database contents
 streamlit run scripts/visualize_app.py               # Streamlit dashboard
@@ -122,6 +128,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds (variadic — pass through any flags the script supports)
+just backfill-nfl-stats --seasons 2024              # Pull nflverse stats for given seasons (--dry-run supported)
+just backfill-draft-capital --since 2010            # Load nflverse draft_picks into draft_capital
+just backfill-vegas --since 2016                    # Load implied totals + Pythagorean win totals from nflverse games.csv
+just seed-win-totals --season 2026                  # Seed hand-curated preseason win totals (implied_total NULL until schedule drops)
+
+# Ad-hoc DB queries
+just py "<python-snippet>"                          # Run a one-off snippet against the project venv (read-only diagnostics)
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Preseason Vegas implied team totals + win totals by season, grouped by NFL division |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |
@@ -38,6 +39,10 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Server component that renders the currently-active projection model's name, version, description, and feature list. Used on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` so methodology copy follows whichever model has `is_active=TRUE` in `projection_models` |
+| `ProjectionYearSelector` | Season picker for projection-driven views |
+| `PositionTierBreakdown` | Per-position tier summary (elite / starter / bench) used in projection accuracy and surplus views |
+| `GlobalPlayerSearch` | Repo-wide player search box rendered in the navigation bar |
 
 ### Column Factories (`components/columns.tsx`)
 
@@ -59,7 +64,7 @@ Shared type definitions in `web/lib/types.ts`:
 
 ## Analysis Logic
 
-Analysis math is ported to `web/lib/analysis.ts` (TS equivalent of `scripts/analysis_utils.py`). Arbitration simulation logic lives in `web/lib/arb-logic.ts`.
+Analysis math is ported to `web/lib/analysis.ts` (TS equivalent of `scripts/analysis_utils.py`). Arbitration simulation logic lives in `web/lib/arb-logic.ts`. Vegas lines fetch helpers live in `web/lib/vegas-lines.ts`, and division/team-code mapping for the `/vegas-lines` page is in `web/lib/nfl-divisions.ts`.
 
 ## Configuration
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -24,7 +24,7 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total + preseason win total, aggregated from nflverse `games.csv` (implied) and seeded sportsbook lines (win total) | `(team, season)` |
 
 ### Projection tables detail
 
@@ -64,6 +64,19 @@ Ottoneu fantasy data only: `games_played`, `snaps`, `ppg`, `pps`, `h1_snaps`, `h
 Core stat columns: `games_played`, `passing_yards`, `passing_tds`, `interceptions`, `passing_attempts`, `completions`, `rushing_yards`, `rushing_tds`, `rushing_attempts`, `receptions`, `targets`, `receiving_yards`, `receiving_tds`, `fg_made_0_39`, `fg_made_40_49`, `fg_made_50_plus`, `pat_made`, `total_points`, `ppg`, `offense_snaps`, `defense_snaps`, `st_snaps`, `total_snaps`, `recent_team`.
 
 Advanced receiving (added in migration 022, populated for 2018+ via nflverse `stats_player`): `target_share`, `air_yards_share`, `wopr` (Weighted Opportunity Rating), `racr` (Receiver Air Conversion Ratio), `receiving_air_yards`.
+
+### `draft_capital` columns (migration 023)
+
+`player_id` (FK -> `players`, unique), `season_drafted` int, `round` int, `overall_pick` int. Indexed on `player_id` and `season_drafted`. Populated by `scripts/backfill_draft_capital.py` from nflverse `draft_picks`. Consumed by the `draft_capital_raw` projection feature.
+
+### `team_vegas_lines` columns (migrations 024–025)
+
+`team` text, `season` int, `implied_total` numeric(6,2) **NULLABLE** (migration 025), `win_total` numeric(4,1) nullable. Unique on `(team, season)`; indexed on `team` and `season`. Populated by:
+
+- `scripts/backfill_vegas_lines.py` — derives `implied_total` (and `win_total` as a Pythagorean estimate) from nflverse `games.csv` once the NFL schedule is published.
+- `scripts/seed_preseason_win_totals.py` — hand-curated `win_total` rows seeded in March/April when sportsbooks publish season-long lines but the schedule has not yet been released. `implied_total` is left NULL on these rows and backfilled later. Migration 025 dropped the NOT NULL constraint to support this two-stage seed/backfill flow.
+
+Consumed by the `implied_team_total_raw` projection feature, which returns `None` when `implied_total` is missing — the learned ridge then substitutes `0.0` (~league mean after centering), so v27 gracefully degrades to roughly v23 behavior in the preseason gap.
 
 ## Schema Files
 


### PR DESCRIPTION
## Summary

Daily sweep of the harness docs (CLAUDE.md, AGENTS.md, docs/**, .claude/commands/**) to catch drift introduced by recent merges. Focus on the schema doc and on routes/components/recipes that landed in the last 24h but weren't documented.

## Commits reviewed (since last run)

- 1e5dcde feat: project drafted rookies from draft capital (#487)
- 384a445 chore: gitignore .claude/plans and .claude/projects (#486)
- 559228b chore: broaden Claude permission allowlist + add backfill recipes (#485)
- aa593d6 chore: single source of truth for active projection model (#484)
- 571f63e feat: backfill 2026 NFL draft + project drafted rookies (#482)
- 4931648 feat: seed 2026 preseason win totals (implied_total nullable) (#481)
- 6cdb5b1 feat: vegas lines review page (#480)
- 8e578f0 feat: vegas implied team totals as projection feature (#378) (#479)

## Changes made

### `docs/generated/db-schema.md` (highest priority)
- `team_vegas_lines` row in the table list now reflects the seed/backfill split (Pythagorean implied total + sportsbook win total).
- New column-level sections for `draft_capital` (migration 023) and `team_vegas_lines` (024–025), including the migration-025 NULLABLE `implied_total` change and how the seed (`seed_preseason_win_totals.py`) vs backfill (`backfill_vegas_lines.py`) split feeds the `implied_team_total_raw` projection feature.

### `docs/FRONTEND.md`
- Added the new `/vegas-lines` route to the routes table.
- Added `ActiveModelCard`, `ProjectionYearSelector`, `PositionTierBreakdown`, and `GlobalPlayerSearch` to the reusable-components table — they were already in `web/components/` but undocumented.
- Pointed the Analysis Logic section at `web/lib/vegas-lines.ts` and `web/lib/nfl-divisions.ts`.

### `docs/COMMANDS.md`
- Documented the new `just` recipes that landed with the backfill work: `backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`, and the ad-hoc `py "<snippet>"` recipe.
- Added matching raw `python scripts/...` invocations under the Backend section so non-`just` users have a reference too.

## Verified, no change needed

- All migrations through 025 are reflected in the schema doc table list.
- Every doc path in the CLAUDE.md / AGENTS.md Documentation Map exists.
- All skills referenced from CLAUDE.md (`ablation`, `compare-models`, `create-pr`, `diagnose-segment`, `experiment`, `feature-importance`, `projection-accuracy`, `retro`, `review-permission-gates`, `run-analyses`, `run-scraper`, `run-tests`, `start-dev`) are present in `.claude/commands/`.
- Every `just` recipe referenced in COMMANDS.md still exists in the Justfile.
- `docs/exec-plans/projection-accuracy-improvement.md` was already refreshed in #482 with v22/v23/v25/v26/v27 results — no further update needed today.
- `docs/ARCHITECTURE.md` already covers the `<ActiveModelCard>` pattern and the rookie fallback flavors (`college_prospect`, `rookie_draft_capital`).

## Items flagged for human follow-up

None — the audit found drift only, no doc bugs that require code-side decisions.

## Test plan

- [x] `git diff` reviewed — only doc files touched
- [ ] Maintainer spot-checks the new schema column descriptions match the migration files

https://claude.ai/code/session_01VsVEReLCn6PNx7EpsnEJk1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsVEReLCn6PNx7EpsnEJk1)_