### PR TITLE
docs: daily harness audit 2026-05-27

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **Verify the model registry row is descriptive.** `projection_models.is_active=TRUE` is now the single source of truth for which model the web UI surfaces — `<ActiveModelCard>` (used by `/projections`, `/arbitration`, `/projection-accuracy`) reads `name`, `version`, `description`, and `features` straight from the row. Confirm those fields are accurate for the newly-promoted model so the UI methodology copy is correct without further code changes. (`update_projections.py` resolves the active model via `get_active_model_name()` rather than a hardcoded constant.)
 
 This ensures every projection change is empirically validated before merge.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -84,6 +84,12 @@ python scripts/feature_projections/feature_analysis.py --model v20_learned_usage
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025  # Residual distribution, heteroscedasticity, persistent errors
 python scripts/feature_projections/residual_analysis.py --model v20_learned_usage --seasons 2022,2023,2024,2025 --output docs/generated/residual-analysis.md  # Write markdown report
 
+# Backfills / Seeds
+python scripts/backfill_nfl_stats.py --seasons 2024                       # Backfill nfl_stats rows from nflverse for the given season(s); supports --dry-run
+python scripts/backfill_draft_capital.py --since 2010                     # Backfill draft_capital from nflverse draft_picks parquet
+python scripts/backfill_vegas_lines.py --since 2016                       # Backfill team_vegas_lines (per-team implied totals + win totals) from nflverse games.csv
+python scripts/seed_preseason_win_totals.py --season 2026                 # Seed preseason win totals for a season before the NFL schedule is released (implied_total stays null until backfill-vegas)
+
 # Utilities
 python scripts/check_db.py                           # Verify database contents
 streamlit run scripts/visualize_app.py               # Streamlit dashboard
@@ -122,6 +128,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds
+just backfill-nfl-stats [--seasons 2024 ...]        # Backfill nfl_stats from nflverse
+just backfill-draft-capital [--since 2010 ...]      # Backfill draft_capital from nflverse draft_picks
+just backfill-vegas [--since 2016 ...]              # Backfill team_vegas_lines (implied totals + win totals) from nflverse games.csv
+just seed-win-totals [--season 2026]                # Seed preseason win_total before schedule release (implied_total left null)
+
+# Ad-hoc DB queries
+just py "<snippet>"                                  # Run a one-off Python snippet against the project venv (read-only diagnostics)
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -22,6 +22,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/arbitration` | Arbitration targets with per-opponent breakdown |
 | `/arbitration-simulation` | Monte Carlo arbitration simulation |
 | `/arbitration-planner` | Plan and save arbitration budget allocations (auth required) |
+| `/vegas-lines` | Per-team Vegas implied totals and win totals review page (auth required) |
 | `/login` | Email/password login |
 | `/admin` | User management (admin only) |
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -17,14 +17,14 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_plans` | Named arbitration budget allocation plans per user (FK -> `users`) | `(league_id, name, user_id)` |
 | `arbitration_plan_allocations` | Per-player dollar allocations within a plan (FK -> `arbitration_plans`, `players`) | `(plan_id, player_id)` |
 | `scraper_jobs` | Persistent job queue with status tracking, dependencies, and retry logic | -- |
