### PR TITLE
docs: daily harness audit 2026-05-14

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year
 - **QB**: A starting QB already receives all offensive snaps. A high H2/H1 ratio simply means they took over mid-season, not that they'll be better next year.
 - **K**: Snap counts are irrelevant to kicker scoring.
 
-`v12_no_qb_trajectory` (current active model) disables the trajectory for QB and K via `WeightedPPGNoQBTrajectoryFeature`. Do not re-enable it for those positions.
+`v12_no_qb_trajectory` introduced `WeightedPPGNoQBTrajectoryFeature`, which disables the trajectory for QB and K. Subsequent learned-ridge models (v20+) inherit this behavior via the same base feature. The single active model is now whatever has `is_active=TRUE` in `projection_models` — query it dynamically (`fetchActiveProjectionModel()` in the web app, `get_active_model_name()` in `scripts/update_projections.py`). Do not re-enable the rookie trajectory for QB or K when authoring new base features.
 
 ### Database migration workflow
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,12 @@ Jobs support dependencies, retries (up to 3 attempts), and batch grouping. `otto
 `nfl_stats` stores pure NFL statistical data from nflverse-data (2010–present), kept separate from the Ottoneu fantasy data in `player_stats`. Backfilled via `scripts/backfill_nfl_stats.py` or the `Backfill NFL Stats` GitHub Action.
 
 - **`player_stats`** = Ottoneu fantasy data (total_points, ppg, pps, snaps from scraping)
-- **`nfl_stats`** = Real NFL stats (passing_yards, rushing_tds, snap counts, etc. from nflverse)
+- **`nfl_stats`** = Real NFL stats (passing_yards, rushing_tds, snap counts, advanced receiving (`target_share`, `air_yards_share`, `wopr`, `racr`, `receiving_air_yards`) from nflverse)
+
+### Auxiliary signal tables (orthogonal to game-log stats)
+
+- **`draft_capital`** — NFL draft round + overall pick per player, backfilled from nflverse `draft_picks` via `scripts/backfill_draft_capital.py`. Consumed by the `draft_capital_raw` feature and by the rookie/college-prospect fallback path in `update_projections.py` (which fits a per-position OLS of historical year-1 PPG against log-scaled overall pick).
+- **`team_vegas_lines`** — Per-(team, season) regular-season implied points-for and Pythagorean win total, aggregated from nflverse `games.csv` via `scripts/backfill_vegas_lines.py`. `implied_total` is nullable so preseason win totals can be seeded via `scripts/seed_preseason_win_totals.py` before the NFL schedule drops. Consumed by the `implied_team_total_raw` feature.
 
 ### Worker Task Modules (`scripts/tasks/`)
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -84,6 +84,13 @@ python scripts/feature_projections/feature_analysis.py --model v20_learned_usage
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025  # Residual distribution, heteroscedasticity, persistent errors
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025 --output docs/generated/residual-analysis.md  # Write markdown report
 
+# Backfills / seeds (prefer `just` recipes — see below)
+python scripts/backfill_nfl_stats.py --seasons 2024                       # Pull per-season nflverse stats into nfl_stats
+python scripts/backfill_draft_capital.py --since 2010                     # Pull NFL draft picks into draft_capital
+python scripts/backfill_draft_capital.py --since 2026 --update-rosters    # Post-draft: also flip college→NFL and insert missing picks
+python scripts/backfill_vegas_lines.py --since 2016                       # Aggregate nflverse game lines into team_vegas_lines.implied_total / win_total
+python scripts/seed_preseason_win_totals.py --season 2026                 # Seed hand-curated preseason sportsbook win totals (implied_total left NULL until schedule drops)
+
 # Utilities
 python scripts/check_db.py                           # Verify database contents
 streamlit run scripts/visualize_app.py               # Streamlit dashboard
@@ -122,6 +129,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds
+just backfill-nfl-stats [--seasons ...]             # Pull nflverse season stats into nfl_stats (supports --dry-run)
+just backfill-draft-capital [--since YEAR]          # Pull NFL draft picks into draft_capital (supports --update-rosters, --dry-run)
+just backfill-vegas [--since YEAR]                  # Aggregate nflverse games into team_vegas_lines (supports --dry-run)
+just seed-win-totals --season YEAR                  # Seed hand-curated preseason win totals (implied_total stays NULL)
+
+# Ad-hoc DB queries
+just py "<snippet>"                                 # Run a one-off Python snippet against the project venv (read-only diagnostics)
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -10,12 +10,14 @@ Next.js App Router. Most pages are server components that fetch live data from S
 |-------|-------------|
 | `/` | Player Efficiency scatter chart (PPG/PPS vs salary) |
 | `/players` | Searchable player directory |
+| `/players/[id]` | Per-player card: bio, salary, projections, season-by-season stats |
 | `/rosters` | League-wide roster view |
 | `/arb-progress` | Public arbitration progress: team completion status and allocation details |
 | `/arb-planner-public` | Public (read-only) arbitration planner view |
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Preseason Vegas implied totals + win totals per team (reads `team_vegas_lines`) |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -17,14 +17,14 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_plans` | Named arbitration budget allocation plans per user (FK -> `users`) | `(league_id, name, user_id)` |
 | `arbitration_plan_allocations` | Per-player dollar allocations within a plan (FK -> `arbitration_plans`, `players`) | `(plan_id, player_id)` |
 | `scraper_jobs` | Persistent job queue with status tracking, dependencies, and retry logic | -- |
