### PR TITLE
docs: daily harness audit 2026-05-25

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **The active model is the single source of truth.** `update_projections.py` reads `projection_models.is_active` dynamically via `get_active_model_name()` — there is no `ACTIVE_MODEL` constant. The UI pages `web/app/projections/page.tsx`, `web/app/arbitration/page.tsx`, and `web/app/projection-accuracy/page.tsx` render the live model name, version, description, and feature list through `<ActiveModelCard />` (fed by `fetchActiveProjectionModel()` in `web/lib/data.ts`). Do not hardcode model names in UI copy — promote the new model and the UI updates itself.
 
 This ensures every projection change is empirically validated before merge.
 
@@ -119,7 +119,7 @@ The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year
 - **QB**: A starting QB already receives all offensive snaps. A high H2/H1 ratio simply means they took over mid-season, not that they'll be better next year.
 - **K**: Snap counts are irrelevant to kicker scoring.
 
-`v12_no_qb_trajectory` (current active model) disables the trajectory for QB and K via `WeightedPPGNoQBTrajectoryFeature`. Do not re-enable it for those positions.
+`WeightedPPGNoQBTrajectoryFeature` disables the trajectory for QB and K and is the base feature for all `v12+` internal models. Do not re-enable the trajectory for those positions in any new variant.
 
 ### Database migration workflow
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,6 +37,14 @@ Jobs support dependencies, retries (up to 3 attempts), and batch grouping. `otto
 - **`player_stats`** = Ottoneu fantasy data (total_points, ppg, pps, snaps from scraping)
 - **`nfl_stats`** = Real NFL stats (passing_yards, rushing_tds, snap counts, etc. from nflverse)
 
+### External Supporting Data (one-shot backfills)
+
+Outside the worker queue, three nflverse-sourced tables feed projection features. Each has a dedicated script and `just` recipe — they are not part of the daily scrape and are run manually when new seasons publish:
+
+- **`draft_capital`** ← `scripts/backfill_draft_capital.py` (`just backfill-draft-capital`). Pulls round + overall pick from nflverse `draft_picks`. Drives the `draft_capital_raw` feature and the `rookie_draft_capital` fallback for drafted rookies with no NFL history.
+- **`team_vegas_lines`** ← `scripts/backfill_vegas_lines.py` (`just backfill-vegas`). Aggregates per-game `spread_line` + `total_line` from nflverse `games.csv` into season-level implied team totals, plus a Pythagorean-derived `win_total`. Drives the `implied_team_total_raw` feature.
+- **`team_vegas_lines.win_total`** seeds ← `scripts/seed_preseason_win_totals.py` (`just seed-win-totals`). For the spring window between sportsbook win-total release (Mar/Apr) and NFL schedule release (mid-May), hand-curated win totals are seeded with `implied_total = NULL`. The projection feature returns `None` for NULL-implied rows and the learned combiner substitutes 0 — see migration 025 and the `/vegas-lines` review page for the operator UI.
+
 ### Worker Task Modules (`scripts/tasks/`)
 
 Each task type lives in its own module. `__init__.py` defines task type constants and `TaskResult` dataclass. The worker caches NFL stats in memory so roster scrapes can match snap counts by player name.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -122,6 +122,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds
+just backfill-nfl-stats [--seasons ...] [--dry-run]     # Backfill nfl_stats from nflverse
+just backfill-draft-capital [--since YYYY] [--dry-run]  # Backfill draft_capital from nflverse draft_picks
+just backfill-vegas [--since YYYY] [--dry-run]          # Backfill team_vegas_lines from nflverse games.csv
+just seed-win-totals [--season YYYY]                    # Seed hand-curated preseason win totals (spring window)
+
+# Ad-hoc DB queries
+just py "<snippet>"                                  # One-off read-only Python snippet against the project venv
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Per-team preseason Vegas implied totals + Pythagorean win totals (auth required) |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |


### PR DESCRIPTION
## Summary

Daily audit of harness docs (CLAUDE.md, AGENTS.md, docs/) against recent merges. The last audit ran on 2026-05-05 (#471); this catches 20 days of drift across 12 PRs that landed since (#473–#487).

## Commits Reviewed

| PR | Doc impact |
|----|----|
| #473 advanced receiving metrics | already in db-schema.md (mig 022) |
| #475 draft capital feature | new table + backfill — covered |
| #476 v25 two-stage residual | already in projection-accuracy-improvement.md |
| #477 refresh model eval | generated docs — current |
| #479 vegas implied team totals | new table + backfill — covered |
| #480 vegas lines review page | new `/vegas-lines` route — covered |
| #481 seed 2026 preseason win totals | new seed script + mig 025 — covered |
| #482 backfill 2026 NFL draft | uses #475 plumbing |
| #484 single source of truth for active model | killed `ACTIVE_MODEL` constant — was still cited in AGENTS.md |
| #485 broaden allowlist + backfill recipes | new just recipes not in COMMANDS.md |
| #486 gitignore .claude/plans | no doc impact |
| #487 project drafted rookies | uses #475 plumbing |

## Changes

- **`docs/FRONTEND.md`** — Added `/vegas-lines` to the routes table (omitted when #480 landed).
- **`AGENTS.md`** — Two stale references fixed:
  - Projection Model Update Requirements #4: replaced the "update UI methodology text when changing `ACTIVE_MODEL`" instruction (both the constant and the hardcoded copy were removed in #484) with a description of the dynamic `is_active` + `<ActiveModelCard />` mechanism.
  - Rookie snap trajectory note: de-version-pinned the example (`v12_no_qb_trajectory` was tagged "current active model" — long stale since active is now `v25_draft_capital_residual` per `update_projections.py` docstring, with `v27_vegas_full_refit` cited as best by the accuracy report).
- **`docs/COMMANDS.md`** — Added the four new `just` recipes from #485 (`backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`) and the `just py "<snippet>"` ad-hoc recipe.
- **`docs/ARCHITECTURE.md`** — New "External Supporting Data" subsection documenting `draft_capital`, `team_vegas_lines`, and the spring-window seed flow — these tables sit outside the worker queue and weren't surfaced anywhere in the data-pipeline narrative.

## Schema Doc (highest-priority check)

`docs/generated/db-schema.md` was already current through migration 025. All four new migrations (022 advanced receiving, 023 draft_capital, 024 team_vegas_lines, 025 nullable implied_total) are present. Table count of 19 verified by row-count.

## Flagged For Human Follow-up

None blocking. One soft observation: the `update_projections.py` module docstring still names `v25_draft_capital_residual` as the promote example, but the accuracy report (and exec plan) crowns `v27_vegas_full_refit`. Could be intentional (spring window where `implied_total` is null), but worth a glance.

## Test Plan

- [x] `git diff` reviewed — only doc files touched, four files, +20/-2 lines
- [x] Cross-referenced new just recipes against `Justfile` lines 138–164
- [x] Cross-referenced new ARCHITECTURE section against `scripts/backfill_draft_capital.py`, `scripts/backfill_vegas_lines.py`, `scripts/seed_preseason_win_totals.py` docstrings
- [x] Cross-referenced AGENTS.md fix against `scripts/update_projections.py:32` (`get_active_model_name`) and `web/lib/data.ts:390` (`fetchActiveProjectionModel`)

https://claude.ai/code/session_01WjVFHBM8K99ehUAPMbQSUu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjVFHBM8K99ehUAPMbQSUu)_