### PR TITLE
docs: daily harness audit 2026-05-11

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **Methodology copy is automatic.** `update_projections.py` queries `projection_models.is_active` at runtime (no more `ACTIVE_MODEL` constant), and the web pages render `<ActiveModelCard />` (`web/components/ActiveModelCard.tsx`), which pulls the live model name, version, description, and feature list from the DB. Do not re-introduce hardcoded model names or feature lists in `web/app/projections/page.tsx`, `web/app/arbitration/page.tsx`, or `web/app/projection-accuracy/page.tsx` — promote a model via `just promote <name>` and the UI follows.
 
 This ensures every projection change is empirically validated before merge.
 
@@ -119,7 +119,7 @@ The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year
 - **QB**: A starting QB already receives all offensive snaps. A high H2/H1 ratio simply means they took over mid-season, not that they'll be better next year.
 - **K**: Snap counts are irrelevant to kicker scoring.
 
-`v12_no_qb_trajectory` (current active model) disables the trajectory for QB and K via `WeightedPPGNoQBTrajectoryFeature`. Do not re-enable it for those positions.
+`WeightedPPGNoQBTrajectoryFeature` (in `features/weighted_ppg.py`) disables the trajectory for QB and K, and every subsequent internal model has inherited that exclusion. Do not re-enable the trajectory for those positions in new base features.
 
 ### Database migration workflow
 

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -19,6 +19,9 @@
 | Components | `web/components/` | Reusable React components |
 | Pages | `web/app/` | Next.js App Router pages |
 | Feature projections | `scripts/feature_projections/` | Feature-based projection system (features, combiner, runner, backtest, CLI) |
+| Backfill/seed scripts | `scripts/backfill_*.py`, `scripts/seed_*.py` | One-off data loaders (NFL stats, draft capital, Vegas lines, preseason win totals) |
+| Vegas / divisions helpers | `web/lib/vegas-lines.ts`, `web/lib/nfl-divisions.ts` | Server fetchers + division/team-code lookups for the `/vegas-lines` page |
+| Active model card | `web/components/ActiveModelCard.tsx` | Server component that renders the live `projection_models.is_active` metadata across projection pages |
 | Data files | `data/` | Manual config data (QB starters, etc.) |
 | CI/CD | `.github/workflows/` | GitHub Actions (tests, scraping, projections) |
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -122,6 +122,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds
+just backfill-nfl-stats [args]                      # Backfill nfl_stats from nflverse (e.g. --seasons 2024)
+just backfill-draft-capital [args]                  # Backfill draft_capital from nflverse (e.g. --since 2010)
+just backfill-vegas [args]                          # Backfill team_vegas_lines from nflverse games.csv (e.g. --since 2016)
+just seed-win-totals --season 2026                  # Seed preseason Vegas win totals (hand-curated) for an upcoming season
+
+# Ad-hoc
+just py "<python snippet>"                          # Run a one-off Python snippet against the project venv
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Preseason Vegas implied team totals + win totals review (reads `team_vegas_lines`) |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |
@@ -38,6 +39,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Server component that reads `projection_models.is_active` and renders the live model name, version, description, and feature list. Used on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` — the single source of truth so methodology copy can't drift from the active model. |
 
 ### Column Factories (`components/columns.tsx`)
 

--- a/docs/exec-plans/feature-projections.md
+++ b/docs/exec-plans/feature-projections.md
@@ -15,25 +15,37 @@ Iterative, ML-like framework for building PPG projections from composable featur
 ```
 scripts/feature_projections/
   features/
