### PR TITLE
docs: daily harness audit 2026-05-16

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -122,6 +122,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds
+just backfill-nfl-stats [--seasons 2024] [--dry-run]      # nflverse → nfl_stats (incl. advanced receiving)
+just backfill-draft-capital [--since 2010] [--dry-run]    # nflverse draft_picks → draft_capital
+just backfill-vegas [--since 2016] [--dry-run]            # nflverse games.csv → team_vegas_lines (implied_total + win_total)
+just seed-win-totals --season 2026                        # Hand-curated preseason win totals (implied_total left null until schedule release)
+
+# Ad-hoc DB queries
+just py "<snippet>"                                       # One-off Python against the project venv for read-only diagnostics
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Per-team preseason Vegas implied totals and win totals (auth required) |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |
@@ -38,6 +39,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Renders the live active projection model (name, version, description, feature list) via `fetchActiveProjectionModel()`. Used on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` so model copy never goes stale on promotion. |
 
 ### Column Factories (`components/columns.tsx`)
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -17,7 +17,7 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_plans` | Named arbitration budget allocation plans per user (FK -> `users`) | `(league_id, name, user_id)` |
 | `arbitration_plan_allocations` | Per-player dollar allocations within a plan (FK -> `arbitration_plans`, `players`) | `(plan_id, player_id)` |
 | `scraper_jobs` | Persistent job queue with status tracking, dependencies, and retry logic | -- |
-| `projection_models` | Registry of versioned projection models (internal feature-based v1–v21+ and external sources) | `(name, version)` |
+| `projection_models` | Registry of versioned projection models (internal feature-based v1–v27+ and external sources) | `(name, version)` |
 | `model_projections` | Per-model projected PPG with raw feature values (FK -> `projection_models`, `players`) | `(model_id, player_id, season)` |
 | `backtest_results` | Cached accuracy metrics per model × season × position (FK -> `projection_models`) | `(model_id, season, position)` |
 | `arbitration_progress` | Scraped player allocation data from Ottoneu arbitration page | -- |
@@ -54,6 +54,31 @@ Nineteen tables, all with UUID primary keys.
 - `r_squared` float — goodness of fit
 - `rmse` float — Root Mean Square Error
 - `player_count` int — sample size for this season × position
+
+**`player_projections`**
+- `player_id` UUID FK -> `players`
+- `season` int
+- `projected_ppg` numeric
+- `projection_method` text — set by `promote.py` to the active model's name (e.g. `v22_advanced_receiving`) for the main path. Rookie fallback rows written by `update_projections.py` use `rookie_draft_capital` (drafted rookies, projected via per-position OLS on log-overall-pick) or `college_prospect` (undrafted, position-mean rookie PPG). Promotion preserves rows tagged with the two rookie methods so they survive across model swaps.
+
+### `draft_capital` columns (migration 023)
+
+- `player_id` UUID FK -> `players` (unique — one row per player)
+- `season_drafted` int — NFL draft year
+- `round` int
+- `overall_pick` int
+
+Sourced from nflverse `draft_picks` via `scripts/backfill_draft_capital.py`. Powers the `draft_capital_raw` feature (log-scaled overall pick for first three NFL seasons, zero for veterans) consumed by v23/v25/v27 and the rookie fallback projection path.
+
+### `team_vegas_lines` columns (migrations 024/025)
+
+- `team` text — nflverse team abbreviation
+- `season` int
+- `implied_total` numeric(6,2), **nullable** — sum of per-game Vegas implied points across the regular season. Nullable so we can seed `win_total` in March/April before the NFL schedule (and therefore per-game lines) is released; backfill fills this in once nflverse picks up the schedule.
+- `win_total` numeric(4,1), nullable — sportsbook preseason win total.
+- Unique on `(team, season)`. Indexed on `season` and `team`.
+
+Populated by `scripts/backfill_vegas_lines.py` (full season aggregation from nflverse `games.csv`) and `scripts/seed_preseason_win_totals.py` (hand-curated preseason win totals for the upcoming season). Powers the `implied_team_total_raw` feature consumed by v26/v27. The feature returns `None` when `implied_total` is null, so those samples contribute zero through the learned ridge.
 
 ### `player_stats` columns
 


### PR DESCRIPTION
## Summary

Daily audit of agent-facing docs against changes merged since the 2026-05-05 audit (PR #471). Two new tables (`draft_capital`, `team_vegas_lines`), a new auth-gated route (`/vegas-lines`), a new component (`ActiveModelCard`), and several new `just` recipes had all landed without their schema/route/command pages catching up.

## Commits reviewed

`git log --since="2026-05-05" origin/main`:

- #487 feat: project drafted rookies from draft capital
- #486 chore: gitignore `.claude/plans` and `.claude/projects`
- #485 chore: broaden Claude permission allowlist + add backfill recipes
- #484 chore: single source of truth for active projection model
- #482 feat: backfill 2026 NFL draft + project drafted rookies
- #481 feat: seed 2026 preseason win totals (migration 025 — `implied_total` nullable)
- #480 feat: vegas lines review page (`/vegas-lines`)
- #479 feat: vegas implied team totals as projection feature (migration 024)
- #477 docs: refresh projection model eval for v22/v23/v25
- #476 feat: two-stage residual model for draft capital (v25)
- #475 feat: draft capital feature for rookie projections (migration 023)
- #473 feat: advanced receiving metrics from nflverse (migration 022)

## Changes made

**`docs/generated/db-schema.md`**
- Added column detail blocks for `draft_capital` (migration 023) and `team_vegas_lines` (migrations 024 + 025), including the `implied_total` nullable note explaining the spring-preseason seeding flow.
- Added a `player_projections` detail block documenting the `projection_method` contract — promotion writes the active model name, `update_projections.py` writes `rookie_draft_capital` / `college_prospect` for the two fallback paths, and `promote.py` preserves those rookie rows across model swaps.
- Bumped the `projection_models` version-range shorthand from `v1–v21+` to `v1–v27+` to match `model_config.MODELS`.

**`docs/FRONTEND.md`**
- Added `/vegas-lines` to the routes table (auth-required, per `web/middleware.ts:PROTECTED_ROUTES`).
- Added `ActiveModelCard` to the reusable-components table — it's now the single source of UI truth for the active projection model and shows on three pages.

**`docs/COMMANDS.md`**
- Listed the `just` backfill/seed recipes added in #485 (`backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`) and the `just py "<snippet>"` ad-hoc runner that CLAUDE.md already references.

## Flagged for human follow-up

- `scripts/check_docs_freshness.py` is warning about three pre-existing items unrelated to this audit and not introduced by recent merges: it surfaces `data.ts`, `config.py`, `config.ts` in `CODE_ORGANIZATION.md` as nonexistent paths (the doc uses these as bare filenames, the checker reads them as paths), plus two orphan files under `docs/superpowers/` left over from the Justfile migration (#436). Worth deciding whether to either tighten the freshness checker's path detection or delete/link the orphan superpowers docs in a separate cleanup PR.

## Test plan

- [x] `git log --since="2026-05-05" origin/main` reviewed; no migration files or new routes left undocumented after these edits.
- [x] Verified the four new recipes listed in COMMANDS.md exist in the Justfile (`backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`, `py`).
- [x] Verified `/vegas-lines` is in `web/middleware.ts:PROTECTED_ROUTES` (auth-required claim is accurate).
- [x] Cross-checked `draft_capital` and `team_vegas_lines` column lists against `migrations/023`, `024`, and `025`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hom1VuyLavPRcrJH7cDCuG)_