### PR TITLE
docs: daily harness audit 2026-05-20

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year
 - **QB**: A starting QB already receives all offensive snaps. A high H2/H1 ratio simply means they took over mid-season, not that they'll be better next year.
 - **K**: Snap counts are irrelevant to kicker scoring.
 
-`v12_no_qb_trajectory` (current active model) disables the trajectory for QB and K via `WeightedPPGNoQBTrajectoryFeature`. Do not re-enable it for those positions.
+`v12_no_qb_trajectory` introduced `WeightedPPGNoQBTrajectoryFeature`, which disables the H2/H1 trajectory for QB and K. Subsequent models inherit this behavior (and learned models like v20+ replace `WeightedPPGFeature` with the no-QB-trajectory variant). Do not re-enable the trajectory for those positions in any new model. Check the live active model via `SELECT name, version FROM projection_models WHERE is_active = TRUE;` — never hardcode it in docs or UI copy.
 
 ### Database migration workflow
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -84,6 +84,12 @@ python scripts/feature_projections/feature_analysis.py --model v20_learned_usage
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025  # Residual distribution, heteroscedasticity, persistent errors
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025 --output docs/generated/residual-analysis.md  # Write markdown report
 
+# Backfills / seeds
+python scripts/backfill_nfl_stats.py [--seasons 2018 2019]      # Backfill nflverse stats into nfl_stats (--dry-run supported)
+python scripts/backfill_draft_capital.py [--since 2010]         # Backfill nflverse draft picks into draft_capital (--update-rosters flips college→NFL for post-draft rookies)
+python scripts/backfill_vegas_lines.py [--since 2016]           # Aggregate nflverse games.csv into team_vegas_lines (implied_total + Pythagorean win_total)
+python scripts/seed_preseason_win_totals.py --season 2026       # Seed hand-curated preseason win totals (sportsbook consensus); used in spring before NFL schedule drops
+
 # Utilities
 python scripts/check_db.py                           # Verify database contents
 streamlit run scripts/visualize_app.py               # Streamlit dashboard
@@ -122,6 +128,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds
+just backfill-nfl-stats [--seasons 2024]            # Backfill nflverse stats into nfl_stats
+just backfill-draft-capital [--since 2010]          # Backfill nflverse draft picks into draft_capital
+just backfill-vegas [--since 2016]                  # Backfill Vegas lines into team_vegas_lines
+just seed-win-totals --season 2026                  # Seed hand-curated preseason win totals (spring use)
+
+# Ad-hoc DB queries
+just py "<snippet>"                                 # Run a one-off Python snippet against the project venv (read-only diagnostics)
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Preseason Vegas implied team totals + win totals review (reads `team_vegas_lines`) |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -24,7 +24,7 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total + win total. `implied_total` is aggregated from nflverse `games.csv`; `win_total` is back-derived (Pythagorean) or hand-seeded from sportsbook preseason consensus. `implied_total` is nullable (migration 025) so win totals can be seeded in spring before the NFL schedule drops. | `(team, season)` |
 
 ### Projection tables detail
 


### PR DESCRIPTION
## Summary

Daily harness-documentation audit. No commits in the last 25 hours, so this is a lighter sweep that catches docs up to the wave of merges from late April through 2026-05-07 (PRs #473–#487) — none of which had touched the harness docs explicitly.

### Commits reviewed (since last audit #471, 2026-05-05)

- #487 feat: project drafted rookies from draft capital
- #486 chore: gitignore .claude/plans and .claude/projects
- #485 chore: broaden Claude permission allowlist + add backfill recipes
- #484 chore: single source of truth for active projection model
- #482 feat: backfill 2026 NFL draft + project drafted rookies
- #481 feat: seed 2026 preseason win totals (implied_total nullable)
- #480 feat: vegas lines review page
- #479 feat: vegas implied team totals as projection feature (#378)
- #477 docs: refresh projection model eval for v22/v23/v25
- #476 feat: two-stage residual model for draft capital (v25)
- #475 feat: draft capital feature for rookie projections (#376)
- #473 feat: advanced receiving metrics from nflverse

### Changes

- **`docs/FRONTEND.md`** — document the new `/vegas-lines` route added by PR #480 (was missing from the routes table).
- **`docs/COMMANDS.md`** — add the new `just` recipes (`backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`, `py`) and the underlying Python scripts (`backfill_draft_capital.py`, `backfill_vegas_lines.py`, `seed_preseason_win_totals.py`) that landed in #475/#479/#481/#482/#485. CLAUDE.md already references these recipes but COMMANDS.md hadn't been updated.
- **`docs/generated/db-schema.md`** — refine the `team_vegas_lines` entry: `win_total` can be Pythagorean-derived *or* hand-seeded from sportsbook consensus, and `implied_total` is nullable after migration 025 (PR #481) to support spring seeding before the NFL schedule drops.
- **`AGENTS.md`** — rewrite the v12_no_qb_trajectory note. PR #484 made `projection_models.is_active` the single source of truth and the doc explicitly warns against hardcoding model names. The "(current active model)" tag would drift the next time we promote. New phrasing captures the durable behavior (no-QB-trajectory base is inherited by v20+ learned models) and points readers at the live DB query.

### Schema cross-check

Walked `migrations/001` → `migrations/025` against `docs/generated/db-schema.md`. The table count (19) and every table row matches the migrations. Only drift was the `team_vegas_lines` description (fixed above). No new migrations since the last audit.

### Items flagged for human follow-up

None — the touch was light and self-contained.

## Test plan

- [ ] CI doc-freshness check passes (`just check-docs`)
- [ ] Spot-check rendered `docs/COMMANDS.md` and `docs/FRONTEND.md` tables on the PR

https://claude.ai/code/session_01BtCLqRgE34sjJYeGNw5hCf

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtCLqRgE34sjJYeGNw5hCf)_