### PR TITLE
docs: daily harness audit 2026-05-21

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -84,6 +84,12 @@ python scripts/feature_projections/feature_analysis.py --model v20_learned_usage
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025  # Residual distribution, heteroscedasticity, persistent errors
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025 --output docs/generated/residual-analysis.md  # Write markdown report
 
+# Backfills / seeds (one-time data loads)
+python scripts/backfill_nfl_stats.py --seasons 2024              # Pull nfl_stats from nflverse-data (one or more seasons)
+python scripts/backfill_draft_capital.py --since 2010            # Populate draft_capital from nflverse draft_picks
+python scripts/backfill_vegas_lines.py --since 2016              # Populate team_vegas_lines (implied totals + win totals) from nflverse games
+python scripts/seed_preseason_win_totals.py --season 2026        # Seed hand-curated preseason win totals before NFL schedule release
+
 # Utilities
 python scripts/check_db.py                           # Verify database contents
 streamlit run scripts/visualize_app.py               # Streamlit dashboard
@@ -122,6 +128,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds (variadic — pass through any script flags)
+just backfill-nfl-stats [--seasons ... | --dry-run]      # Backfill nfl_stats from nflverse-data
+just backfill-draft-capital [--since YYYY | --dry-run]   # Backfill draft_capital from nflverse draft_picks
+just backfill-vegas [--since YYYY | --dry-run]           # Backfill team_vegas_lines implied totals
+just seed-win-totals --season YYYY                       # Seed hand-curated preseason win totals
+
+# Ad-hoc DB inspection (read-only diagnostics)
+just py "<python-snippet>"                               # Run a one-off snippet against the project venv
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Preseason Vegas implied team totals + Pythagorean win totals (reads `team_vegas_lines`); AFC/NFC division layout |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |
@@ -38,6 +39,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Server component that reads `projection_models.is_active` (via `fetchActiveProjectionModel`) and renders the live model name/version/features — use on every page that surfaces projection methodology so copy never drifts from the promoted model |
 
 ### Column Factories (`components/columns.tsx`)
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -24,7 +24,7 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total (nullable) + preseason win total, sourced from nflverse `games.csv` + hand-curated win totals | `(team, season)` |
 
 ### Projection tables detail
 
@@ -64,6 +64,14 @@ Ottoneu fantasy data only: `games_played`, `snaps`, `ppg`, `pps`, `h1_snaps`, `h
 Core stat columns: `games_played`, `passing_yards`, `passing_tds`, `interceptions`, `passing_attempts`, `completions`, `rushing_yards`, `rushing_tds`, `rushing_attempts`, `receptions`, `targets`, `receiving_yards`, `receiving_tds`, `fg_made_0_39`, `fg_made_40_49`, `fg_made_50_plus`, `pat_made`, `total_points`, `ppg`, `offense_snaps`, `defense_snaps`, `st_snaps`, `total_snaps`, `recent_team`.
 
 Advanced receiving (added in migration 022, populated for 2018+ via nflverse `stats_player`): `target_share`, `air_yards_share`, `wopr` (Weighted Opportunity Rating), `racr` (Receiver Air Conversion Ratio), `receiving_air_yards`.
+
+### `team_vegas_lines` columns
+
+`team` (PFR code), `season`, `implied_total` numeric — season points implied from per-game lines (nullable since migration 025 so win totals can be seeded before the NFL schedule releases per-game lines), `win_total` numeric — preseason sportsbook win total (Pythagorean post-schedule, hand-curated before schedule release via `seed_preseason_win_totals.py`). Backfilled via `backfill_vegas_lines.py`.
+
+### `draft_capital` columns
+
+`player_id` (unique), `season_drafted`, `round`, `overall_pick`. Sourced from nflverse `draft_picks` parquet via `backfill_draft_capital.py`. Feeds the `draft_capital_raw` projection feature (vets) and the per-position log-pick OLS used by `update_projections.py` to project drafted rookies (`projection_method = 'rookie_draft_capital'`).
 
 ## Schema Files
 


### PR DESCRIPTION
## Summary

Daily harness-doc audit. Zero commits landed in the 25-hour window the audit prompt targets, so this is a sweep against the merges since the last audit (2026-05-05, PR #471) — picking up several routes/scripts/migrations that shipped without their corresponding harness-doc updates.

## Commits reviewed (since #471)

- #473 advanced receiving metrics from nflverse
- #475 draft capital feature for rookie projections
- #476 two-stage residual model for draft capital (v25)
- #477 docs refresh for v22/v23/v25 eval
- #479 vegas implied team totals as a projection feature
- #480 `/vegas-lines` review page
- #481 seed 2026 preseason win totals + migration 025 (`implied_total` nullable)
- #482 backfill 2026 NFL draft + project drafted rookies
- #484 single source of truth for active projection model (`ActiveModelCard`)
- #485 broaden Claude permission allowlist + add backfill recipes
- #486 gitignore `.claude/plans` and `.claude/projects`
- #487 project drafted rookies from draft capital

## Changes made

- **`docs/FRONTEND.md`** — add the `/vegas-lines` route (#480) and the `ActiveModelCard` reusable component (#484) so agents updating projection-methodology copy use the single-source-of-truth pattern instead of hardcoding model names.
- **`docs/COMMANDS.md`** — document the just recipes added in #485 (`backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`, `py`) plus the underlying raw script invocations they wrap. These were in CLAUDE.md but the canonical commands reference was silent on them.
- **`docs/generated/db-schema.md`** — flag that `team_vegas_lines.implied_total` is nullable since migration 025, and add column-level entries for `team_vegas_lines` and `draft_capital` so the projection-pipeline linkage (`draft_capital_raw` feature, `rookie_draft_capital` projection method, `seed_preseason_win_totals.py` graceful-degradation path) is reachable from the schema doc.

## Verified

- All 25 migrations cross-checked against the schema doc's table list — 19 tables, columns aligned with migrations 001–025.
- Skill files in `.claude/commands/` all present and referenced in CLAUDE.md.
- All file paths cited in CLAUDE.md / AGENTS.md still exist.
- Just recipes referenced in COMMANDS.md all exist in the Justfile.

## Items flagged for human follow-up

None. ARCHITECTURE.md was already refreshed in #484 and #487 (rookie/draft-capital path, ghost-row promote behavior, ActiveModelCard data flow), and `exec-plans/projection-accuracy-improvement.md` was updated in #481 with the Vegas-data graceful-degradation notes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gte1W7bKrtfYV7tjePQatt)_