### PR TITLE
docs: daily harness audit 2026-05-24

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **Promote the new model** (`just promote <name>`) so its `is_active=TRUE` flag flips in `projection_models`. The web UI sources methodology text from the `<ActiveModelCard>` server component (`web/components/ActiveModelCard.tsx`) via `fetchActiveProjectionModel()`, so `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` pick up the new model's name, version, description, and feature list automatically — no hand-edits to page files needed. Make sure the model's `description` and `features` columns in the DB are accurate, since that's what users will see.
 
 This ensures every projection change is empirically validated before merge.
 

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -14,6 +14,8 @@
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
 | API input schemas | `web/lib/schemas/` | Zod schemas for API route bodies (admin/users, arbitration-plans, surplus-adjustments) |
 | Request validation | `web/lib/validate.ts` | `parseJson(req, schema)` helper — returns typed data or a 400 response with Zod issues |
+| Vegas lines data | `web/lib/vegas-lines.ts` | Read helpers for `team_vegas_lines` used by `/vegas-lines` |
+| NFL divisions | `web/lib/nfl-divisions.ts` | Canonical AFC/NFC division + team-code map used to lay out `/vegas-lines` |
 | DB schema | `schema.sql` | Canonical schema definition |
 | Migrations | `migrations/` | Numbered SQL migration files |
 | Components | `web/components/` | Reusable React components |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -104,7 +104,8 @@ just typecheck          # TypeScript type check
 just test               # Run all tests (Python + web)
 just test-python        # Python tests with coverage
 just test-web           # Jest tests with coverage
-just test-web-file <path>  # Run a single web test file (e.g. just test-web-file __tests__/lib/session.test.ts)
+just test-web-file <path>  # Run a single web test file, no coverage (e.g. just test-web-file __tests__/lib/session.test.ts)
+just py "<snippet>"     # Run a one-off Python snippet against the project venv (e.g. ad-hoc DB inspection)
 just scrape             # Full scrape pipeline
 just analyze            # Run all analysis scripts
 just check-db           # Verify database contents
@@ -122,6 +123,12 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds (all support --dry-run)
+just backfill-nfl-stats [--seasons 2024 ...]        # Backfill nfl_stats from nflverse for the given seasons
+just backfill-draft-capital [--since 2010]          # Backfill draft_capital from nflverse draft_picks; pass --update-rosters post-draft
+just backfill-vegas [--since 2016]                  # Backfill team_vegas_lines (implied + Pythagorean) from nflverse games.csv
+just seed-win-totals --season 2026                  # Seed preseason win_total rows for an upcoming season (hand-curated)
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Preseason Vegas review: per-division implied team totals + win totals, grouped AFC/NFC, with deltas vs league average |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |
@@ -38,6 +39,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Server component that renders the live `is_active=TRUE` projection model's name, version, description, and features. Single source of truth used by `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` — do not hardcode model names in page copy |
 
 ### Column Factories (`components/columns.tsx`)
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -24,7 +24,7 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total + win total. `implied_total` is summed from nflverse per-game spread/total lines (nullable until the NFL schedule is released each spring); `win_total` is either sportsbook preseason consensus or Pythagorean back-calculation from the implied totals | `(team, season)` |
 
 ### Projection tables detail
 


### PR DESCRIPTION
## Summary

Daily audit of agent-facing harness docs. Catches them up to the 13 commits merged to `main` since the 2026-05-05 audit (#471), with special focus on the schema doc and the projection-model promotion workflow.

## Commits reviewed (since #471)

- #487 feat: project drafted rookies from draft capital
- #486 chore: gitignore .claude/plans and .claude/projects
- #485 chore: broaden Claude permission allowlist + add backfill recipes
- #484 chore: single source of truth for active projection model
- #482 feat: backfill 2026 NFL draft + project drafted rookies
- #481 feat: seed 2026 preseason win totals (implied_total nullable)
- #480 feat: vegas lines review page
- #479 feat: vegas implied team totals as projection feature (#378)
- #477 docs: refresh projection model eval for v22/v23/v25
- #476 feat: two-stage residual model for draft capital (v25)
- #475 feat: draft capital feature for rookie projections (#376)
- #473 feat: advanced receiving metrics from nflverse (#375)

## Changes

- **`AGENTS.md`** — Projection Model Update Requirements step 4 referenced a no-longer-existent `ACTIVE_MODEL` constant in `update_projections.py` and "hardcoded methodology descriptions" in `web/app/projections/page.tsx` / `web/app/arbitration/page.tsx`. After #484 the active model is sourced dynamically from `projection_models.is_active=TRUE` and the UI methodology block lives in `<ActiveModelCard>`. Rewrote the step to match.
- **`docs/generated/db-schema.md`** — Updated the `team_vegas_lines` row to note that `implied_total` is now nullable (migration 025) and that `win_total` can be either sportsbook preseason consensus (`seed_preseason_win_totals.py`) or Pythagorean back-calculation (`backfill_vegas_lines.py`). All other migrations (022, 023, 024) were already reflected.
- **`docs/FRONTEND.md`** — Added the `/vegas-lines` route (#480) and the `ActiveModelCard` component (#484), both missing from the tables.
- **`docs/COMMANDS.md`** — Added the new just recipes that landed without doc updates: `backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`, plus the previously-added `test-web-file` and `py` recipes that were also missing.
- **`docs/CODE_ORGANIZATION.md`** — Listed the new `web/lib/vegas-lines.ts` and `web/lib/nfl-divisions.ts` files alongside the other data-layer entries.

## Items flagged for human follow-up

None — all drift surfaced in this audit was scoped to doc edits.

## Test plan

- [ ] Doc-only change — no code or tests touched. CI `check-docs` should remain green.

https://claude.ai/code/session_01BsKEkFvtkAJbGvWGjmWyR1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsKEkFvtkAJbGvWGjmWyR1)_