-| `projection_models` | Registry of versioned projection models (internal feature-based v1–v21+ and external sources) | `(name, version)` |
+| `projection_models` | Registry of versioned projection models (internal feature-based v1–v27+ and external sources) | `(name, version)` |
 | `model_projections` | Per-model projected PPG with raw feature values (FK -> `projection_models`, `players`) | `(model_id, player_id, season)` |
 | `backtest_results` | Cached accuracy metrics per model × season × position (FK -> `projection_models`) | `(model_id, season, position)` |
 | `arbitration_progress` | Scraped player allocation data from Ottoneu arbitration page | -- |
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv`. `implied_total` is nullable (migration 025) — preseason win totals publish months before the NFL schedule + per-game lines become available | `(team, season)` |
 
 ### Projection tables detail
 


### PR DESCRIPTION
## Summary

Daily harness-doc audit. No commits landed in the last 25 hours, so this is a sweep against the burst of work that merged 2026-05-05 → 2026-05-07 (PRs #473–#487) which the previous audit (#471, dated 2026-05-05) didn't yet have visibility into. Several harness docs still reflected the pre-burst state.

### Commits reviewed

| PR | Title | Doc impact |
|----|-------|------------|
| #473 | feat: advanced receiving metrics from nflverse | schema (migration 022 — already documented) |
| #475 | feat: draft capital feature for rookie projections | schema (migration 023 — already documented) |
| #476 | feat: two-stage residual model for draft capital (v25) | model versions (`v1–v21+` → `v1–v27+`) |
| #477 | docs: refresh projection model eval for v22/v23/v25 | (generated only) |
| #479 | feat: vegas implied team totals as projection feature | schema (migration 024) |
| #480 | feat: vegas lines review page | new `/vegas-lines` route + middleware-protected |
| #481 | feat: seed 2026 preseason win totals (implied_total nullable) | migration 025 — schema doc didn't capture the nullable relaxation |
| #482 | feat: backfill 2026 NFL draft + project drafted rookies | `backfill_draft_capital` script |
| #484 | chore: single source of truth for active projection model | retired hardcoded UI methodology text in favor of `<ActiveModelCard>` |
| #485 | chore: broaden Claude permission allowlist + add backfill recipes | new `just backfill-*` / `just seed-win-totals` / `just py` recipes |
| #486 | chore: gitignore `.claude/plans` and `.claude/projects` | (no harness-doc impact) |
| #487 | feat: project drafted rookies from draft capital | (covered by ARCHITECTURE.md update in same PR) |

### Changes made

- `docs/generated/db-schema.md` — projection model range bumped to `v1–v27+`; noted `team_vegas_lines.implied_total` is now nullable (migration 025) with rationale (preseason win totals publish before the NFL schedule).
- `docs/FRONTEND.md` — added the `/vegas-lines` route to the routes table (auth-required via `web/middleware.ts`).
- `docs/COMMANDS.md` — documented the four new backfill/seed scripts (`backfill_nfl_stats.py`, `backfill_draft_capital.py`, `backfill_vegas_lines.py`, `seed_preseason_win_totals.py`) and their `just` wrappers, plus the `just py "<snippet>"` ad-hoc DB query escape hatch.
- `AGENTS.md` — replaced step 4 of *Projection Model Update Requirements*. The previous wording told agents to update hardcoded methodology copy on `/projections` and `/arbitration`; that copy is now rendered dynamically from `projection_models.is_active` via `<ActiveModelCard>` (PR #484), so the new requirement is to verify the model registry row's `description` / `features` are accurate.

### Schema doc cross-check

- Migrations through 025 reviewed against `docs/generated/db-schema.md`. Tables added since the last audit (`draft_capital` #023, `team_vegas_lines` #024) were already in the table list; advanced receiving columns (#022) were already in the `nfl_stats columns` section. Only drift was the version-range string and the nullable relaxation noted above.

### Flagged for human follow-up

- `scripts/check_docs_freshness.py` reports two pre-existing orphan files under `docs/superpowers/` that aren't linked from AGENTS.md / CLAUDE.md, and a false-positive `CODE_ORGANIZATION.md paths` warning (the checker is matching bare basenames like `data.ts` rather than the path-prefixed mentions in the table). Both are out of scope for this audit but worth tracking — could be cleaned up in a follow-up.
- `docs/exec-plans/feature-projections.md` still references "v1–v6 + external" in a couple of places. The exec plan is historical context for the original buildout, so I left it alone — flagging in case you'd prefer it updated.

## Test plan

- [x] `python3 scripts/check_docs_freshness.py` — no new warnings introduced; AGENTS.md / CLAUDE.md link targets all resolve.
- [x] Spot-checked each new route/recipe/script against the repo (`web/middleware.ts`, `Justfile`, `scripts/backfill_*.py`, `scripts/seed_preseason_win_totals.py`).
- [x] Verified migration 025 contents match the new schema-doc note.

https://claude.ai/code/session_01YQgQG4FxSL7LECXLu8AcvA

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQgQG4FxSL7LECXLu8AcvA)_