### PR TITLE
docs: daily harness audit 2026-05-23

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **No UI copy changes needed when swapping the active model.** `update_projections.py` reads the active model dynamically from `projection_models.is_active`, and `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` render the live name/version/description/features via `fetchActiveProjectionModel()` + `<ActiveModelCard>`. Don't reintroduce hardcoded model names or methodology copy on those pages.
 
 This ensures every projection change is empirically validated before merge.
 
@@ -119,7 +119,7 @@ The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year
 - **QB**: A starting QB already receives all offensive snaps. A high H2/H1 ratio simply means they took over mid-season, not that they'll be better next year.
 - **K**: Snap counts are irrelevant to kicker scoring.
 
-`v12_no_qb_trajectory` (current active model) disables the trajectory for QB and K via `WeightedPPGNoQBTrajectoryFeature`. Do not re-enable it for those positions.
+`WeightedPPGNoQBTrajectoryFeature` (used by `v12_no_qb_trajectory` and inherited by every later learned model — `v20`+ ridge variants and the v25/v27 lines) disables the trajectory for QB and K. Do not re-enable it for those positions. To confirm the currently-promoted model, query `SELECT name FROM projection_models WHERE is_active = TRUE;`.
 
 ### Database migration workflow
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -84,6 +84,13 @@ python scripts/feature_projections/feature_analysis.py --model v20_learned_usage
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025  # Residual distribution, heteroscedasticity, persistent errors
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025 --output docs/generated/residual-analysis.md  # Write markdown report
 
+# Backfills & seeds (idempotent loaders; all support --dry-run)
+python scripts/backfill_nfl_stats.py --seasons 2024                          # Backfill nfl_stats from nflverse for one or more seasons
+python scripts/backfill_draft_capital.py --since 2010                        # Backfill draft_capital table from nflverse draft_picks
+python scripts/backfill_draft_capital.py --since 2026 --update-rosters       # Post-draft: flip matched college players to NFL + insert unmatched picks
+python scripts/backfill_vegas_lines.py --since 2016                          # Backfill team_vegas_lines from nflverse games.csv
+python scripts/seed_preseason_win_totals.py --season 2026                    # Seed hand-curated preseason win_totals for a season
+
 # Utilities
 python scripts/check_db.py                           # Verify database contents
 streamlit run scripts/visualize_app.py               # Streamlit dashboard
