### PR TITLE
docs: daily harness audit 2026-05-22

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **Keep `projection_models.description` and `features` current for any model you might promote.** The `<ActiveModelCard>` server component (`web/components/ActiveModelCard.tsx`) renders model name, version, description, and feature list on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` directly from `projection_models` via `fetchActiveProjectionModel()`. No hand-edited UI methodology copy exists anymore — if the DB row is wrong, the UI will be wrong. Edit the row's description in `model_config.py` (or via SQL) before promoting.
 
 This ensures every projection change is empirically validated before merge.
 
@@ -119,7 +119,7 @@ The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year
 - **QB**: A starting QB already receives all offensive snaps. A high H2/H1 ratio simply means they took over mid-season, not that they'll be better next year.
 - **K**: Snap counts are irrelevant to kicker scoring.
 
-`v12_no_qb_trajectory` (current active model) disables the trajectory for QB and K via `WeightedPPGNoQBTrajectoryFeature`. Do not re-enable it for those positions.
+Models that use `WeightedPPGNoQBTrajectoryFeature` (e.g. `v12_no_qb_trajectory` and every subsequent model that inherits from it via residual stacking) disable the trajectory for QB and K. Do not re-enable it for those positions when adding or refactoring features. Run `just list-models` and inspect `model_config.py` to confirm which base feature a candidate model uses.
 
 ### Database migration workflow
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -122,6 +122,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds
+just backfill-nfl-stats [--seasons 2024]            # Pull nflverse season stats (supports --dry-run)
+just backfill-draft-capital [--since 2010]          # Backfill draft_capital from nflverse draft_picks
+just backfill-vegas [--since 2016]                  # Compute team_vegas_lines.implied_total from nflverse games.csv
+just seed-win-totals [--season 2026]                # Seed preseason win_total rows before the schedule drops
+
+# Ad-hoc DB inspection
+just py "<python snippet>"                          # Run a one-off Python snippet against the project venv
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Per-team preseason Vegas implied totals and win totals (reads `team_vegas_lines`), grouped by division with a season selector |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |
@@ -38,6 +39,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Server component that renders the live `is_active=TRUE` projection model's name, version, description, and feature list. Drop it onto any page that displays projections so methodology copy always matches what's actually being served. |
 
 ### Column Factories (`components/columns.tsx`)
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -17,14 +17,14 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_plans` | Named arbitration budget allocation plans per user (FK -> `users`) | `(league_id, name, user_id)` |
 | `arbitration_plan_allocations` | Per-player dollar allocations within a plan (FK -> `arbitration_plans`, `players`) | `(plan_id, player_id)` |
 | `scraper_jobs` | Persistent job queue with status tracking, dependencies, and retry logic | -- |
-| `projection_models` | Registry of versioned projection models (internal feature-based v1–v21+ and external sources) | `(name, version)` |
+| `projection_models` | Registry of versioned projection models (internal feature-based v1–v27+ and external sources). Exactly one row has `is_active=TRUE`; the web app reads it via `fetchActiveProjectionModel()`. | `(name, version)` |
 | `model_projections` | Per-model projected PPG with raw feature values (FK -> `projection_models`, `players`) | `(model_id, player_id, season)` |
 | `backtest_results` | Cached accuracy metrics per model × season × position (FK -> `projection_models`) | `(model_id, season, position)` |
 | `arbitration_progress` | Scraped player allocation data from Ottoneu arbitration page | -- |
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total + preseason win total. `implied_total` is **nullable** so preseason win-total seeds can land before the schedule is released. | `(team, season)` |
 
 ### Projection tables detail
 
@@ -54,6 +54,24 @@ Nineteen tables, all with UUID primary keys.
 - `r_squared` float — goodness of fit
 - `rmse` float — Root Mean Square Error
 - `player_count` int — sample size for this season × position
