### PR TITLE
docs: daily harness audit 2026-05-26

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ Comprehensive database and analytics platform for Ottoneu Fantasy Football Leagu
 - **Git workflow:** See [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md) for branch and PR requirements
 - **Domain rules:** See [docs/references/ottoneu-rules.md](docs/references/ottoneu-rules.md) for scoring, roster, salary cap, and arbitration
 - **Environment:** See [docs/references/environment-variables.md](docs/references/environment-variables.md) for `.env` setup
-- **Market Projections:** See [docs/exec-plans/market-projections.md](docs/exec-plans/market-projections.md) for the market-based projection system implementation plan
+- **Projection Accuracy Plan:** See [docs/exec-plans/projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md) for the 4-phase accuracy improvement roadmap (Issues #271-#285)
+- **Market Projections:** See [docs/exec-plans/market-projections.md](docs/exec-plans/market-projections.md) for the market-based projection system implementation plan (DEFERRED)
 
 ## Documentation Map
 
@@ -37,7 +38,7 @@ docs/
 ├── TESTING.md                         # Python + web test setup and CI
 ├── exec-plans/
 │   ├── [feature-projections.md](docs/exec-plans/feature-projections.md)         # Feature-based player projection system
-│   ├── [market-projections.md](docs/exec-plans/market-projections.md)          # Market-based projection system implementation plan
+│   ├── [market-projections.md](docs/exec-plans/market-projections.md)          # Market-based projection system (DEFERRED)
 │   ├── [projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md)  # 4-phase accuracy improvement roadmap
 │   └── [qb-usage-share.md](docs/exec-plans/qb-usage-share.md)              # QB Usage Share findings and next steps
 ├── generated/
@@ -104,7 +105,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **Promote the new model to flip the live methodology copy.** The active model is the row in `projection_models` with `is_active=TRUE`, set by `scripts/feature_projections/promote.py <model_name>`. `update_projections.py` reads it dynamically via `get_active_model_name()`, and the web UI surfaces it through `fetchActiveProjectionModel()` + the `<ActiveModelCard>` component on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy`. Don't hardcode model names in UI copy — the card pulls name/version/description/features straight from the DB row.
 
 This ensures every projection change is empirically validated before merge.
 
@@ -119,7 +120,7 @@ The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year
 - **QB**: A starting QB already receives all offensive snaps. A high H2/H1 ratio simply means they took over mid-season, not that they'll be better next year.
 - **K**: Snap counts are irrelevant to kicker scoring.
 
-`v12_no_qb_trajectory` (current active model) disables the trajectory for QB and K via `WeightedPPGNoQBTrajectoryFeature`. Do not re-enable it for those positions.
+`v12_no_qb_trajectory` introduced `WeightedPPGNoQBTrajectoryFeature` to disable the H2/H1 trajectory for QB and K, and every successor model (v14 through v27) still uses that base feature. Do not re-enable the trajectory for those positions.
 
 ### Database migration workflow
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -122,6 +122,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills & seeds (variadic — pass --dry-run, --since, --seasons as needed)
+just backfill-nfl-stats [--seasons 2024 ...]        # nflverse → nfl_stats
+just backfill-draft-capital [--since 2010]          # nflverse draft_picks → draft_capital
+just backfill-vegas [--since 2016]                  # nflverse games.csv → team_vegas_lines
+just seed-win-totals [--season 2026]                # Sportsbook win totals → team_vegas_lines (implied_total stays NULL until schedule release)
+
+# Ad-hoc DB inspection
+just py "<python snippet>"                          # Run a one-off Python snippet against the project venv
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Per-team preseason Vegas implied team total + Pythagorean win total (reads `team_vegas_lines`) |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |
@@ -38,6 +39,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Server component that renders the live `is_active=TRUE` projection model's name/version/description/features. Single source of truth for "which model is the site serving" across `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` — reads via `fetchActiveProjectionModel()` in `web/lib/data.ts`. |
 
 ### Column Factories (`components/columns.tsx`)
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -24,7 +24,7 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` (sportsbook win totals can be seeded before the schedule release, so `implied_total` is nullable — migration 025) | `(team, season)` |
 
 ### Projection tables detail
 


### PR DESCRIPTION
## Summary

Daily audit covering the 3 weeks of merges since the last audit (#473–#487, since 2026-05-05). The repo gained draft-capital projections, Vegas implied team totals, a `/vegas-lines` review page, and most importantly switched from a hardcoded `ACTIVE_MODEL` constant to a dynamic `is_active=TRUE` lookup surfaced via `<ActiveModelCard>` — several harness docs hadn't caught up.

## Commits reviewed

| # | Title | Doc impact |
|---|---|---|
| #473 | Advanced receiving metrics from nflverse | already covered in db-schema (migration 022) |
| #475 | Draft capital feature for rookie projections | already covered in db-schema (migration 023) |
| #476 | Two-stage residual model for draft capital (v25) | no doc change |
| #477 | Refresh projection model eval for v22/v23/v25 | no doc change |
| #479 | Vegas implied team totals as projection feature | already covered in db-schema (migration 024) |
| #480 | Vegas lines review page | **`/vegas-lines` route missing from FRONTEND.md** |
| #481 | Seed 2026 preseason win totals (`implied_total` nullable) | **db-schema didn't note nullability (migration 025)** |
| #482 | Backfill 2026 NFL draft + project drafted rookies | no doc change |
| #484 | Single source of truth for active projection model | **`ACTIVE_MODEL` rule in AGENTS.md was stale; `<ActiveModelCard>` missing from FRONTEND.md** |
| #485 | Broaden Claude permission allowlist + add backfill recipes | **four new `just` recipes missing from COMMANDS.md** |
| #486 | Gitignore `.claude/plans` and `.claude/projects` | no doc change |
| #487 | Project drafted rookies from draft capital | no doc change (already in ARCHITECTURE.md's promotion section) |

## Changes made

- **AGENTS.md**: Rewrote the "Update UI methodology text" rule (`ACTIVE_MODEL` no longer exists — active model is now set via `promote.py` and rendered by `<ActiveModelCard>`). Dropped the "current active model" phrasing on the v12 rookie-trajectory note (v12 is the lineage, every successor through v27 still uses `WeightedPPGNoQBTrajectoryFeature`). Added the projection-accuracy plan to Quick Reference and tagged `market-projections.md` as DEFERRED to match CLAUDE.md.
- **docs/COMMANDS.md**: Listed the four new `just` recipes from #485 — `backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals` — plus `just py` for ad-hoc DB inspection.
- **docs/FRONTEND.md**: Added the `/vegas-lines` route (#480) and the `ActiveModelCard` reusable component (#484).
- **docs/generated/db-schema.md**: Noted that `team_vegas_lines.implied_total` is nullable per migration 025 so win totals can be seeded before the NFL schedule is released.

## Schema cross-check

Migrations 022–025 all reconciled against `docs/generated/db-schema.md`:
- 022 (advanced receiving cols) — already in `nfl_stats columns` section ✓
- 023 (`draft_capital` table) — already in table list ✓
- 024 (`team_vegas_lines` table) — already in table list ✓
- 025 (`implied_total` NULL) — **added in this PR**

Table count (19) is still accurate; 025 only relaxed a constraint.

## Items flagged for human follow-up

- `docs/generated/projection-accuracy.md` was last generated 2026-05-07 and is therefore current relative to today's model set (covers up through v27). No regeneration needed — but worth re-running `just accuracy-report --run-backtest` if any new model lands.
- `docs/superpowers/plans/2026-04-19-build-system-just.md` and `docs/superpowers/specs/2026-04-19-build-system-design.md` are flagged as orphans by `check_docs_freshness.py`. They're historical artifacts from the Make→Just migration; leaving in place but worth a human decision on whether to archive or link.
- `scripts/check_docs_freshness.py` is flagging false-positive "missing file" warnings on `data.ts`, `config.py`, `config.ts` references in CODE_ORGANIZATION.md — the checker matches bare filenames instead of the prefixed paths actually written in the doc (`web/lib/data.ts`, etc.). Not actionable here; consider tightening the checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015p7y9wwvhQ78VNshPH48Za)_