### PR TITLE
docs: daily harness audit 2026-05-19

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **Promote the new model to flip `is_active`.** The active model is the single row in `projection_models` with `is_active=TRUE` — there is no longer an `ACTIVE_MODEL` constant in `update_projections.py`. `web/components/ActiveModelCard.tsx` renders the live model name, version, description, and feature list on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` via `fetchActiveProjectionModel()` (`web/lib/data.ts`). Do not hardcode model names or feature lists in UI copy — they drift the moment a new model is promoted. Promote via `just promote <model>` (or `scripts/feature_projections/promote.py <model>`).
 
 This ensures every projection change is empirically validated before merge.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -45,6 +45,12 @@ python scripts/analyze_arbitration_simulation.py     # Monte Carlo arbitration s
 python scripts/analyze_projected_arbitration.py      # Projected arbitration targets based on historical stats
 python scripts/scrape_arbitration_progress.py        # Scrape Ottoneu arbitration progress (allocations + team status)
 
+# Backfills / seeds (one-off data loads from external sources)
+python scripts/backfill_nfl_stats.py --seasons 2024              # Backfill nfl_stats from nflverse (supports --dry-run)
+python scripts/backfill_draft_capital.py --since 2010            # Backfill draft_capital from nflverse draft_picks (supports --dry-run)
+python scripts/backfill_vegas_lines.py --since 2016              # Backfill team_vegas_lines from nflverse games.csv (supports --dry-run)
+python scripts/seed_preseason_win_totals.py --season 2026        # Seed preseason win totals (implied_total backfilled later when schedule lands)
+
 # Feature-based Projections
 python scripts/feature_projections/cli.py list                                              # List available model definitions
 # Note: `run` uses --seasons but `backtest` uses --test-seasons (different flag names)
@@ -122,6 +128,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds (variadic passthrough — all flags forward to the script)
+just backfill-nfl-stats [--seasons 2024 ...]        # Backfill nfl_stats from nflverse
+just backfill-draft-capital [--since 2010]          # Backfill draft_capital from nflverse draft_picks
+just backfill-vegas [--since 2016]                  # Backfill team_vegas_lines from nflverse games.csv
+just seed-win-totals [--season 2026]                # Seed preseason win totals
+
+# Ad-hoc DB queries
+just py "<python snippet>"                          # Run a one-off Python snippet in the project venv (read-only diagnostics)
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Preseason Vegas implied team totals + win totals, grouped by division |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |
@@ -38,6 +39,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Server component — renders methodology metadata for the currently-active projection model (driven by `projection_models.is_active`); used on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` |
 
 ### Column Factories (`components/columns.tsx`)
 


### PR DESCRIPTION
## Summary

Daily harness-doc audit. Catches up the AI-agent docs with the burst of merges since the last audit (PR #471 on 2026-05-05): draft capital (#475/#476), Vegas implied team totals (#479/#480/#482), 2026 preseason win totals (#481), backfill recipes (#485), and the `is_active`-driven projection-model single-source-of-truth refactor (#484).

### Commits reviewed (2026-05-05 → today)

```
1e5dcde feat: project drafted rookies from draft capital (#487)
384a445 chore: gitignore .claude/plans and .claude/projects (#486)
559228b chore: broaden Claude permission allowlist + add backfill recipes (#485)
aa593d6 chore: single source of truth for active projection model (#484)
571f63e feat: backfill 2026 NFL draft + project drafted rookies (#482)
4931648 feat: seed 2026 preseason win totals (implied_total nullable) (#481)
6cdb5b1 feat: vegas lines review page (#480)
8e578f0 feat: vegas implied team totals as projection feature (#378) (#479)
3f4a29f docs: refresh projection model eval for v22/v23/v25 (#477)
cf3c03a feat: two-stage residual model for draft capital (v25) (#476)
2027ffd feat: draft capital feature for rookie projections (#376) (#475)
6533791 feat: advanced receiving metrics from nflverse (#375) (#473)
```

### Changes made

- **AGENTS.md** — Step 4 of the Projection Model Update Requirements still pointed at `ACTIVE_MODEL` in `update_projections.py`, but that constant was removed in #484. Rewrote the step to describe the current flow: a single `projection_models.is_active=TRUE` row + `ActiveModelCard.tsx` rendering methodology dynamically, with promotion via `just promote <model>`. Removed the misleading "pages contain hardcoded methodology descriptions" line — they don't anymore.
- **docs/FRONTEND.md** — Added `/vegas-lines` route (#480) to the routes table, and `ActiveModelCard` (#484) to the reusable components table.
- **docs/COMMANDS.md** — Added backfill/seed scripts to both the raw-Python section (`backfill_nfl_stats.py`, `backfill_draft_capital.py`, `backfill_vegas_lines.py`, `seed_preseason_win_totals.py`) and the just-recipes section (`backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`), plus the `just py` ad-hoc helper that CLAUDE.md already references but COMMANDS.md hadn't picked up.

### Schema doc check

`docs/generated/db-schema.md` is already current through migration 025 — covers `draft_capital` (022/023), `team_vegas_lines` (024/025), and advanced receiving columns. No drift. Migration count and 19-table header match reality.

### Items flagged for human follow-up (not addressed here)

- `scripts/check_docs_freshness.py` reports three CODE_ORGANIZATION.md warnings (bare filenames `data.ts` / `config.py` / `config.ts` flagged as "not found"). These are pre-existing false positives — the freshness checker doesn't understand the implicit `web/lib/` / `scripts/` paths in that doc's tabular layout. Either tighten the doc to use full paths or relax the checker; either fix is out of scope for a daily audit.
- Two orphan files under `docs/superpowers/` (the `2026-04-19-build-system-*.md` plan/spec from the just-recipe rollout) aren't linked from AGENTS.md or CLAUDE.md. They look like historical planning artifacts — worth a human eye on whether to link or delete.

## Test plan

- [x] `git diff` shows only doc edits (no code touched)
- [x] `python scripts/check_docs_freshness.py` introduces no new warnings vs main
- [x] Spot-checked every newly-mentioned just recipe exists in `Justfile`
- [x] Spot-checked every newly-mentioned script exists under `scripts/`
- [x] Spot-checked `/vegas-lines` route renders from `web/app/vegas-lines/page.tsx` and `ActiveModelCard.tsx` is imported by the three pages claimed


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9bS69FHqBoWh6GQ9srTAX)_