@@ -122,6 +129,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills & seeds (all variadic — flags pass through to the underlying script)
+just backfill-nfl-stats --seasons 2024              # Backfill nfl_stats from nflverse
+just backfill-draft-capital --since 2010            # Backfill draft_capital from nflverse draft_picks
+just backfill-vegas --since 2016                    # Backfill team_vegas_lines from nflverse games.csv
+just seed-win-totals --season 2026                  # Seed hand-curated preseason win_totals
+
+# Ad-hoc DB inspection (read-only one-liners against the project venv)
+just py "from scripts.config import get_supabase_client; print(get_supabase_client().table('players').select('id', count='exact').execute().count)"
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Preseason Vegas implied team totals review (AFC/NFC divisions, season selector) |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |
@@ -38,6 +39,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Renders the live active projection model (name, version, description, features) driven by `fetchActiveProjectionModel()` — used on `/projections`, `/arbitration` (projected), and `/projection-accuracy` |
 
 ### Column Factories (`components/columns.tsx`)
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -65,6 +65,26 @@ Core stat columns: `games_played`, `passing_yards`, `passing_tds`, `interception
 
 Advanced receiving (added in migration 022, populated for 2018+ via nflverse `stats_player`): `target_share`, `air_yards_share`, `wopr` (Weighted Opportunity Rating), `racr` (Receiver Air Conversion Ratio), `receiving_air_yards`.
 
+### `draft_capital` columns
+
+Added in migration 023. One row per player who has been drafted into the NFL (loaded from nflverse `draft_picks`).
+
+- `player_id` UUID FK -> `players` (unique — exactly one row per drafted player)
+- `season_drafted` int — NFL draft year
+- `round` int
+- `overall_pick` int — used as the raw input to the `draft_capital_raw` feature (log-scaled)
+
+### `team_vegas_lines` columns
+
+Added in migration 024. One row per (team, season) holding preseason Vegas market data, sourced from nflverse `games.csv` per-game lines.
+
+- `team` text — Ottoneu team code (e.g. `KC`, `LV`, `LA`)
+- `season` int
+- `implied_total` numeric(6,2) — sum of per-game implied points; powers the `implied_team_total_raw` projection feature. **Nullable** (relaxed in migration 025): preseason win totals publish in March/April, but per-game lines need the NFL schedule (mid-May release), so this column is briefly null each spring until `backfill_vegas_lines.py` re-runs.
+- `win_total` numeric(4,1) — Pythagorean win total; can be seeded ahead of `implied_total` via `seed_preseason_win_totals.py`
+
+When `implied_total` is null, the `implied_team_total_raw` feature returns `None` and the learned ridge substitutes a near-zero contribution after standardization — the active model gracefully degrades to its no-vegas counterpart.
+
 ## Schema Files
 
 - **Canonical schema:** `schema.sql` (auto-generated via Supabase MCP)


### PR DESCRIPTION
## Summary

Daily sweep across harness documentation. 13 commits merged to `main` since the last audit (`docs: daily harness audit 2026-05-05` / #471), spanning four broad themes — onboard advanced receiving stats, draft capital, and Vegas implied team totals as projection features; ship a `/vegas-lines` review page; consolidate the active projection model into a single DB-driven source of truth; expand the `just` recipe surface with backfill/seed/ad-hoc-query helpers.

### Commits reviewed (origin/main since 2026-05-05)

- #487 `feat: project drafted rookies from draft capital`
- #486 `chore: gitignore .claude/plans and .claude/projects`
- #485 `chore: broaden Claude permission allowlist + add backfill recipes`
- #484 `chore: single source of truth for active projection model`
- #482 `feat: backfill 2026 NFL draft + project drafted rookies`
- #481 `feat: seed 2026 preseason win totals (implied_total nullable)`
- #480 `feat: vegas lines review page`
- #479 `feat: vegas implied team totals as projection feature (#378)`
- #477 `docs: refresh projection model eval for v22/v23/v25`
- #476 `feat: two-stage residual model for draft capital (v25)`
- #475 `feat: draft capital feature for rookie projections (#376)`
- #473 `feat: advanced receiving metrics from nflverse (#375)`

### Doc changes

- **`docs/COMMANDS.md`** — Document the `just backfill-nfl-stats`, `just backfill-draft-capital`, `just backfill-vegas`, `just seed-win-totals`, and `just py "<snippet>"` recipes added in #485, plus the corresponding raw `scripts/backfill_*.py` / `scripts/seed_*.py` invocations (including the post-draft `--update-rosters` mode from #482).
- **`docs/FRONTEND.md`** — Add the `/vegas-lines` route (#480) to the routes table and the new `ActiveModelCard` component (#484) to the reusable-components table.
- **`AGENTS.md`** — Two stale-fact fixes.
  - The "Projection Model Update Requirements" item #4 used to demand updating hardcoded methodology copy in `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` whenever `ACTIVE_MODEL` flipped. #484 removed both the constant (the script now reads `projection_models.is_active` dynamically) and the hardcoded copy (replaced by `<ActiveModelCard>` driven by `fetchActiveProjectionModel()`). Rewrite the rule to say "no UI copy changes needed — don't reintroduce them."
  - The rookie-trajectory section asserted `v12_no_qb_trajectory` was the "current active model." It hasn't been since v25 was promoted, and v27 has come and gone in the rotation since. Reframe the note around the **feature class** (`WeightedPPGNoQBTrajectoryFeature`, inherited by every learned model from v20 onward) and point readers at `SELECT name FROM projection_models WHERE is_active = TRUE;` for the live answer.
- **`docs/generated/db-schema.md`** — Add column-level detail for the two new tables. `draft_capital` (#475) gets a four-field breakdown noting the `(player_id)` uniqueness constraint. `team_vegas_lines` (#479) gets one too, including the migration 025 nullability relaxation on `implied_total`, the spring-window rationale, and the documented graceful-degradation behavior when the column is null.

### Items flagged for human follow-up

- `scripts/check_docs_freshness.py` surfaces five pre-existing warnings (orphan `docs/superpowers/{plans,specs}/2026-04-19-build-system-*.md` files; false-positive CODE_ORGANIZATION.md path matches for `data.ts` / `config.py` / `config.ts`). Out of scope for this audit but worth a cleanup pass — the orphans probably want to either be referenced from AGENTS.md/CLAUDE.md or deleted.
- No schema doc gaps remain after this PR; migrations 022–025 are all reflected.

## Test plan

- [ ] `just check-docs` (informational, pre-existing warnings only)
- [ ] CI runs the architectural tests + freshness check on the PR
- [ ] Manual eyeball on the rendered tables in COMMANDS.md / FRONTEND.md / db-schema.md

https://claude.ai/code/session_01Lw3ZBN2xf9F1nBnjHBsKb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lw3ZBN2xf9F1nBnjHBsKb3)_