### PR TITLE
docs: daily harness audit 2026-05-30

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Comprehensive database and analytics platform for Ottoneu Fantasy Football Leagu
 - **Testing:** See [docs/TESTING.md](docs/TESTING.md) for running Python and web tests
 - **Git workflow:** See [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md) for branch and PR requirements
 - **Domain rules:** See [docs/references/ottoneu-rules.md](docs/references/ottoneu-rules.md) for scoring, roster, salary cap, and arbitration
+- **Domain strategy:** See [docs/references/ottoneu-strategy.md](docs/references/ottoneu-strategy.md) for the format's economics (surplus value, dollar-per-point inflation, Superflex QB premium, raise treadmill, arbitration game theory) and the reasoning checklist used by the `/ottoneu-roster-question` skill.
 - **Environment:** See [docs/references/environment-variables.md](docs/references/environment-variables.md) for `.env` setup
 - **Market Projections:** See [docs/exec-plans/market-projections.md](docs/exec-plans/market-projections.md) for the market-based projection system implementation plan
 
@@ -48,7 +49,8 @@ docs/
 │   └── [segment-analysis.md](docs/generated/segment-analysis.md)            # Segmented projection accuracy analysis
 └── references/
     ├── environment-variables.md       # .env and .env.local variable reference
-    └── ottoneu-rules.md               # Scoring, roster, salary cap, arbitration rules
+    ├── ottoneu-rules.md               # Scoring, roster, salary cap, arbitration rules
+    └── ottoneu-strategy.md            # Format economics + AI reasoning checklist for roster construction
 ```
 
 ## Worktree Notes

--- a/Justfile
+++ b/Justfile
@@ -155,6 +155,15 @@ seed-win-totals *args:
     {{python}} scripts/seed_preseason_win_totals.py {{args}}
 
 # ──────────────────────────────────────────────
+# AI context packs
+# ──────────────────────────────────────────────
+
+# Emit a compact league roster-economics snapshot for AI context (default season 2026)
+# Consumed by the /ottoneu-roster-question skill.
+roster-context *args:
+    {{python}} scripts/roster_context_pack.py {{args}}
+
+# ──────────────────────────────────────────────
 # Ad-hoc DB queries
 # ──────────────────────────────────────────────
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -101,7 +101,7 @@ just test-python        # Python tests with coverage
 just test-web           # Jest tests with coverage
 just test-web-file <path>  # Run a single web test file (e.g. just test-web-file __tests__/lib/session.test.ts)
 just scrape             # Full scrape pipeline
-just analyze            # Run all analysis scripts
+just analyze            # Update player projections (runs active model → promote → rookie fallback)
 just check-db           # Verify database contents
 just check-arch         # Architectural/structural tests only
 just check-docs         # Documentation freshness check
@@ -123,6 +123,9 @@ just backfill-nfl-stats [--seasons ...] [--dry-run]    # Backfill nfl_stats from
 just backfill-draft-capital [--since YYYY] [--dry-run] # Backfill draft_capital from nflverse draft_picks
 just backfill-vegas [--since YYYY] [--dry-run]         # Backfill team_vegas_lines from nflverse games.csv
 just seed-win-totals --season YYYY                     # Upsert preseason sportsbook win totals (implied_total left NULL until schedule drops)
+
+# AI context packs
+just roster-context [--season YYYY]                 # Emit league roster-economics snapshot (cap, salaries, projections) for the /ottoneu-roster-question skill
 
 # Ad-hoc DB queries
 just py "<python-snippet>"                          # Run a one-off Python snippet against the project venv (read-only diagnostics)


### PR DESCRIPTION
## Summary

Daily reconciliation of harness docs against the eight commits merged since the 2026-05-29 audit (#510): #511 (shared-DB note), #512 (RLS on draft_capital/team_vegas_lines), #513 (deprecated Python analysis stack removed), #514 (arb-planner dedup), #515 (in-process projection pipeline), #516 (scripts/ as installable package), #517 (Ottoneu strategy primer).

## Commits reviewed

| PR | Doc impact | Status |
|----|------------|--------|
| #511 — shared-DB / `fp_*` rule | CLAUDE.md, AGENTS.md, ARCHITECTURE.md, db-schema.md already updated in the PR | ✅ accurate |
| #512 — RLS on draft_capital + team_vegas_lines | db-schema.md RLS section + table list already correct | ✅ accurate |
| #513 — remove deprecated `analyze_*.py` | ARCHITECTURE, COMMANDS top, README updated in PR — but `just analyze` blurb in COMMANDS still said "Run all analysis scripts" | 🔧 fixed |
| #514 — dedupe arb-planner | FRONTEND.md `components/arb-planner/` section added in PR | ✅ accurate |
| #515 — in-process projection pipeline | Internal refactor, no doc surface affected | ✅ accurate |
| #516 — `scripts/` installable package | CODE_ORGANIZATION.md path-setup section already updated | ✅ accurate |
| #517 — Ottoneu strategy primer | CLAUDE.md updated, but AGENTS.md doc map missed `ottoneu-strategy.md`, and `just roster-context` was referenced in CLAUDE.md + the skill but never added to the Justfile | 🔧 fixed |

## Changes

- **`Justfile`**: add the missing `roster-context` recipe. CLAUDE.md and `.claude/commands/ottoneu-roster-question.md` both tell agents to run `just roster-context`, but #517 only shipped the Python script (`scripts/roster_context_pack.py`) — the recipe itself was never wired up.
- **`docs/COMMANDS.md`**: refresh the `just analyze` blurb to match its current body (now runs only `update_projections.py` after #513), and list the new `roster-context` recipe.
- **`AGENTS.md`**: add `docs/references/ottoneu-strategy.md` to the Quick Reference and Documentation Map (CLAUDE.md got this in #517, AGENTS.md did not).

## Schema doc

No drift. Migrations through 026 (RLS enable on `draft_capital` + `team_vegas_lines`) are reflected in `docs/generated/db-schema.md`; table count (19) and RLS posture lists remain accurate. No new migration files since #512.

## Items flagged for human follow-up

None — all changes in this PR are mechanical and self-contained.

## Test plan

- [x] `git diff` reviewed — three files, +16/-2.
- [ ] `just check-docs` (not runnable here — no `just` installed in this sandbox; CI will run it)
- [ ] CI green on PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmk4toEG2srd5KfMnjk5A8)_