### PR TITLE
docs: daily harness audit 2026-05-09

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -84,6 +84,12 @@ python scripts/feature_projections/feature_analysis.py --model v20_learned_usage
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025  # Residual distribution, heteroscedasticity, persistent errors
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025 --output docs/generated/residual-analysis.md  # Write markdown report
 
+# Backfills / seeds (prefer the matching `just` recipes — see below)
+python scripts/backfill_nfl_stats.py --seasons 2024                       # Backfill nflverse weekly + advanced receiving stats into `nfl_stats`
+python scripts/backfill_draft_capital.py --since 2010                     # Backfill nflverse `draft_picks` parquet into `draft_capital`
+python scripts/backfill_vegas_lines.py --since 2016                       # Scrape PFR schedules → aggregate to `team_vegas_lines` per (team, season)
+python scripts/seed_preseason_win_totals.py --season 2026                 # Seed preseason win totals (implied_total stays NULL until schedule release)
+
 # Utilities
 python scripts/check_db.py                           # Verify database contents
 streamlit run scripts/visualize_app.py               # Streamlit dashboard
@@ -122,6 +128,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds
+just backfill-nfl-stats [--seasons 2024 ...]        # nflverse weekly + advanced receiving stats → nfl_stats
+just backfill-draft-capital [--since 2010]          # nflverse draft_picks → draft_capital
+just backfill-vegas [--since 2016]                  # PFR schedules → team_vegas_lines (implied + win totals)
+just seed-win-totals [--season 2026]                # Seed preseason win totals (implied_total nullable until schedule release)
+
+# Ad-hoc
+just py "<python snippet>"                          # Run a one-off snippet against the project venv
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -22,6 +22,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/arbitration` | Arbitration targets with per-opponent breakdown |
 | `/arbitration-simulation` | Monte Carlo arbitration simulation |
 | `/arbitration-planner` | Plan and save arbitration budget allocations (auth required) |
+| `/vegas-lines` | Preseason Vegas implied team totals + win totals review (sourced from `team_vegas_lines`) |
 | `/login` | Email/password login |
 | `/admin` | User management (admin only) |
 
@@ -38,6 +39,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Server component that surfaces the active projection model (name, version, features) on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy`. Reads from `fetchActiveProjectionModel()` so promotions propagate without code changes. |
 
 ### Column Factories (`components/columns.tsx`)
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -24,7 +24,7 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv`. `implied_total` is nullable (migration 025) so preseason rows can be seeded from win totals before the schedule is released. | `(team, season)` |
 
 ### Projection tables detail
 


### PR DESCRIPTION
## Summary

Daily harness-doc audit covering merges since the last run on 2026-05-05 (PR #471).

### Commits reviewed (13)

- #473 advanced receiving metrics (migration 022, `target_share`/`air_yards_share`/`wopr`/`racr`/`receiving_air_yards`)
- #475 draft capital feature for rookie projections (migration 023, `draft_capital`)
- #476 two-stage residual model for draft capital (`v25_draft_capital_residual`)
- #477 docs refresh — projection model eval for v22/v23/v25
- #479 vegas implied team totals as projection feature (migration 024, `team_vegas_lines`)
- #480 vegas lines review page (`/vegas-lines`, `ActiveModelCard`, `web/lib/vegas-lines.ts`, `web/lib/nfl-divisions.ts`)
- #481 seed 2026 preseason win totals (migration 025 — `implied_total` nullable, `seed_preseason_win_totals.py`)
- #482 backfill 2026 NFL draft + project drafted rookies
- #484 single source of truth for active projection model (`ActiveModelCard` consumers)
- #485 broaden Claude permission allowlist + add backfill recipes (`just backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`)
- #486 gitignore `.claude/plans` and `.claude/projects`
- #487 project drafted rookies from draft capital

### Doc changes

- **`docs/FRONTEND.md`** — added `/vegas-lines` to the route table; added `ActiveModelCard` to the components table.
- **`docs/COMMANDS.md`** — added a `Backfills / seeds` block under Backend (raw `python` invocations for `backfill_nfl_stats.py`, `backfill_draft_capital.py`, `backfill_vegas_lines.py`, `seed_preseason_win_totals.py`) and a matching `just` recipe block (`backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`, plus `just py "<snippet>"`).
- **`docs/generated/db-schema.md`** — annotated `team_vegas_lines` to reflect migration 025 (`implied_total` is nullable so preseason rows can be seeded before the NFL schedule is released).

### Already current — no changes needed

- `docs/generated/db-schema.md` already has both `draft_capital` and `team_vegas_lines` rows + the migration-022 advanced-receiving column block.
- `docs/ARCHITECTURE.md` was refreshed in #484 (active-model section + `<ActiveModelCard>` references) and in #487 (rookie fallback flavors `rookie_draft_capital` / `college_prospect`).
- `docs/exec-plans/projection-accuracy-improvement.md` already documents the new backfill scripts.
- All skill files referenced in the CLAUDE.md Documentation Map exist under `.claude/commands/`.

### Items flagged for human follow-up

None. The new `web/lib/nfl-divisions.ts` + `web/lib/vegas-lines.ts` modules are scoped to the `/vegas-lines` page only; not promoted into the `CODE_ORGANIZATION.md` table since that table is curated for cross-cutting modules. Worth revisiting if Vegas data starts being consumed elsewhere.

## Test plan

- [x] `git diff` reviewed — all edits are doc-only and additive
- [x] No referenced file paths broken
- [x] All `just` recipes added match the live `Justfile`

https://claude.ai/code/session_0161K4GMBAMc55tFtFChJLX3

---
_Generated by [Claude Code](https://claude.ai/code/session_0161K4GMBAMc55tFtFChJLX3)_