-| `projection_models` | Registry of versioned projection models (internal feature-based v1–v21+ and external sources) | `(name, version)` |
+| `projection_models` | Registry of versioned projection models (internal feature-based v1–v27+ and external sources) | `(name, version)` |
 | `model_projections` | Per-model projected PPG with raw feature values (FK -> `projection_models`, `players`) | `(model_id, player_id, season)` |
 | `backtest_results` | Cached accuracy metrics per model × season × position (FK -> `projection_models`) | `(model_id, season, position)` |
 | `arbitration_progress` | Scraped player allocation data from Ottoneu arbitration page | -- |
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv`. `implied_total` is nullable so preseason win totals can be seeded before the NFL schedule is released (see migration 025). | `(team, season)` |
 
 ### Projection tables detail
 
@@ -64,6 +64,24 @@ Ottoneu fantasy data only: `games_played`, `snaps`, `ppg`, `pps`, `h1_snaps`, `h
 Core stat columns: `games_played`, `passing_yards`, `passing_tds`, `interceptions`, `passing_attempts`, `completions`, `rushing_yards`, `rushing_tds`, `rushing_attempts`, `receptions`, `targets`, `receiving_yards`, `receiving_tds`, `fg_made_0_39`, `fg_made_40_49`, `fg_made_50_plus`, `pat_made`, `total_points`, `ppg`, `offense_snaps`, `defense_snaps`, `st_snaps`, `total_snaps`, `recent_team`.
 
 Advanced receiving (added in migration 022, populated for 2018+ via nflverse `stats_player`): `target_share`, `air_yards_share`, `wopr` (Weighted Opportunity Rating), `racr` (Receiver Air Conversion Ratio), `receiving_air_yards`.
+
+### `draft_capital` columns
+
+- `player_id` UUID FK -> `players` (unique)
+- `season_drafted` int — draft year
+- `round` int — draft round (1–7)
+- `overall_pick` int — overall pick number
+
+Backfilled from nflverse `draft_picks` parquet via `scripts/backfill_draft_capital.py` (default since 2010). Consumed by the `draft_capital_raw` feature (v23+, v25, v27) to inject pre-NFL signal into rookie and early-career projections. The `--update-rosters` flag also flips matched college players to NFL and inserts new player rows for fresh drafts.
+
+### `team_vegas_lines` columns
+
+- `team` text — NFL team abbreviation
+- `season` int
+- `implied_total` numeric(6,2), **nullable** — sum of per-game implied points-for across the regular season, derived from nflverse `games.csv` `spread_line` + `total_line`
+- `win_total` numeric(4,1) — Pythagorean expectation `PF^k / (PF^k + PA^k) * games` with k=2.37, OR preseason sportsbook win total when `implied_total` is null
+
+Backfilled via `scripts/backfill_vegas_lines.py` (nflverse games, 2016+) and seeded via `scripts/seed_preseason_win_totals.py` (hand-curated sportsbook win totals for upcoming seasons). Consumed by the `implied_team_total_raw` feature (v26, v27) to inject market expectations into season projections.
 
 ## Schema Files
 


