### PR TITLE
docs: daily harness audit 2026-05-10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **Promote, don't hardcode.** The active model is the single row in `projection_models` with `is_active=TRUE`. `update_projections.py` reads it dynamically via `get_active_model_name()`, and the web UI surfaces the methodology through `<ActiveModelCard>` (sourced from `fetchActiveProjectionModel()` in `web/lib/data.ts`). To switch which model the site serves, run `just promote <model_name>` — no UI copy edits required. If you do edit hand-written intro text on `/projections`, `/arbitration`, or `/projection-accuracy`, keep it model-agnostic so it doesn't drift on the next promotion.
 
 This ensures every projection change is empirically validated before merge.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -84,6 +84,12 @@ python scripts/feature_projections/feature_analysis.py --model v20_learned_usage
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025  # Residual distribution, heteroscedasticity, persistent errors
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025 --output docs/generated/residual-analysis.md  # Write markdown report
 
+# Backfills / seeds
+python scripts/backfill_nfl_stats.py --seasons 2024              # Backfill nfl_stats (advanced receiving included from 2018+)
+python scripts/backfill_draft_capital.py --since 2010            # Populate draft_capital from nflverse draft_picks
+python scripts/backfill_vegas_lines.py --since 2016              # Populate team_vegas_lines from nflverse games.csv
+python scripts/seed_preseason_win_totals.py --season 2026        # Seed preseason win totals (allows null implied_total)
+
 # Utilities
 python scripts/check_db.py                           # Verify database contents
 streamlit run scripts/visualize_app.py               # Streamlit dashboard
@@ -122,6 +128,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds
+just backfill-nfl-stats [--seasons 2024] ...        # Backfill nfl_stats from nflverse
+just backfill-draft-capital [--since 2010] ...      # Backfill draft_capital from nflverse draft_picks
+just backfill-vegas [--since 2016] ...              # Backfill team_vegas_lines from nflverse games.csv
+just seed-win-totals [--season 2026] ...            # Seed preseason win totals (implied_total may be null)
+
+# Ad-hoc DB queries
+just py "<python snippet>"                          # Run a one-off snippet against the project venv
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Preseason Vegas implied team totals + Pythagorean win totals (reads `team_vegas_lines`) |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |
@@ -38,6 +39,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Server component that renders the live projection-model methodology (name, version, description, features) for whichever model is flagged `is_active=TRUE` in `projection_models`. Used on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy`. Don't hardcode model names in those pages — promote a different model and the card updates on the next render. |
 
 ### Column Factories (`components/columns.tsx`)
 


### PR DESCRIPTION
## Summary

Daily harness-doc audit covering the 13 commits merged since the last audit (2026-04-19 → 2026-05-07). Three drift items found and fixed; no schema-doc changes needed (db-schema.md was kept current by the feature PRs themselves).

## Commits reviewed (baac1ca..1e5dcde)

- `1e5dcde` feat: project drafted rookies from draft capital
- `559228b` chore: broaden Claude permission allowlist + add backfill recipes
- `aa593d6` chore: single source of truth for active projection model
- `571f63e` feat: backfill 2026 NFL draft + project drafted rookies
- `4931648` feat: seed 2026 preseason win totals (implied_total nullable)
- `6cdb5b1` feat: vegas lines review page
- `8e578f0` feat: vegas implied team totals as projection feature
- `cf3c03a` feat: two-stage residual model for draft capital (v25)
- `2027ffd` feat: draft capital feature for rookie projections
- `6533791` feat: advanced receiving metrics from nflverse
- plus three docs/refresh commits already updated by their PRs

## Changes

**`docs/FRONTEND.md`**
- Added `/vegas-lines` to the Routes table (added in #480, present in nav menu but undocumented)
- Added `ActiveModelCard` to the Reusable Components table — explains the "single source of truth" model surfacing pattern introduced in #484

**`docs/COMMANDS.md`**
- Added `just backfill-nfl-stats`, `just backfill-draft-capital`, `just backfill-vegas`, `just seed-win-totals`, `just py` (recipes added in #485 but missing from the doc)
- Added the matching raw `python scripts/backfill_*.py` / `seed_*.py` invocations to the Backend block

**`AGENTS.md`**
- Rewrote Projection Model Update Requirements item #4. The previous wording told agents to update "hardcoded methodology descriptions" in `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` whenever they changed `ACTIVE_MODEL` in `update_projections.py`. Both of those references are now stale: `ACTIVE_MODEL` was deleted in #484 (replaced by `get_active_model_name()` reading `projection_models.is_active`), and the hardcoded methodology copy was replaced by the new `<ActiveModelCard>` server component sourcing from `fetchActiveProjectionModel()`. New wording tells agents to promote rather than hand-edit, and warns against hardcoding model names in the surrounding intro copy.

## Schema doc

`docs/generated/db-schema.md` already covers migrations 022–025 (advanced receiving columns, `draft_capital`, `team_vegas_lines`) — those PRs updated it inline. No changes needed.

## Items flagged for human follow-up

None — all drift identified was fixable in this PR.

## Test plan

- [x] `git diff` reviewed
- [ ] CI passes (lint, typecheck, tests, doc-freshness check)

https://claude.ai/code/session_01H9WVMsHVXwViwL4PWwmWd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9WVMsHVXwViwL4PWwmWd7)_