### PR TITLE
docs: daily harness audit 2026-05-29

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    - The task output / conversation summary
    - The PR description body under a `## Projection Accuracy` section
 3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Update UI methodology text** when changing `ACTIVE_MODEL` in `update_projections.py`. The pages `web/app/projections/page.tsx` and `web/app/arbitration/page.tsx` contain hardcoded methodology descriptions that must reflect the active model's feature set.
+4. **Promote via `just promote <model>` (or `cli.py promote --model <name>`)** to switch which model the web app serves — `update_projections.py` now reads `projection_models.is_active` dynamically (no more hardcoded `ACTIVE_MODEL` constant). Methodology copy on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` is rendered live by `<ActiveModelCard>` (`web/components/ActiveModelCard.tsx`) from `fetchActiveProjectionModel()`, so do **not** hardcode model names or feature lists in page copy.
 
 This ensures every projection change is empirically validated before merge.
 
@@ -119,7 +119,7 @@ The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year
 - **QB**: A starting QB already receives all offensive snaps. A high H2/H1 ratio simply means they took over mid-season, not that they'll be better next year.
 - **K**: Snap counts are irrelevant to kicker scoring.
 
-`v12_no_qb_trajectory` (current active model) disables the trajectory for QB and K via `WeightedPPGNoQBTrajectoryFeature`. Do not re-enable it for those positions.
+`v12_no_qb_trajectory` and every model that inherits its base feature (e.g. `WeightedPPGNoQBTrajectoryFeature`) disable the trajectory for QB and K. Do not re-enable it for those positions in new models.
 
 ### Database migration workflow
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -122,6 +122,15 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+
+# Backfills / seeds
+just backfill-nfl-stats [--seasons ...] [--dry-run]    # Backfill nfl_stats from nflverse
+just backfill-draft-capital [--since YYYY] [--dry-run] # Backfill draft_capital from nflverse draft_picks
+just backfill-vegas [--since YYYY] [--dry-run]         # Backfill team_vegas_lines from nflverse games.csv
+just seed-win-totals --season YYYY                     # Upsert preseason sportsbook win totals (implied_total left NULL until schedule drops)
+
+# Ad-hoc DB queries
+just py "<python-snippet>"                          # Run a one-off Python snippet against the project venv (read-only diagnostics)
 ```
 
 ## Daily Scheduling (cron)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -22,6 +22,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/arbitration` | Arbitration targets with per-opponent breakdown |
 | `/arbitration-simulation` | Monte Carlo arbitration simulation |
 | `/arbitration-planner` | Plan and save arbitration budget allocations (auth required) |
+| `/vegas-lines` | Preseason Vegas implied team totals review (AFC/NFC division cards, season selector) — spot-check the data feeding the `implied_team_total_raw` projection feature |
 | `/login` | Email/password login |
 | `/admin` | User management (admin only) |
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -24,7 +24,7 @@ Nineteen tables, all with UUID primary keys.
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
-| `team_vegas_lines` | Per-team-season Vegas implied total + Pythagorean win total, aggregated from nflverse `games.csv` | `(team, season)` |
+| `team_vegas_lines` | Per-team-season Vegas implied total + win total. `implied_total` is aggregated per-game from nflverse `games.csv` and is **nullable** (migration 025) — preseason win totals publish months before the NFL schedule, so the column stays NULL until per-game lines are available. `win_total` is Pythagorean (back-calculated from per-game implied totals) for past seasons, or the sportsbook preseason consensus seeded via `scripts/seed_preseason_win_totals.py` for upcoming seasons. | `(team, season)` |
 
 ### Projection tables detail
 


### PR DESCRIPTION
## Summary

Daily harness-doc audit. The 25-hour window had zero new commits on `main` (latest merge is 2026-05-07 #487), so this is a lighter sweep against the still-unreconciled tail of the 2026-05-06/07 burst (#476–#487).

## Commits reviewed (drift sources)

- **#481 / migration 025** — `team_vegas_lines.implied_total` was relaxed to NULL.
- **#480** — new `/vegas-lines` review page.
- **#484** — `update_projections.py` no longer has an `ACTIVE_MODEL` constant; UI methodology copy is now rendered live by `<ActiveModelCard>` from `fetchActiveProjectionModel()`.
- **#485** — Justfile gained `backfill-nfl-stats`, `backfill-draft-capital`, `backfill-vegas`, `seed-win-totals`, and `py` recipes.

## Changes made

- `docs/generated/db-schema.md` — flag `team_vegas_lines.implied_total` as nullable and document the dual-source `win_total` (Pythagorean from `games.csv` for past seasons vs preseason sportsbook seed for upcoming seasons).
- `docs/FRONTEND.md` — add the `/vegas-lines` route to the route table.
- `docs/COMMANDS.md` — list the four new backfill/seed `just` recipes and `just py`.
- `AGENTS.md` — replace the stale `ACTIVE_MODEL` / hardcoded-methodology-copy guidance with the live `is_active` + `<ActiveModelCard>` workflow, and drop the rotting "(current active model)" parenthetical on `v12_no_qb_trajectory`.

## Items flagged for human follow-up

- `schema.sql` does not include `draft_capital` (migration 023) or `team_vegas_lines` (024/025). It is auto-generated via Supabase MCP, so regenerating it is a one-shot operator action — not a doc edit.
- `scripts/check_docs_freshness.py` warns about three pre-existing issues unrelated to this audit: it can't resolve the bare-basename references (`data.ts`, `config.py`, `config.ts`) in `docs/CODE_ORGANIZATION.md`, and two orphan files in `docs/superpowers/` are not linked from `AGENTS.md`/`CLAUDE.md`. Worth addressing in a future sweep — out of scope for today.

## Test plan

- [x] `python scripts/check_docs_freshness.py` — no new warnings introduced (5 pre-existing).
- [x] Cross-checked every new recipe against `Justfile`.
- [x] Confirmed `/vegas-lines` exists in `web/app/`.
- [x] Confirmed migration 025 drops `NOT NULL` on `team_vegas_lines.implied_total`.
- [x] Confirmed `update_projections.py` reads `is_active` (no `ACTIVE_MODEL` constant).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDXC95bz3NNq4FPqvrUMCc)_