### PR TITLE
docs: note shared Supabase DB with fantasy-pulse, mark fp_* tables off-limits

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -93,7 +93,8 @@
       "mcp__github__get_pull_request_status",
       "Read(//private/tmp/**)",
       "Read(//Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/bin/**)",
-      "Skill(update-config)"
+      "Skill(update-config)",
+      "mcp__supabase__list_tables"
     ]
   },
   "enabledMcpjsonServers": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ Run `just check-arch` to validate these rules locally.
 ## Critical Rules
 
 - **Always use `just <recipe>`** instead of invoking Python, pytest, or npm scripts directly. This ensures the correct venv and flags are used, and keeps the agent allowlist minimal. Run `just --list` to see all available recipes.
+- **Do not touch `fp_*` tables.** The Supabase project is shared with the `fantasy-pulse` app. Tables whose names start with `fp_` (currently `fp_notes`, `fp_user_integrations`, `fp_leagues`, `fp_teams`, but the prefix is the rule, not the list) are owned by that other codebase. Do not read from, write to, alter, drop, or migrate them from this repo. They will appear in `list_tables` output and in regenerated Supabase TS types — ignore them. See [docs/generated/db-schema.md](docs/generated/db-schema.md#shared-database--hands-off-fp_).
 - **Update documentation:** Always try to update the agent documentation after completing a task. Update existing documents or add new documents and sections as needed to reflect architectural or contextual changes.
 - **Never commit directly to `main`.** All changes go through pull requests.
 - **Always create a PR.** Every task must end with `gh pr create --fill`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Note: The local directory is `ottoneu_db` (underscore) but the GitHub repo name 
 ## Critical Rules
 
 - **Prefer `just <recipe>` over raw commands.** Run `just --list` to see available recipes. Common ones: `just typecheck`, `just lint`, `just test-web`, `just test-python`, `just train MODEL`, `just project MODEL`, `just backtest MODEL`, `just promote MODEL`, `just accuracy-report`, `just diagnostics`, `just segment-analysis`, `just backfill-nfl-stats`, `just backfill-draft-capital`, `just backfill-vegas`, `just seed-win-totals`. For ad-hoc DB inspection use `just py "<snippet>"`.
+- **Do not touch `fp_*` tables.** The Supabase project is shared with the `fantasy-pulse` app. Tables whose names start with `fp_` (currently `fp_notes`, `fp_user_integrations`, `fp_leagues`, `fp_teams`, but the prefix is the rule, not the list) are owned by that other codebase. Do not read from, write to, alter, drop, or migrate them from this repo. They will appear in `list_tables` output and in regenerated Supabase TS types — ignore them. See [docs/generated/db-schema.md](docs/generated/db-schema.md#shared-database--hands-off-fp_).
 - **Update documentation:** Always try to update the agent documentation after completing a task. Update existing documents or add new documents and sections as needed to reflect architectural or contextual changes.
 - **Never commit directly to `main`.** All changes go through pull requests.
 - **Always create a PR.** Every task must end with `gh pr create --fill`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ Python Scripts (scripts/)
 
 - **Frontend:** Next.js 16, React 19, TypeScript, Tailwind CSS 4, Recharts
 - **Backend:** Python 3.9+, Playwright (scraping), pandas, nfl_data_py
-- **Database:** Supabase (PostgreSQL)
+- **Database:** Supabase (PostgreSQL) — **shared with the `fantasy-pulse` app.** Tables prefixed `fp_` are owned by fantasy-pulse and must not be touched by this project. See [docs/generated/db-schema.md](generated/db-schema.md#shared-database--hands-off-fp_) for the full rule.
 - **Environment:** `.env` (root, for Python) and `web/.env.local` (for Next.js) hold Supabase credentials
 
 ## Data Pipeline

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -1,6 +1,18 @@
 # Database Schema
 
-Nineteen tables, all with UUID primary keys.
+Nineteen tables owned by this project, all with UUID primary keys.
+
+## Shared Database — Hands Off `fp_*`
+
+The Supabase project (`OttoneuDB`, ref `rbinbcwinchphipvcfqk`) is **shared with a separate app, `fantasy-pulse`**, as of 2026-05. Any table whose name starts with `fp_` belongs to fantasy-pulse and is owned by that codebase, not this one.
+
+**Rules:**
+- **Do not read, write, alter, drop, or migrate any `fp_*` table** from this project's scripts, web app, or migrations.
+- Do not include `fp_*` tables in TypeScript type generation outputs intended for this repo unless you explicitly strip them — they will appear in `mcp__supabase__list_tables` output and in regenerated `web/types/supabase.ts`. Leave them alone, but be aware they show up.
+- New migrations in `migrations/` must only touch ottoneu tables. Never write a migration that modifies an `fp_*` table.
+- When listing tables for any purpose (analysis, debugging, schema docs), filter `fp_*` out.
+
+**Current fantasy-pulse tables (informational, do not modify):** `fp_notes`, `fp_user_integrations`, `fp_leagues`, `fp_teams`. This list may grow — anything matching `fp_*` belongs to fantasy-pulse.
 
 ## Tables
 


### PR DESCRIPTION
## Summary
- Document that the Supabase project is now shared with the `fantasy-pulse` app and that any `fp_*` table belongs to that codebase
- Add a hands-off-`fp_*` rule to AGENTS.md and CLAUDE.md Critical Rules so future agent sessions don't accidentally read/write/migrate those tables
- New "Shared Database — Hands Off `fp_*`" section in `docs/generated/db-schema.md` listing current fp_ tables (`fp_notes`, `fp_user_integrations`, `fp_leagues`, `fp_teams`)
- Tech-stack line in `docs/ARCHITECTURE.md` now links to the rule
- Adds `mcp__supabase__list_tables` to the local allowlist (used to enumerate the fp_ tables)

## Test plan
- [ ] Confirm the new section in `docs/generated/db-schema.md` reads correctly and the anchor link from `ARCHITECTURE.md` resolves
- [ ] Spot-check that no code changes were made — docs + settings only

🤖 Generated with [Claude Code](https://claude.com/claude-code)