### PR TITLE
docs: daily harness audit 2026-05-17

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **Promote the new model to make it active** via `just promote <name>` (or `scripts/feature_projections/cli.py promote --model <name>`). UI methodology text is driven by the `<ActiveModelCard>` component reading `projection_models.is_active` — there is no hardcoded `ACTIVE_MODEL` constant to update. `update_projections.py` reads `is_active` dynamically, so the next pipeline run picks up the new model automatically.
 
 This ensures every projection change is empirically validated before merge.
 
@@ -119,7 +119,7 @@ The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year
 - **QB**: A starting QB already receives all offensive snaps. A high H2/H1 ratio simply means they took over mid-season, not that they'll be better next year.
 - **K**: Snap counts are irrelevant to kicker scoring.
 
-`v12_no_qb_trajectory` (current active model) disables the trajectory for QB and K via `WeightedPPGNoQBTrajectoryFeature`. Do not re-enable it for those positions.
+All current production models (v14+, including v22/v25/v27 and the learned-ridge family) disable the trajectory for QB and K via `WeightedPPGNoQBTrajectoryFeature`. Do not re-enable it for those positions in any new model.
 
 ### Database migration workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Note: The local directory is `ottoneu_db` (underscore) but the GitHub repo name 
 
 ## Critical Rules
 
-- **Prefer `just <recipe>` over raw commands.** Run `just --list` to see available recipes. Common ones: `just typecheck`, `just lint`, `just test-web`, `just test-python`, `just train MODEL`, `just project MODEL`, `just backtest MODEL`, `just promote MODEL`, `just accuracy-report`, `just diagnostics`, `just segment-analysis`, `just backfill-nfl-stats`, `just backfill-draft-capital`, `just backfill-vegas`, `just seed-win-totals`. For ad-hoc DB inspection use `just py "<snippet>"`.
+- **Prefer `just <recipe>` over raw commands.** Run `just --list` to see available recipes. Common ones: `just typecheck`, `just lint`, `just test-web`, `just test-web-file <path>`, `just test-python`, `just train MODEL`, `just project MODEL`, `just backtest MODEL`, `just promote MODEL`, `just accuracy-report`, `just diagnostics`, `just segment-analysis`, `just backfill-nfl-stats`, `just backfill-draft-capital`, `just backfill-vegas`, `just seed-win-totals`. For ad-hoc DB inspection use `just py "<snippet>"`.
 - **Update documentation:** Always try to update the agent documentation after completing a task. Update existing documents or add new documents and sections as needed to reflect architectural or contextual changes.
 - **Never commit directly to `main`.** All changes go through pull requests.
 - **Always create a PR.** Every task must end with `gh pr create --fill`.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -84,6 +84,12 @@ python scripts/feature_projections/feature_analysis.py --model v20_learned_usage
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025  # Residual distribution, heteroscedasticity, persistent errors
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025 --output docs/generated/residual-analysis.md  # Write markdown report
 
+# Backfills / Seeds
+python scripts/backfill_nfl_stats.py --seasons 2024              # Backfill nflverse NFL stats for given seasons (--dry-run supported)
+python scripts/backfill_draft_capital.py --since 2010            # Backfill draft_capital rows from nflverse draft_picks (--dry-run supported)
+python scripts/backfill_vegas_lines.py --since 2016              # Backfill team_vegas_lines (implied_total + win_total) from nflverse games.csv
+python scripts/seed_preseason_win_totals.py --season 2026        # Seed preseason win_total rows (implied_total stays NULL until schedule is released)
+
 # Utilities
 python scripts/check_db.py                           # Verify database contents
 streamlit run scripts/visualize_app.py               # Streamlit dashboard
