### PR TITLE
docs: daily harness audit 2026-05-12

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -122,6 +122,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds
+just backfill-nfl-stats [--seasons 2024 ...] [--dry-run]    # Sync nflverse season totals into nfl_stats
+just backfill-draft-capital [--since 2010] [--dry-run]      # Populate draft_capital from nflverse draft_picks parquet
+just backfill-vegas [--since 2016] [--dry-run]              # Aggregate per-game lines into team_vegas_lines (implied_total + Pythagorean win_total)
+just seed-win-totals --season 2026 [--dry-run]              # Hand-seed preseason win_total before schedule release (implied_total left null)
+
+# Ad-hoc DB inspection
+just py "<python snippet>"                          # Run a one-off snippet against the project venv
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Preseason Vegas implied team totals + Pythagorean win totals (reads `team_vegas_lines`, grouped by division) |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |
@@ -30,6 +31,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | Component | Purpose |
 |-----------|---------|
 | `Navigation.tsx` | Shared nav bar across all pages |
+| `ActiveModelCard` | Renders the currently-active projection model (name, version, description, feature list) on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy`. Pulls from `fetchActiveProjectionModel()` — do NOT hardcode model names in UI copy |
 | `DataTable` | Generic sortable table with type safety and highlight rules |
 | `SummaryCard` | Metric display cards with variant styles (default, positive, negative) |
 | `PositionFilter` | Position selection buttons with multi-select support |

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -24,7 +24,7 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv`. `implied_total` is nullable (mig 025) — preseason rows can be seeded with `win_total` only and have `implied_total` backfilled once the schedule is released | `(team, season)` |
 
 ### Projection tables detail
 
@@ -64,6 +64,14 @@ Ottoneu fantasy data only: `games_played`, `snaps`, `ppg`, `pps`, `h1_snaps`, `h
 Core stat columns: `games_played`, `passing_yards`, `passing_tds`, `interceptions`, `passing_attempts`, `completions`, `rushing_yards`, `rushing_tds`, `rushing_attempts`, `receptions`, `targets`, `receiving_yards`, `receiving_tds`, `fg_made_0_39`, `fg_made_40_49`, `fg_made_50_plus`, `pat_made`, `total_points`, `ppg`, `offense_snaps`, `defense_snaps`, `st_snaps`, `total_snaps`, `recent_team`.
 
 Advanced receiving (added in migration 022, populated for 2018+ via nflverse `stats_player`): `target_share`, `air_yards_share`, `wopr` (Weighted Opportunity Rating), `racr` (Receiver Air Conversion Ratio), `receiving_air_yards`.
+
+### `draft_capital` columns
+
+`player_id` (FK), `season_drafted`, `round`, `overall_pick`. One row per drafted player (UNIQUE on `player_id`). Populated by `scripts/backfill_draft_capital.py` from the nflverse `draft_picks` parquet.
+
+### `team_vegas_lines` columns
+
+`team`, `season`, `implied_total numeric(6,2)` (nullable since mig 025), `win_total numeric(4,1)` (nullable). One row per team-season (UNIQUE on `(team, season)`). Backfilled from nflverse `games.csv` via `scripts/backfill_vegas_lines.py`; preseason `win_total` is hand-seeded via `scripts/seed_preseason_win_totals.py`.
 
 ## Schema Files
 


### PR DESCRIPTION
## Summary

Daily harness-doc audit. Reviewed every commit merged to `main` since the last audit on 2026-05-05 and brought the affected docs back in line.

### Commits reviewed

| PR    | Summary                                                                 |
|-------|-------------------------------------------------------------------------|
| #473  | feat: advanced receiving metrics from nflverse                          |
| #475  | feat: draft capital feature for rookie projections (mig 023)            |
| #476  | feat: two-stage residual model for draft capital (v25)                  |
| #477  | docs: refresh projection model eval for v22/v23/v25                     |
| #479  | feat: vegas implied team totals as projection feature (mig 024)         |
| #480  | feat: vegas lines review page (`/vegas-lines`)                          |
| #481  | feat: seed 2026 preseason win totals (mig 025: `implied_total` nullable)|
| #482  | feat: backfill 2026 NFL draft + project drafted rookies                 |
| #484  | chore: single source of truth for active projection model               |
| #485  | chore: broaden Claude permission allowlist + add backfill recipes       |
| #486  | chore: gitignore `.claude/plans` and `.claude/projects`                 |
| #487  | feat: project drafted rookies from draft capital                        |

### Changes made

- **`docs/generated/db-schema.md`**
  - Note that `team_vegas_lines.implied_total` is nullable as of migration 025 (preseason rows can be seeded with `win_total` only).
  - Add column-level detail sections for `draft_capital` and `team_vegas_lines` so the schema doc covers the recently-added tables consistently with the rest of the file.
- **`docs/COMMANDS.md`** — document the four new `just` backfill/seed recipes (`backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`) plus the `just py "<snippet>"` ad-hoc DB inspection recipe added in #485. These were already referenced in `CLAUDE.md` but missing from the canonical command reference.
- **`docs/FRONTEND.md`**
  - Add the `/vegas-lines` route (#480).
  - Document the `<ActiveModelCard>` component (#484) and call out the "no hardcoded model names in UI copy" rule.

### Items flagged for human follow-up

None. Schema, routes, components, and recipes are all in sync with `main` as of this audit.

## Test plan

- [ ] Spot-check that the new `/vegas-lines` route description matches the actual page.
- [ ] Confirm the four new `just` recipes documented in COMMANDS.md exist in `Justfile` and behave as described.
- [ ] Verify `docs/generated/db-schema.md` lines up with `migrations/022`–`025`.

https://claude.ai/code/session_01MVvAvwvK5DKWyKd9uqi4qH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVvAvwvK5DKWyKd9uqi4qH)_