### PR TITLE
refactor: call projection pipeline in-process instead of subprocesses

### DIFF
--- a/scripts/update_projections.py
+++ b/scripts/update_projections.py
@@ -13,19 +13,24 @@ To switch which model the website serves, promote a different model:
 from __future__ import annotations
 
 import os
-import subprocess
 import sys
 import pandas as pd
 
-# Setup paths
+# Setup paths: scripts/ resolves `config`/`analysis_utils`/`projection_methods`;
+# repo_root resolves the `scripts.feature_projections.*` namespace those modules
+# import internally.
 script_dir = os.path.dirname(os.path.abspath(__file__))
+repo_root = os.path.dirname(script_dir)
 if script_dir not in sys.path:
     sys.path.append(script_dir)
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
 from config import get_supabase_client, MIN_GAMES
 from analysis_utils import fetch_multi_season_stats
 from projection_methods import CollegeProspectPPG, RookieDraftCapitalPPG
+from scripts.feature_projections.runner import run_model
+from scripts.feature_projections.promote import promote_model
 
-cli_path = os.path.join(script_dir, "feature_projections", "cli.py")
 TARGET_SEASONS = [2024, 2025, 2026]
 
 
@@ -236,25 +241,20 @@ def update_projections() -> None:
     """Calculate projections and upsert them into the database."""
     active_model = get_active_model_name()
     print(f"Generating projections across seasons {TARGET_SEASONS} using model '{active_model}'...")
-    try:
-        # 1. Run the active model for the target seasons.
-        subprocess.run(
-            [sys.executable, cli_path, "run", "--model", active_model, "--seasons", ",".join(map(str, TARGET_SEASONS))],
-            check=True
-        )
-        # 2. Promote into player_projections.
-        subprocess.run(
-            [sys.executable, cli_path, "promote", "--model", active_model],
-            check=True
-        )
-        # 3. Rookie/college fallback — feature_projections only emits rows for
-        # players with NFL stats history, so 0-history players are layered on top.
-        upsert_college_projections()
 
-        print("Successfully updated player projections.")
-    except subprocess.CalledProcessError as e:
-        print(f"ERROR: Failed to update projections: {e}")
-        sys.exit(1)
+    # 1. Run the active model for the target seasons.
+    run_count = run_model(active_model, TARGET_SEASONS)
+    print(f"Generated {run_count} model projections.")
+
+    # 2. Promote into player_projections.
+    promoted = promote_model(active_model)
+    print(f"Promoted {promoted} projections into player_projections.")
+
+    # 3. Rookie/college fallback — feature_projections only emits rows for
+    # players with NFL stats history, so 0-history players are layered on top.
+    upsert_college_projections()
+
+    print("Successfully updated player projections.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

`scripts/update_projections.py` drove the production projection pipeline by **shelling out to `feature_projections/cli.py`** twice (`run` then `promote`) via `subprocess.run([sys.executable, cli_path, ...])`. That approach:

- discarded tracebacks (only saw `CalledProcessError`),
- couldn't be unit-tested,
- paid interpreter-startup cost on every invocation.

The CLI subcommands already delegate to clean importable functions, so no extraction was needed:
- `cli.py cmd_run` → `runner.run_model(model_name, seasons)` → `int`
- `cli.py cmd_promote` → `promote.promote_model(model_name)` → `int`

This PR makes `update_projections()` call those functions directly, letting real exceptions propagate. `cli.py` remains a thin argparse wrapper over the same functions.

## Changes

- Replace the two `subprocess.run(...)` calls + `try/except CalledProcessError` with direct `run_model(...)` / `promote_model(...)` calls.
- Add `repo_root` to `sys.path` so the `scripts.feature_projections.*` namespace those modules import internally resolves (previously only `scripts/` was on the path).
- Drop the now-unused `subprocess` import and `cli_path`.

Behavior and ordering are preserved: run active model for `TARGET_SEASONS` → promote into `player_projections` → `upsert_college_projections()` rookie/college fallback.

## Testing

`pytest scripts/tests` → **792 passed, 25 skipped**. Import smoke-test confirms the module loads and no longer references `subprocess`. Did not run a live projection update against production data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)