### PR DESCRIPTION
## Summary

Daily audit of harness docs. Reviewed 12 commits merged since the 2026-05-05 audit (#471). The big new surface area to document: advanced receiving cols on `nfl_stats` (#473), draft_capital table + feature (#475, #476, #487), team_vegas_lines table + nullable `implied_total` + preseason win-total seeding (#479, #480, #481), and the single-source-of-truth active-model lookup (#484).

## Commits reviewed (since 2026-05-05)

```
1e5dcde feat: project drafted rookies from draft capital (#487)
384a445 chore: gitignore .claude/plans and .claude/projects (#486)
559228b chore: broaden Claude permission allowlist + add backfill recipes (#485)
aa593d6 chore: single source of truth for active projection model (#484)
571f63e feat: backfill 2026 NFL draft + project drafted rookies (#482)
4931648 feat: seed 2026 preseason win totals (implied_total nullable) (#481)
6cdb5b1 feat: vegas lines review page (#480)
8e578f0 feat: vegas implied team totals as projection feature (#378) (#479)
3f4a29f docs: refresh projection model eval for v22/v23/v25 (#477)
cf3c03a feat: two-stage residual model for draft capital (v25) (#476)
2027ffd feat: draft capital feature for rookie projections (#376) (#475)
6533791 feat: advanced receiving metrics from nflverse (#375) (#473)
```

## Changes made

- **`docs/generated/db-schema.md`** (priority): bump version range on `projection_models` (v21+ → v27+), note nullable `implied_total` on `team_vegas_lines`, and add new column-level subsections for `draft_capital` and `team_vegas_lines` describing sources and the features that consume them.
- **`docs/ARCHITECTURE.md`**: list advanced receiving columns on `nfl_stats`, and add an "Auxiliary signal tables" subsection covering `draft_capital` (with the rookie OLS fallback path in `update_projections.py`) and `team_vegas_lines` (with the `seed_preseason_win_totals.py` seeding workflow).
- **`docs/COMMANDS.md`**: document four backfill/seed scripts (`backfill_nfl_stats.py`, `backfill_draft_capital.py`, `backfill_vegas_lines.py`, `seed_preseason_win_totals.py`) and their matching `just` recipes (`just backfill-nfl-stats`, `just backfill-draft-capital`, `just backfill-vegas`, `just seed-win-totals`). Also surface `just py "<snippet>"` for ad-hoc DB inspection (already advertised in `CLAUDE.md` but not in `COMMANDS.md`).
- **`docs/FRONTEND.md`**: add the new `/vegas-lines` route, and also the previously-undocumented `/players/[id]` detail page (in scope after the route inventory.
- **`AGENTS.md`**: replace the stale "v12_no_qb_trajectory (current active model)" claim with a pointer to the dynamic `is_active=TRUE` source-of-truth helpers (`fetchActiveProjectionModel()` in the web app, `get_active_model_name()` in `scripts/update_projections.py`). Keeps the original QB/K guidance about not re-enabling the rookie trajectory.

## Items flagged for human follow-up

- **Migration 024 comment is slightly inaccurate.** It says `team_vegas_lines.implied_total` is "Sourced by scraping Pro-Football-Reference game schedules", but the backfill script (`scripts/backfill_vegas_lines.py`) actually reads nflverse `games.csv` (PFR is now Cloudflare-walled per the exec plan). The docs and code agree on nflverse; only the migration comment is stale. Not changing here because rewriting a committed migration's comment is risky.
- **`docs/exec-plans/feature-projections.md`** still calls v2_age_adjusted the production recommendation. It's an older planning doc and predates v20+, so it's intentionally historical — flagging in case a future cleanup wants to mark it as historical at the top.

## Test plan

- [x] `git diff` reviewed — five small doc edits, no code changes
- [x] All new file paths referenced in the docs exist (`scripts/backfill_*.py`, `scripts/seed_preseason_win_totals.py`, `web/app/vegas-lines/`, `web/app/players/[id]/`)
- [x] All new `just` recipes referenced exist in the `Justfile`

https://claude.ai/code/session_019ag5Dsbj3gCtjPidcmt58M

---
_Generated by [Claude Code](https://claude.ai/code/session_019ag5Dsbj3gCtjPidcmt58M)_