@@ -122,6 +128,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds
+just backfill-nfl-stats [--seasons 2024 ...]        # Backfill nflverse NFL stats (--dry-run supported)
+just backfill-draft-capital [--since 2010]          # Backfill draft_capital from nflverse draft_picks
+just backfill-vegas [--since 2016]                  # Backfill team_vegas_lines from nflverse games.csv
+just seed-win-totals --season 2026                  # Seed preseason win totals (implied_total left NULL)
+
+# Ad-hoc DB queries
+just py "<python snippet>"                          # Run a one-off Python snippet via the project venv
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Preseason Vegas implied team totals + win totals review, grouped by NFL division |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |
@@ -38,6 +39,8 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Server-rendered card showing the currently active projection model (name, version, description, features) — reads `projection_models.is_active` via `fetchActiveProjectionModel()` |
+| `ProjectionYearSelector` | Year-toggle control for projection views |
 
 ### Column Factories (`components/columns.tsx`)
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -17,14 +17,14 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_plans` | Named arbitration budget allocation plans per user (FK -> `users`) | `(league_id, name, user_id)` |
 | `arbitration_plan_allocations` | Per-player dollar allocations within a plan (FK -> `arbitration_plans`, `players`) | `(plan_id, player_id)` |
 | `scraper_jobs` | Persistent job queue with status tracking, dependencies, and retry logic | -- |
-| `projection_models` | Registry of versioned projection models (internal feature-based v1–v21+ and external sources) | `(name, version)` |
+| `projection_models` | Registry of versioned projection models (internal feature-based v1–v27+ and external sources) | `(name, version)` |
 | `model_projections` | Per-model projected PPG with raw feature values (FK -> `projection_models`, `players`) | `(model_id, player_id, season)` |
 | `backtest_results` | Cached accuracy metrics per model × season × position (FK -> `projection_models`) | `(model_id, season, position)` |
 | `arbitration_progress` | Scraped player allocation data from Ottoneu arbitration page | -- |
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv`. `implied_total` is nullable (migration 025) so preseason win totals can be seeded before the schedule is released. | `(team, season)` |
 
 ### Projection tables detail
 


### PR DESCRIPTION
## Summary

Daily sweep of harness docs against `main`. The last audit shipped on 2026-05-05 (#471); since then the projection system has gone from `v12` → `v22`/`v25`/`v27` and picked up draft-capital, advanced-receiving, and Vegas-implied-total features, plus a new `/vegas-lines` page and backfill/seed scripts. Several docs still referenced the pre-v22 world.

## Commits reviewed (since #471)

| PR | Subject |
|----|---------|
| #473 | advanced receiving metrics from nflverse |
| #475 | draft capital feature for rookie projections |
| #476 | two-stage residual model for draft capital (v25) |
| #477 | refresh projection model eval for v22/v23/v25 |
| #479 | vegas implied team totals as projection feature |
| #480 | vegas lines review page |
| #481 | seed 2026 preseason win totals (implied_total nullable) |
| #482 | backfill 2026 NFL draft + project drafted rookies |
| #484 | single source of truth for active projection model |
| #485 | broaden Claude permission allowlist + add backfill recipes |
| #486 | gitignore `.claude/plans` and `.claude/projects` |
| #487 | project drafted rookies from draft capital |

## Doc changes

- **AGENTS.md** — Step 4 of "Projection Model Update Requirements" no longer points at a hardcoded `ACTIVE_MODEL` constant in `update_projections.py`; it now describes the `is_active`-driven `<ActiveModelCard>` flow (#484). Also updated the "weighted_ppg trajectory" section so it doesn't claim `v12_no_qb_trajectory` is the current active model.
- **FRONTEND.md** — Added `/vegas-lines` route (#480) and documented the `ActiveModelCard` and `ProjectionYearSelector` components.
- **COMMANDS.md** — Added the new backfill/seed `just` recipes (`backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`) introduced in #485, plus `just py` for ad-hoc DB snippets and the raw script invocations.
- **db-schema.md** — Noted migration 025 making `team_vegas_lines.implied_total` nullable. Bumped the model registry range from `v1–v21+` to `v1–v27+`.
- **CLAUDE.md** — Added `just test-web-file <path>` to the quick-reference recipe list.

## Schema cross-check

Compared `migrations/022`–`025` against `docs/generated/db-schema.md`:

- `nfl_stats` advanced receiving columns (migration 022): already documented ✅
- `draft_capital` table (migration 023): already documented ✅
- `team_vegas_lines` table (migration 024): already documented ✅
- `team_vegas_lines.implied_total NOT NULL` drop (migration 025): now documented ✅
- Table count "Nineteen tables" still matches reality ✅

## Items flagged for human follow-up

These are pre-existing and were not introduced by the recent commits, so I didn't fix them here:

1. **`scripts/check_docs_freshness.py` false positives** — flags bare backtick filenames (`data.ts`, `config.py`, `config.ts`) inside `CODE_ORGANIZATION.md` even when the file is actually documented under its full path. Either tighten the regex (require a `/` in the path) or rewrite the references to be fully qualified.
2. **Orphan docs under `docs/superpowers/`** — `2026-04-19-build-system-just.md` and `2026-04-19-build-system-design.md` are not referenced from `AGENTS.md` or `CLAUDE.md`. Decide whether to link them from the Documentation Map or remove them now that the Justfile migration has shipped.

## Test plan

- [x] Doc-only changes; no code paths exercised.
- [x] `python3 scripts/check_docs_freshness.py` — no new warnings (pre-existing ones noted above are unchanged).
- [x] `git diff main` reviewed; all replacements preserve surrounding context.

https://claude.ai/code/session_01HyGvtVPjiAQE7JYp1AH7mR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyGvtVPjiAQE7JYp1AH7mR)_