-    base.py              # ProjectionFeature ABC
-    weighted_ppg.py      # Port of existing WeightedAveragePPG + RookieTrajectoryPPG
-    age_curve.py         # Positional age curve from birth_date
-    stat_efficiency.py   # Per-stat projection from nfl_stats → PPG
-    games_played.py      # Availability/durability adjustment
-    team_context.py      # Team offense quality adjustment
-    usage_share.py       # Target/touch/attempt share projection
+    base.py                  # ProjectionFeature ABC
+    weighted_ppg.py          # Port of existing WeightedAveragePPG + RookieTrajectoryPPG; also WeightedPPGNoQBTrajectoryFeature
+    age_curve.py             # Positional age curve from birth_date
+    stat_efficiency.py       # Per-stat projection from nfl_stats → PPG
+    games_played.py          # Availability/durability adjustment
+    team_context.py          # Team offense quality adjustment
+    usage_share.py           # Target/touch/attempt share projection
+    qb_starter_usage.py      # Manual QB starter-vs-backup designation (v14+)
+    regression_to_mean.py    # Tiered mean-reversion (v8, v21 negative-factor variant)
+    snap_trend.py            # Snap-share trajectory adjustment
+    advanced_receiving.py    # target_share, air_yards_share, wopr, racr from nflverse (v22)
+    draft_capital.py         # NFL draft round/overall pick as a raw feature (v23/v25/v27)
+    vegas_team_total.py      # Preseason Vegas implied team total as a raw feature (v26/v27)
   external_sources/
