### PR TITLE
security: enable RLS on draft_capital and team_vegas_lines

### DIFF
--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -71,6 +71,16 @@ Advanced receiving (added in migration 022, populated for 2018+ via nflverse `st
 - **Migrations:** `migrations/` (numbered SQL migration files)
 - **Job queue:** `migrations/002_add_scraper_jobs.sql` defines the `scraper_jobs` table for the persistent job queue
 
+## Row-Level Security
+
+All public tables have RLS enabled. Server-side code uses the Supabase **service key** (Python via `scripts.config.get_supabase_client()`, Next.js writes via `web/lib/supabase.supabaseAdmin`) which bypasses RLS. The anon key is restricted to read-only access on a curated set of public reference data.
+
+**Tables with an anon SELECT policy** (web reads via the anon client): `players`, `player_stats`, `nfl_stats`, `league_prices`, `transactions`, `surplus_adjustments`, `player_projections`, `projection_models`, `model_projections`, `backtest_results`, `arbitration_progress`, `arbitration_progress_teams`, `arbitration_allocation_details`, `team_vegas_lines`.
+
+**Tables with no anon policy** (server-only, anon fully blocked): `users`, `arbitration_plans`, `arbitration_plan_allocations`, `scraper_jobs`, `draft_capital`.
+
+When adding a new table, decide upfront: does the web frontend read from it via the anon `supabase` client (see `web/lib/supabase.ts`)? If yes, the migration must `ENABLE ROW LEVEL SECURITY` *and* add a `FOR SELECT TO anon USING (true)` policy. If no, just enable RLS — server writes via the service key still work, and anon is locked out. The Supabase advisor (`mcp__supabase__get_advisors --type security`) will flag `rls_disabled_in_public` as a critical ERROR if either step is skipped. See migrations 015 and 026 for the canonical pattern.
+
 ## Key Relationships
 
 - `player_stats.player_id` -> `players.id`

--- a/migrations/026_enable_rls_draft_capital_vegas_lines.sql
+++ b/migrations/026_enable_rls_draft_capital_vegas_lines.sql
@@ -1,0 +1,21 @@
+-- Migration 026: Enable RLS on draft_capital and team_vegas_lines.
+--
+-- Fixes the critical Supabase advisor `rls_disabled_in_public` for both
+-- tables. Without RLS, anyone with the anon key can read or modify every
+-- row via PostgREST. Server-side code (Python scripts via
+-- `scripts/config.get_supabase_client()` and Next.js server routes via
+-- `web/lib/supabase.supabaseAdmin`) uses the service key, which bypasses
+-- RLS, so writes are unaffected.
+--
+-- Reads:
+--   * team_vegas_lines is read by the web frontend via the anon
+--     Supabase client (web/lib/vegas-lines.ts), so it needs a public
+--     SELECT policy.
+--   * draft_capital is not read from the web. Only Python uses it (via
+--     the service key), so no anon policy is needed.
+
+ALTER TABLE public.draft_capital ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.team_vegas_lines ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Enable read access for all users" ON public.team_vegas_lines
+  FOR SELECT TO anon USING (true);


### PR DESCRIPTION
## Summary
- Fixes the critical Supabase advisor `rls_disabled_in_public` for `draft_capital` and `team_vegas_lines`, which were fully exposed to the anon role via PostgREST
- `draft_capital`: RLS enabled, no anon policy — web doesn't read it; Python writes use the service key (which bypasses RLS)
- `team_vegas_lines`: RLS enabled plus a `FOR SELECT TO anon USING (true)` policy so `web/lib/vegas-lines.ts` (anon client) keeps working
- Documents the project-wide RLS posture in `docs/generated/db-schema.md` so future tables follow the same pattern

**Already applied to the live DB** via `mcp__supabase__apply_migration`. Both ERROR-level `rls_disabled_in_public` advisories now clear. Pre-existing INFO/WARN advisors are unrelated and out of scope.

## Test plan
- [ ] Hit `/vegas-lines` in the web app and confirm the page still loads (validates the anon SELECT policy on `team_vegas_lines`)
- [ ] Re-run any Python script that writes to `draft_capital` or `team_vegas_lines` (e.g. `just backfill-draft-capital`, `just backfill-vegas`) and confirm writes still succeed (validates the service key still bypasses RLS)
- [ ] Re-run `mcp__supabase__get_advisors --type security` and confirm no ERROR-level `rls_disabled_in_public` rows remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)