### PR TITLE
docs: daily harness audit 2026-05-13

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **Promote** the new model with `just promote <name>` (or `venv/bin/python scripts/feature_projections/promote.py <name>`) to flip `is_active=TRUE` in `projection_models`. The UI methodology is rendered by `<ActiveModelCard>` (`web/components/ActiveModelCard.tsx`) which reads the active model from the database via `fetchActiveProjectionModel()` — no page-level edits required when swapping models. Only update the per-page surrounding copy (e.g. the rookie/college fallback note in `web/app/projections/page.tsx`) if the new model changes that behavior.
 
 This ensures every projection change is empirically validated before merge.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -84,6 +84,12 @@ python scripts/feature_projections/feature_analysis.py --model v20_learned_usage
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025  # Residual distribution, heteroscedasticity, persistent errors
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025 --output docs/generated/residual-analysis.md  # Write markdown report
 
+# Backfills / Seeds
+python scripts/backfill_nfl_stats.py --seasons 2024                    # Backfill NFL stats from nflverse for given seasons
+python scripts/backfill_draft_capital.py --since 2010                  # Backfill NFL draft picks → `draft_capital`
+python scripts/backfill_vegas_lines.py --since 2016                    # Backfill per-team-season Vegas implied totals → `team_vegas_lines`
+python scripts/seed_preseason_win_totals.py --season 2026              # Seed preseason win totals (implied_total NULL) before schedule release
+
 # Utilities
 python scripts/check_db.py                           # Verify database contents
 streamlit run scripts/visualize_app.py               # Streamlit dashboard
@@ -122,6 +128,16 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / Seeds
+just backfill-nfl-stats --seasons 2024              # Backfill nflverse NFL stats (supports --dry-run)
+just backfill-draft-capital --since 2010            # Backfill NFL draft picks → draft_capital
+just backfill-vegas --since 2016                    # Backfill Vegas implied team totals → team_vegas_lines
+just seed-win-totals --season 2026                  # Seed preseason win totals before schedule release
+
+# Ad-hoc DB queries
+just py "<python_snippet>"                          # Run a one-off Python snippet against the project venv (read-only diagnostics)
+just test-web-file <path>                           # Run a single web test file without coverage
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Preseason Vegas implied team totals + win totals by season (reads `team_vegas_lines`) |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |


### PR DESCRIPTION
## Summary

Daily sweep of harness documentation. No commits merged in the last 25 hours (latest was #487 on 2026-05-07), so this is a lighter pass focused on drift accumulated since the draft-capital / Vegas-lines feature work shipped (#475, #479, #480, #481, #482, #484, #485, #486, #487).

## Commits reviewed

- #487 feat: project drafted rookies from draft capital
- #486 chore: gitignore .claude/plans and .claude/projects
- #485 chore: broaden Claude permission allowlist + add backfill recipes
- #484 chore: single source of truth for active projection model
- #482 feat: backfill 2026 NFL draft + project drafted rookies
- #481 feat: seed 2026 preseason win totals (implied_total nullable)
- #480 feat: vegas lines review page
- #479 feat: vegas implied team totals as projection feature
- #477 docs: refresh projection model eval for v22/v23/v25
- #476 feat: two-stage residual model for draft capital (v25)
- #475 feat: draft capital feature for rookie projections

## Changes made

**`AGENTS.md`** — §Projection Model Update Requirements step 4 referenced an `ACTIVE_MODEL` constant in `update_projections.py` that was removed in #484. The doc now describes the actual current flow: promote a model via `just promote <name>` to flip `is_active=TRUE`, and the UI methodology renders dynamically through `<ActiveModelCard>` reading `fetchActiveProjectionModel()` — no page-level edits required when swapping models.

**`docs/FRONTEND.md`** — Added the `/vegas-lines` route (shipped in #480 but missed by the docs). Confirmed the page is wired into `Navigation.tsx` under the Projections menu.

**`docs/COMMANDS.md`** — Added two missing sections:
- Raw scripts: `backfill_nfl_stats.py`, `backfill_draft_capital.py`, `backfill_vegas_lines.py`, `seed_preseason_win_totals.py`
- `just` recipes: `backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals` (added in #485) plus the long-undocumented `just py` and `just test-web-file` recipes

## Schema audit (highest priority)

Cross-referenced `migrations/023_create_draft_capital.sql`, `024_create_team_vegas_lines.sql`, and `025_team_vegas_lines_implied_nullable.sql` against `docs/generated/db-schema.md`. The schema doc is **already current** — both new tables (`draft_capital`, `team_vegas_lines`) are listed with correct unique constraints and the table count (19) matches reality. The canonical `schema.sql` is one step behind the migrations (17 tables vs 19) but the generated doc tracks the migration files, which is the correct source of truth.

No changes to `db-schema.md` required.

## Items flagged for human follow-up

- `schema.sql` is stale relative to `migrations/` (missing `draft_capital` and `team_vegas_lines`). Probably worth a one-off regeneration via Supabase MCP, but not strictly a harness-doc issue.
- `docs/exec-plans/feature-projections.md` still describes models v1–v6 as the active roster. Real active model is now far ahead (v25 / draft-capital two-stage). Not touched here because it's an exec-plan rather than current-state harness doc, but flagging for whoever owns the projection narrative.

## Test plan

- [x] All referenced doc paths exist
- [x] All `just` recipes added match `Justfile`
- [x] Scripts referenced in COMMANDS.md exist under `scripts/`
- [x] `/vegas-lines` route exists under `web/app/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Da6xsGkUrpXAVo87vjpnty)_