### PR TITLE
docs: daily harness audit 2026-05-15

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **Promote the new model when it wins.** The active model is the row in `projection_models` with `is_active=TRUE` — there is no `ACTIVE_MODEL` constant. `update_projections.py` reads it dynamically via `get_active_model_name()`, and the web UI surfaces the active model's name/description/features through `<ActiveModelCard>` (driven by `fetchActiveProjectionModel()` in `web/lib/data.ts`). Methodology text is no longer hardcoded per page — promoting via `just promote <name>` flips the flag and the UI updates on the next request.
 
 This ensures every projection change is empirically validated before merge.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -84,6 +84,12 @@ python scripts/feature_projections/feature_analysis.py --model v20_learned_usage
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025  # Residual distribution, heteroscedasticity, persistent errors
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025 --output docs/generated/residual-analysis.md  # Write markdown report
 
+# Backfills / Seeds
+python scripts/backfill_nfl_stats.py --seasons 2024                   # Backfill nfl_stats from nflverse (incl. advanced receiving cols for 2018+)
+python scripts/backfill_draft_capital.py --since 2010                 # Backfill draft_capital from nflverse draft_picks
+python scripts/backfill_vegas_lines.py --since 2016                   # Backfill team_vegas_lines from nflverse games.csv
+python scripts/seed_preseason_win_totals.py --season 2026             # Seed preseason win_total rows before schedule release
+
 # Utilities
 python scripts/check_db.py                           # Verify database contents
 streamlit run scripts/visualize_app.py               # Streamlit dashboard
@@ -122,6 +128,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds (variadic — pass --dry-run, --since, --seasons, etc. through)
+just backfill-nfl-stats [--seasons 2024]            # Backfill nfl_stats from nflverse (per-season)
+just backfill-draft-capital [--since 2010]          # Backfill draft_capital from nflverse draft_picks
+just backfill-vegas [--since 2016]                  # Backfill team_vegas_lines from nflverse games.csv
+just seed-win-totals --season 2026                  # Seed preseason win_total rows (implied_total left NULL until schedule lands)
+
+# Ad-hoc DB inspection
+just py "<python snippet>"                          # Run a one-off Python snippet against the project venv
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -22,6 +22,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/arbitration` | Arbitration targets with per-opponent breakdown |
 | `/arbitration-simulation` | Monte Carlo arbitration simulation |
 | `/arbitration-planner` | Plan and save arbitration budget allocations (auth required) |
+| `/vegas-lines` | Preseason Vegas lines review (per-team implied totals + win totals by season) |
 | `/login` | Email/password login |
 | `/admin` | User management (admin only) |
 
@@ -38,6 +39,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Renders the live active projection model (name, version, description, features) from `fetchActiveProjectionModel()` — shown on `/projections`, `/arbitration` (projected mode), `/projection-accuracy`. Never hardcode model names in UI copy. |
 
 ### Column Factories (`components/columns.tsx`)
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -24,7 +24,7 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total (nullable) + Pythagorean win total, aggregated from nflverse `games.csv`. `implied_total` is nullable so the preseason `win_total` can be seeded in March/April before the NFL schedule (and thus per-game spreads) is released; the `implied_team_total_raw` feature returns `None` until backfilled (migration 025) | `(team, season)` |
 
 ### Projection tables detail
 


### PR DESCRIPTION
## Summary

Daily audit of harness docs against commits merged since 2026-05-05 (last audit, #471).

### Commits reviewed (12 since last audit)

- #487 feat: project drafted rookies from draft capital
- #486 chore: gitignore .claude/plans and .claude/projects
- #485 chore: broaden Claude permission allowlist + add backfill recipes
- #484 chore: single source of truth for active projection model
- #482 feat: backfill 2026 NFL draft + project drafted rookies
- #481 feat: seed 2026 preseason win totals (implied_total nullable)  ← migration 025
- #480 feat: vegas lines review page
- #479 feat: vegas implied team totals as projection feature  ← migration 024
- #477 docs: refresh projection model eval for v22/v23/v25
- #476 feat: two-stage residual model for draft capital (v25)
- #475 feat: draft capital feature for rookie projections  ← migration 023
- #473 feat: advanced receiving metrics from nflverse  ← migration 022

### Doc changes

- **AGENTS.md**: replaced stale "Update UI methodology text when changing `ACTIVE_MODEL`" instruction. After #484 there is no `ACTIVE_MODEL` constant — `update_projections.py` reads `is_active` dynamically and the web UI renders methodology via `<ActiveModelCard>` from `fetchActiveProjectionModel()`. New wording points contributors at `just promote <name>` as the only step needed.
- **docs/COMMANDS.md**: added the four new backfill/seed `just` recipes (`backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`), the `just py "<snippet>"` ad-hoc recipe, and corresponding raw `python scripts/…` entry points.
- **docs/FRONTEND.md**: added `/vegas-lines` route (#480) and the new `ActiveModelCard` component (#484) to the route/component tables.
- **docs/generated/db-schema.md**: noted that `team_vegas_lines.implied_total` is nullable per migration 025, and why — preseason `win_total` lands before the NFL schedule, so `implied_total` is backfilled later.

### Schema audit

- Migrations 022 (advanced receiving cols on `nfl_stats`), 023 (`draft_capital`), and 024 (`team_vegas_lines`) were already reflected in `db-schema.md` by their feature PRs.
- Migration 025 (drop NOT NULL on `team_vegas_lines.implied_total`) was the only previously-undocumented drift — fixed here.

### Items flagged for human follow-up

- **`schema.sql` is stale.** Header on `db-schema.md` says "Nineteen tables" and the migrations directory matches, but `schema.sql` only contains 17 `CREATE TABLE` statements (missing `draft_capital` and `team_vegas_lines`). `schema.sql` is auto-generated via Supabase MCP — regenerating it requires DB access, which is out of scope for this audit. Worth re-dumping next time someone has Supabase MCP available.

## Test plan
- [ ] Doc-only changes; no code touched
- [ ] `just check-docs` (documentation freshness)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JwYee83xZqS4Bcf82v7tt5)_