-    fantasypros_fetcher.py  # Scrape FP consensus projections
-    scoring.py              # Stat-line → Ottoneu PPG
-    player_matcher.py       # Fuzzy name matching to players table
-    ingest_external.py      # Register + upsert external model
-  combiner.py            # Weighted addition of feature outputs → final PPG
-  model_config.py        # Model definitions (v1-v6 + external)
-  runner.py              # Generate projections, upsert to model_projections
-  backtest.py            # Compare to actuals, store in backtest_results
-  accuracy_report.py     # Markdown comparison table across all models/seasons
-  promote.py             # Copy model_projections → player_projections
-  cli.py                 # CLI: run, backtest, compare, promote, list
+    fantasypros_fetcher.py   # Scrape FP consensus projections
+    scoring.py               # Stat-line → Ottoneu PPG
+    player_matcher.py        # Fuzzy name matching to players table
+    ingest_external.py       # Register + upsert external model
+  trained_models/            # JSON artifacts for learned (Ridge) models (v20+, v22, v23, v25, v26, v27)
+  combiner.py                # Weighted addition of feature outputs → final PPG
+  learned_combiner.py        # Ridge combiner used by learned (v20+) models
+  model_config.py            # Model registry (v1–v27 internal + external)
+  runner.py                  # Generate projections, upsert to model_projections
+  backtest.py                # Compare to actuals, store in backtest_results
+  accuracy_report.py         # Markdown comparison table across all models/seasons
+  promote.py                 # Copy model_projections → player_projections (also deletes prior non-college rows per season to prevent ghost rows)
+  train_model.py             # Fit Ridge coefficients via LOSO CV → trained_models/*.json
+  diagnostics.py             # Per-player backtest diagnostics
+  segment_analysis.py        # Segmented accuracy analysis
+  hypothesis_test.py / feature_analysis.py / residual_analysis.py  # Model iteration tooling
+  cli.py                     # CLI: run, backtest, compare, promote, list, diagnostics, segment-analysis
 ```
 
 ---
@@ -223,5 +235,5 @@ See [projection-accuracy-improvement.md](projection-accuracy-improvement.md) for
 | Phase 1: Foundation (tables, base class, runner) | ✅ Complete | |
 | Phase 2: Features v1–v6 + CLI | ✅ Complete | |
 | Phase 3: Backtest + accuracy report + external benchmark | ✅ Complete | FantasyPros ingested 2022–2025 |
-| Phase 4: Model comparison UI | Deferred | Low ROI given backtest results; v2 dominates |
-| Phase 5: Production integration | In progress | v2 should be promoted; run `promote --model v2_age_adjusted` |
+| Phase 4: Model comparison UI | Deferred | Low ROI given backtest results |
+| Phase 5: Production integration | ✅ Live | `update_projections.py` reads `projection_models.is_active` dynamically; `<ActiveModelCard />` surfaces the live model name + feature list on `/projections`, `/arbitration`, `/projection-accuracy`. Subsequent model work (v7–v27, including learned/Ridge models, advanced receiving, draft capital, Vegas) is tracked in [projection-accuracy-improvement.md](projection-accuracy-improvement.md). |

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -24,7 +24,7 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total + win total. `implied_total` (nullable) is aggregated from nflverse `games.csv` per-game lines; `win_total` is either Pythagorean (when backfilled from games) or hand-curated from preseason sportsbook reporting (when seeded via `scripts/seed_preseason_win_totals.py` before the NFL schedule is released) | `(team, season)` |
 
 ### Projection tables detail
 


### PR DESCRIPTION
## Summary

Daily harness audit covering merges since the last audit (2026-05-05, #471) through 2026-05-07. Focus areas: new schema for advanced receiving, draft capital, and Vegas implied team totals; new backfill/seed scripts and `just` recipes; single-source-of-truth active projection model wiring.

### Commits reviewed

- #473 advanced receiving metrics from nflverse (migration 022)
- #475 draft capital feature for rookie projections (migration 023)
- #476 two-stage residual draft capital model (v25)
- #477 projection model eval refresh for v22/v23/v25
- #479 vegas implied team totals as projection feature (migration 024)
- #480 vegas lines review page (`/vegas-lines`, `web/lib/vegas-lines.ts`, `web/lib/nfl-divisions.ts`)
- #481 seed 2026 preseason win totals (migration 025 — implied_total nullable)
- #482 backfill 2026 NFL draft + project drafted rookies
- #484 single source of truth for active projection model (`<ActiveModelCard />`, `get_active_model_name()`)
- #485 broaden permission allowlist + add backfill recipes
- #486 gitignore `.claude/plans` and `.claude/projects`
- #487 project drafted rookies from draft capital

### Changes made

- **AGENTS.md** — drop stale `ACTIVE_MODEL`/hardcoded-methodology guidance (now driven by `projection_models.is_active` + `<ActiveModelCard />`); stop naming `v12_no_qb_trajectory` as the "current" active model.
- **docs/COMMANDS.md** — document new `just` recipes: `backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`, `py`.
- **docs/FRONTEND.md** — add `/vegas-lines` route and `ActiveModelCard` component.
- **docs/CODE_ORGANIZATION.md** — surface backfill/seed scripts, vegas-lines helpers, and `ActiveModelCard`.
- **docs/generated/db-schema.md** — clarify `team_vegas_lines` description (implied_total nullable; win_total can be Pythagorean or hand-curated preseason).
- **docs/exec-plans/feature-projections.md** — refresh feature/architecture diagram with current modules (`advanced_receiving`, `draft_capital`, `vegas_team_total`, `learned_combiner`, `train_model`, `trained_models/`, `qb_starter_usage`, `regression_to_mean`, `snap_trend`, `diagnostics`, `segment_analysis`); mark Phase 5 production integration ✅ live and point readers to the accuracy improvement plan for v7–v27.

### Schema audit

Migrations 022–025 are now reflected in `db-schema.md`. Table count remains 19. Advanced receiving columns and both new tables (`draft_capital`, `team_vegas_lines`) were already added in #471/#477; this PR refines the `team_vegas_lines` description to capture migration 025's nullability and the dual-source `win_total`.

### Items flagged for human follow-up

- `docs/exec-plans/feature-projections.md` "Tuning Recommendations" section is historical (still recommends promoting v2). Phase Status now points readers to `projection-accuracy-improvement.md`, but a fuller rewrite (or formal "historical" header) could be worthwhile next time someone touches that file.
- `CLAUDE.md` note that "The local directory is `ottoneu_db` (underscore)" doesn't match the current checkout (`ottoneu-db`). Could be environment-specific drift; left untouched.

## Test plan

- [x] `git diff` reviewed for each edited doc
- [ ] `just check-docs` (couldn't run locally — no venv in this environment; CI will exercise it on the PR)


---
_Generated by [Claude Code](https://claude.ai/code/session_017nGv8rpAqKJFJJR5KRoH3r)_