### PR TITLE
docs: daily harness audit 2026-05-28

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **Promote the new active model via `promote.py`, not by editing code.** `update_projections.py` reads the active model dynamically from `projection_models.is_active` — there is no `ACTIVE_MODEL` constant to change. Web UI pages (`/projections`, `/arbitration` projected mode, `/projection-accuracy`) render methodology copy from the active model's row via the `<ActiveModelCard>` component (`web/components/ActiveModelCard.tsx`), so no hardcoded copy needs editing either. Make sure the new model row has an accurate `description` and `features` list before promoting.
 
 This ensures every projection change is empirically validated before merge.
 
@@ -119,7 +119,7 @@ The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year
 - **QB**: A starting QB already receives all offensive snaps. A high H2/H1 ratio simply means they took over mid-season, not that they'll be better next year.
 - **K**: Snap counts are irrelevant to kicker scoring.
 
-`v12_no_qb_trajectory` (current active model) disables the trajectory for QB and K via `WeightedPPGNoQBTrajectoryFeature`. Do not re-enable it for those positions.
+`WeightedPPGNoQBTrajectoryFeature` disables the trajectory for QB and K. All `weighted_ppg`-based models from `v12_no_qb_trajectory` onward use it. Do not re-enable the trajectory for those positions in any new variant. (The currently-promoted model is whichever row has `is_active=TRUE` in `projection_models`; don't hardcode that name in docs.)
 
 ### Database migration workflow
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -64,6 +64,12 @@ python scripts/feature_projections/cli.py segment-analysis --segments experience
 python scripts/feature_projections/cli.py segment-analysis --models v8_age_regression --seasons 2024,2025  # Custom models/seasons
 python scripts/feature_projections/promote.py <model_name>                                             # Promote a model to production (clears stale rows + upserts new + flips is_active)
 
+# Backfills / seeds
+python scripts/backfill_nfl_stats.py --seasons 2024                                                      # Backfill nflverse NFL stats (one or more seasons; --dry-run supported)
+python scripts/backfill_draft_capital.py --since 2010                                                    # Backfill draft pick metadata from nflverse (--update-rosters flips matched college players, inserts new picks)
+python scripts/backfill_vegas_lines.py --since 2016                                                      # Backfill team_vegas_lines from nflverse games.csv
+python scripts/seed_preseason_win_totals.py --season 2026                                                # Upsert hand-curated preseason win_total values (used before the schedule releases implied_total inputs)
+
 # Projection Development Workflow (two-step process)
 # Step 1: Generate projections for the model (required after any feature code change)
 python scripts/feature_projections/cli.py run --model <name> --seasons 2022,2023,2024,2025
@@ -96,7 +102,7 @@ Install `just` once with `brew install just`, then run any recipe from the repo 
 
 ```bash
 just                    # List all recipes
-just install            # Install all dependencies (Python + Node)
+just install            # Install all dependencies (Python + Node + Playwright chromium)
 just dev                # Start Next.js dev server on localhost:3000
 just build              # Production build
 just lint               # ESLint
@@ -122,6 +128,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds
+just backfill-nfl-stats [--seasons ...]             # Backfill nflverse NFL stats
+just backfill-draft-capital [--since YYYY]          # Backfill draft pick metadata from nflverse
+just backfill-vegas [--since YYYY]                  # Backfill team_vegas_lines from nflverse games.csv
+just seed-win-totals [--season YYYY]                # Upsert hand-curated preseason win_total values
+
+# Ad-hoc DB queries
+just py "<python snippet>"                          # Run a one-off Python snippet against the project venv (read-only diagnostics)
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |
 | `/projections` | Player projections table (reads `player_projections`) |
 | `/projection-accuracy` | Model backtest accuracy explorer |
+| `/vegas-lines` | Preseason Vegas implied team totals + Pythagorean win totals, season selector + AFC/NFC division cards |
 | `/vorp` | VORP analysis with bar chart and filterable table |
 | `/surplus-value` | Surplus value rankings, bargains, overpaid, team summaries |
 | `/surplus-adjustments` | Per-user manual value overrides (auth required) |
@@ -38,6 +39,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `PlayerName` | Player name renderer with link/hover-card/plain-text modes |
 | `StatValue` | Numeric stat formatter with currency/decimal/number/null handling |
 | `PlayerHoverCard` | Rich hover preview card for player context |
+| `ActiveModelCard` | Reads the live `is_active` row from `projection_models` via `fetchActiveProjectionModel()` and renders the active model's name/version/description/feature list. Used on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` so methodology copy never drifts from the promoted model. |
 
 ### Column Factories (`components/columns.tsx`)
 


### PR DESCRIPTION
## Summary

Daily harness-doc audit. No commits in the last 25 hours (most recent merge on `main` is 1e5dcde from 2026-05-07), so this is a lighter sweep covering everything merged since the previous audit (#471, 2026-05-05) — PRs #473 through #487. Three real drift items surfaced:

### Changes

- **AGENTS.md**
  - Projection-update checklist item 4 told agents to "Update UI methodology text when changing `ACTIVE_MODEL` in `update_projections.py`." That constant was removed in #484 (single source of truth for active projection model) — the active model is now read from `projection_models.is_active`, and methodology copy is rendered by `<ActiveModelCard>` rather than hardcoded in each page. Rewrote the item to reflect the new flow.
  - "Rookie snap trajectory" section called `v12_no_qb_trajectory` "(current active model)". That hasn't been true since v22/v25/v27 shipped. Rephrased around the `WeightedPPGNoQBTrajectoryFeature` class so the rule survives future promotions.
- **docs/COMMANDS.md**
  - Added the four backfill/seed `just` recipes introduced in #485 (`backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`) plus the new `just py "<snippet>"` ad-hoc helper. These were already listed in CLAUDE.md's Critical Rules but missing from the canonical command reference.
  - Added the matching raw `scripts/backfill_*.py` / `scripts/seed_preseason_win_totals.py` commands under the backend section.
  - Noted that `just install` now also runs `playwright install chromium`.
- **docs/FRONTEND.md**
  - Added the `/vegas-lines` route (#480).
  - Added the `ActiveModelCard` reusable component (#484).

### Items checked, no change needed

- **docs/generated/db-schema.md** — `draft_capital`, `team_vegas_lines`, and the advanced-receiving `nfl_stats` columns from migrations 022–024 were already documented (added in the 2026-05-05 audit and in #479 itself). Migration 025 (nullable `implied_total`) doesn't change the table list. Table count still says "Nineteen tables", which matches.
- **docs/ARCHITECTURE.md** — already refreshed by #484 and #487 for the dynamic-active-model flow and rookie-fallback split (`rookie_draft_capital` vs `college_prospect`).
- **docs/exec-plans/projection-accuracy-improvement.md** — refreshed by #477/#479 with the v22/v23/v25/v27 numbers.
- **.claude/commands/*.md** — all 13 referenced skills exist. They still use raw `source venv/bin/activate && python ...` invocations rather than `just <recipe>`, which is mild drift vs. AGENTS.md's "Always use `just <recipe>`" rule but is a larger refactor; flagging here for human follow-up rather than rewriting them.

### Items flagged for human follow-up

- Skills under `.claude/commands/` (`run-tests.md`, `run-scraper.md`, `run-analyses.md`, `projection-accuracy.md`) reach for `source venv/bin/activate && python ...` while AGENTS.md's Critical Rules now mandate `just <recipe>`. Consider a follow-up to convert them so the agent's allowlist surface keeps shrinking.
- `Justfile` recipe examples reference `v23_baseline` / `v24_learned_elite`, which are not in current `model_config.py`. Harmless (they're just illustrative placeholders) but easy to refresh to currently-defined models if desired.

## Test plan

- [x] `git diff` reviewed
- [x] Referenced paths (`web/components/ActiveModelCard.tsx`, `scripts/backfill_*.py`, `scripts/seed_preseason_win_totals.py`, all `Justfile` recipes) confirmed to exist
- [ ] (No code touched — no automated tests apply)

https://claude.ai/code/session_01EbTA7bBoiPDQXJwHXvP3Jv

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbTA7bBoiPDQXJwHXvP3Jv)_