+
+### `draft_capital` columns (migration 023)
+
+- `player_id` UUID FK -> `players` (unique — one draft row per player)
+- `season_drafted` int
+- `round` int
+- `overall_pick` int
+
+Populated by `scripts/backfill_draft_capital.py` from the nflverse `draft_picks` parquet (which now includes the 2026 class). Consumed by the `draft_capital_raw` projection feature and by the `rookie_draft_capital` fallback in `update_projections.py`.
+
+### `team_vegas_lines` columns (migrations 024, 025)
+
+- `team` text (3-letter NFL code, e.g. `KC`)
+- `season` int
+- `implied_total` numeric(6,2) **nullable** — season sum of per-game implied points; null until the NFL schedule is released and `scripts/backfill_vegas_lines.py` can compute it from nflverse `games.csv`
+- `win_total` numeric(4,1) nullable — preseason Vegas win total; seeded by `scripts/seed_preseason_win_totals.py` as soon as books post numbers
+
+The `implied_team_total_raw` projection feature already returns `None` when `implied_total` is null, so partial rows are safe to land. The frontend surface for this table lives at `/vegas-lines`.
 
 ### `player_stats` columns
 


### PR DESCRIPTION
## Summary

Daily audit of the AI-agent harness docs (CLAUDE.md, AGENTS.md, docs/, .claude/commands/). Reviewed the 13 commits merged between the last audit (#471, 2026-05-05) and today — PRs #473 through #487 — and corrected drift introduced by them.

### Commits reviewed

| PR | Doc-relevant change |
|---|---|
| #473 | Added `advanced_receiving` columns to `nfl_stats` (migration 022) |
| #475 | Created `draft_capital` table (migration 023) + feature |
| #476 | v25 two-stage residual model for draft capital |
| #477 | Eval refresh for v22/v23/v25 |
| #479 | Created `team_vegas_lines` (migration 024) + `implied_team_total_raw` feature, backfill script |
| #480 | New `/vegas-lines` page in the web app |
| #481 | Made `team_vegas_lines.implied_total` nullable (migration 025) + `seed_preseason_win_totals.py` |
| #482 | Backfill 2026 draft + project drafted rookies |
| #484 | **Single source of truth for active projection model** — `ActiveModelCard` + `fetchActiveProjectionModel()` |
| #485 | New `just backfill-draft-capital`, `backfill-vegas`, `seed-win-totals` recipes |
| #486 | gitignore update only |
| #487 | Project drafted rookies through `update_projections.py` |

### Doc changes made

- **`docs/generated/db-schema.md` (schema doc, highest priority):**
  - Bumped the `projection_models` row's model-range to `v1–v27+` and called out the `is_active=TRUE` singleton invariant.
  - Rewrote the `team_vegas_lines` row to flag `implied_total` as **nullable** (migration 025) — important for any agent writing code against this table.
  - Added explicit column listings for `draft_capital` (migration 023) and `team_vegas_lines` (migrations 024 + 025), including which scripts/features populate and consume them.

- **`AGENTS.md`:**
  - Replaced the stale "Update UI methodology text when changing `ACTIVE_MODEL` in `update_projections.py`" instruction. PR #484 deleted those hand-edited blurbs in favor of the `<ActiveModelCard>` server component, so the new instruction tells agents to keep `projection_models.description`/`features` correct instead.
  - Rephrased the QB/K snap-trajectory note so it doesn't pin to "v12 is the current active model" — the active model now floats and is checked dynamically via `just list-models` + `model_config.py`.

- **`docs/FRONTEND.md`:**
  - Added `/vegas-lines` to the routes table.
  - Added `ActiveModelCard` to the reusable components table.

- **`docs/COMMANDS.md`:**
  - Documented the four new backfill `just` recipes from PR #485 (`backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`) plus the `just py` ad-hoc snippet runner that's referenced in CLAUDE.md but wasn't yet in COMMANDS.md.

### Items flagged for human follow-up (none blocking)

- `docs/generated/projection-accuracy.md` was last generated 2026-05-07. The `/projection-accuracy` skill regenerates it on demand, but a fresh run after v27 was added could refresh the displayed numbers if desired.
- `docs/generated/experiment-log.md` is current through v27 — no action needed.

## Test plan

- [x] `git diff` reviewed; only docs touched (4 files, +33/-4).
- [ ] CI doc-freshness check on this branch (will run automatically).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgftSjPUon1Jcr2Qp7E7pW)_