### PR TITLE
feat: add Draft Sharks auction values to player cards/pages

### DIFF
--- a/.github/workflows/scrape-draft-sharks.yml
+++ b/.github/workflows/scrape-draft-sharks.yml
@@ -1,0 +1,45 @@
+name: Scrape Draft Sharks Auction Values
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+
+  # Weekly, Mondays at 8:00 AM UTC. Auction values move slowly and are relevant
+  # year-round (offseason draft prep), so there is no in-season gate.
+  schedule:
+    - cron: "0 8 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install playwright supabase python-dotenv beautifulsoup4
+          # Install this repo as a package so `import scripts.*` resolves
+          pip install -e . --no-deps
+
+      - name: Install Playwright browsers
+        run: playwright install --with-deps chromium
+
+      - name: Create .env
+        run: |
+          echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" > .env
+          echo "SUPABASE_KEY=${{ secrets.SUPABASE_KEY }}" >> .env
+
+      - name: Scrape Draft Sharks auction values
+        run: python scripts/scrape_draft_sharks.py

--- a/Justfile
+++ b/Justfile
@@ -154,6 +154,10 @@ backfill-vegas *args:
 seed-win-totals *args:
     {{python}} scripts/seed_preseason_win_totals.py {{args}}
 
+# Scrape Draft Sharks auction values (x2 for the $400 cap)  (e.g. just scrape-draft-sharks --season 2026 --dry-run)
+scrape-draft-sharks *args:
+    {{python}} scripts/scrape_draft_sharks.py {{args}}
+
 # ──────────────────────────────────────────────
 # Ad-hoc DB queries
 # ──────────────────────────────────────────────

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,6 +37,18 @@ Jobs support dependencies, retries (up to 3 attempts), and batch grouping. `otto
 - **`player_stats`** = Ottoneu fantasy data (total_points, ppg, pps, snaps from scraping)
 - **`nfl_stats`** = Real NFL stats (passing_yards, rushing_tds, snap counts, etc. from nflverse)
 
+### Draft Sharks Auction Values (separate weekly scrape)
+
+`draft_sharks_values` stores Draft Sharks' Half-PPR Superflex auction values (both their
+own `ds_auction_value` and the consensus `market_auction_value`) per player per season.
+The Draft Sharks rankings table is client-rendered and lazy-loads on scroll, so
+`scripts/scrape_draft_sharks.py` drives it with Playwright, reads each row's position from
+its rank label, multiplies the site's $200-cap values by 2 (this league is $400), and
+matches players by `(normalized name, position)`. This is **not** part of the main
+`just scrape` pipeline — it runs standalone via `just scrape-draft-sharks` or the weekly
+`Scrape Draft Sharks Auction Values` GitHub Action. The web app surfaces these values on
+player cards and hover cards for users with projections access.
+
 ### Worker Task Modules (`scripts/tasks/`)
 
 Each task type lives in its own module. `__init__.py` defines task type constants and `TaskResult` dataclass. The worker caches NFL stats in memory so roster scrapes can match snap counts by player name.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -123,6 +123,7 @@ just backfill-nfl-stats [--seasons ...] [--dry-run]    # Backfill nfl_stats from
 just backfill-draft-capital [--since YYYY] [--dry-run] # Backfill draft_capital from nflverse draft_picks
 just backfill-vegas [--since YYYY] [--dry-run]         # Backfill team_vegas_lines from nflverse games.csv
 just seed-win-totals --season YYYY                     # Upsert preseason sportsbook win totals (implied_total left NULL until schedule drops)
+just scrape-draft-sharks [--season YYYY] [--positions qb rb wr te] [--dry-run]  # Scrape Draft Sharks Half-PPR Superflex auction values (stored ×2 for the $400 cap)
 
 # Ad-hoc DB queries
 just py "<python-snippet>"                          # Run a one-off Python snippet against the project venv (read-only diagnostics)
@@ -137,3 +138,10 @@ just py "<python-snippet>"                          # Run a one-off Python snipp
 # Every 6 hours (Jan-Mar): scrape arbitration progress
 0 */6 * 1-3 * cd /path/to/ottoneu_db && source venv/bin/activate && python scripts/scrape_arbitration_progress.py
 ```
+
+### GitHub Actions
+
+- `.github/workflows/scrape-draft-sharks.yml` — scrapes Draft Sharks auction values weekly
+  (Mondays 08:00 UTC) and on manual `workflow_dispatch`. Runs `scripts/scrape_draft_sharks.py`
+  via Playwright; no in-season gate (auction values matter year-round). Requires the
+  `SUPABASE_URL` / `SUPABASE_KEY` repo secrets.

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -1,6 +1,6 @@
 # Database Schema
 
-Nineteen tables owned by this project, all with UUID primary keys.
+Twenty tables owned by this project, all with UUID primary keys.
 
 ## Shared Database — Hands Off `fp_*`
 
@@ -36,6 +36,7 @@ The Supabase project (`OttoneuDB`, ref `rbinbcwinchphipvcfqk`) is **shared with 
 | `arbitration_progress_teams` | Per-team arbitration completion status | `(league_id, season, team_name)` |
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
+| `draft_sharks_values` | Draft Sharks Half-PPR Superflex auction values, scraped per player per season by `scripts/scrape_draft_sharks.py` and stored at $400-cap scale (site values are ×2). Columns: `ds_auction_value`, `market_auction_value` (FK -> `players`) | `(player_id, season)` |
 | `team_vegas_lines` | Per-team-season Vegas implied total + win total. `implied_total` is aggregated per-game from nflverse `games.csv` and is **nullable** (migration 025) — preseason win totals publish months before the NFL schedule, so the column stays NULL until per-game lines are available. `win_total` is Pythagorean (back-calculated from per-game implied totals) for past seasons, or the sportsbook preseason consensus seeded via `scripts/seed_preseason_win_totals.py` for upcoming seasons. | `(team, season)` |
 
 ### Projection tables detail
@@ -87,7 +88,7 @@ Advanced receiving (added in migration 022, populated for 2018+ via nflverse `st
 
 All public tables have RLS enabled. Server-side code uses the Supabase **service key** (Python via `scripts.config.get_supabase_client()`, Next.js writes via `web/lib/supabase.supabaseAdmin`) which bypasses RLS. The anon key is restricted to read-only access on a curated set of public reference data.
 
-**Tables with an anon SELECT policy** (web reads via the anon client): `players`, `player_stats`, `nfl_stats`, `league_prices`, `transactions`, `surplus_adjustments`, `player_projections`, `projection_models`, `model_projections`, `backtest_results`, `arbitration_progress`, `arbitration_progress_teams`, `arbitration_allocation_details`, `team_vegas_lines`.
+**Tables with an anon SELECT policy** (web reads via the anon client): `players`, `player_stats`, `nfl_stats`, `league_prices`, `transactions`, `surplus_adjustments`, `player_projections`, `projection_models`, `model_projections`, `backtest_results`, `arbitration_progress`, `arbitration_progress_teams`, `arbitration_allocation_details`, `team_vegas_lines`, `draft_sharks_values`.
 
 **Tables with no anon policy** (server-only, anon fully blocked): `users`, `arbitration_plans`, `arbitration_plan_allocations`, `scraper_jobs`, `draft_capital`.
 

--- a/migrations/027_create_draft_sharks_values.sql
+++ b/migrations/027_create_draft_sharks_values.sql
@@ -1,0 +1,34 @@
+-- Migration 027: Create draft_sharks_values table.
+--
+-- Stores Draft Sharks Half-PPR Superflex auction values, scraped per player
+-- per season by scripts/scrape_draft_sharks.py. Draft Sharks publishes values
+-- on a $200 cap; this league uses $400, so the scraper stores values already
+-- multiplied by 2 (i.e. the $400-scale value).
+--
+-- Two dollar columns are captured:
+--   * ds_auction_value     — Draft Sharks' own model-recommended bid
+--   * market_auction_value — Draft Sharks' consensus "auction market value"
+--
+-- Reads: the web frontend reads this table via the anon Supabase client
+-- (web/lib/data.ts) to show values on player cards / hover cards for users
+-- with projections access, so it needs a public SELECT policy. Writes happen
+-- server-side via the service key (scripts/config.get_supabase_client()),
+-- which bypasses RLS.
+
+CREATE TABLE IF NOT EXISTS public.draft_sharks_values (
+    id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    player_id            uuid NOT NULL REFERENCES public.players(id) ON DELETE CASCADE,
+    season               integer NOT NULL,
+    ds_auction_value     numeric,
+    market_auction_value numeric,
+    scraped_at           timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (player_id, season)
+);
+
+CREATE INDEX IF NOT EXISTS idx_draft_sharks_values_season
+    ON public.draft_sharks_values (season);
+
+ALTER TABLE public.draft_sharks_values ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Enable read access for all users" ON public.draft_sharks_values
+  FOR SELECT TO anon USING (true);

--- a/scripts/scrape_draft_sharks.py
+++ b/scripts/scrape_draft_sharks.py
@@ -1,0 +1,238 @@
+"""Scrape Draft Sharks Half-PPR Superflex auction values into draft_sharks_values.
+
+Draft Sharks publishes auction values for a $200 salary cap; this league uses a
+$400 cap, so every dollar value is multiplied by 2 before storage. Two columns
+are captured per player:
+
+  * ds_auction_value     — Draft Sharks' own model-recommended bid
+  * market_auction_value — Draft Sharks' consensus "auction market value"
+
+The rankings table is rendered client-side and lazy-loads rows as you scroll, so
+we drive it with Playwright (already a dependency, see scripts/worker.py). Each
+position page (.../auction-values/<pos>/half-ppr-superflex) actually renders the
+full cross-position board; we read each row's position from its rank label
+(e.g. "RB1", "QB12") and keep only rows matching the page we requested.
+
+Players are matched to our DB by (normalized name, position) using the same
+lookup as scripts/backfill_draft_capital.py. Unmatched names are reported so
+aliases can be added to scripts/name_utils.NAME_ALIASES.
+
+Usage:
+    venv/bin/python scripts/scrape_draft_sharks.py
+    venv/bin/python scripts/scrape_draft_sharks.py --season 2026
+    venv/bin/python scripts/scrape_draft_sharks.py --positions rb wr --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from playwright.async_api import async_playwright
+
+from scripts.config import SEASON, fetch_all_rows, get_supabase_client
+from scripts.name_utils import normalize_player_name
+
+POSITIONS = ["qb", "rb", "wr", "te"]
+
+URL_TEMPLATE = "https://www.draftsharks.com/auction-values/{pos}/half-ppr-superflex"
+
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/120.0.0.0 Safari/537.36"
+)
+
+# JS run in the page to pull every loaded player row from the rankings table.
+# Returns [{name, pos, ds, market}] where ds/market are the raw site dollar ints.
+_EXTRACT_JS = r"""
+() => {
+  const t = document.querySelector('#rankingsTable');
+  if (!t) return [];
+  const rows = [...t.querySelectorAll('tr.player-row')];
+  return rows.map(r => {
+    const nameCell = r.querySelector('td.player-name');
+    const fullText = nameCell ? nameCell.innerText : '';
+    const name = fullText.split('\n').map(s => s.trim()).filter(Boolean)[0] || '';
+    const m = fullText.replace(/\s+/g, ' ').match(/\b([A-Z]{1,3})\d+\b/);
+    const pos = m ? m[1] : '';
+    const dsCell = r.querySelector('td[data-attribute="dsAuctionValue"]');
+    const mktCell = r.querySelector('td[data-attribute="auctionMarketValue"]');
+    const parseDollar = (el) => {
+      if (!el) return null;
+      const raw = (el.getAttribute('data-value') || el.innerText || '').replace(/[^0-9.]/g, '');
+      return raw === '' ? null : parseFloat(raw);
+    };
+    return { name, pos, ds: parseDollar(dsCell), market: parseDollar(mktCell) };
+  });
+}
+"""
+
+
+async def _load_all_rows(page) -> int:
+    """Scroll to the bottom repeatedly until the lazy-loaded row count stabilizes."""
+    await page.wait_for_selector("#rankingsTable tr.player-row", timeout=30_000)
+    last = -1
+    stable = 0
+    for _ in range(40):
+        count = await page.eval_on_selector_all(
+            "#rankingsTable tr.player-row", "els => els.length"
+        )
+        if count == last:
+            stable += 1
+            if stable >= 3:
+                break
+        else:
+            stable = 0
+            last = count
+        await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+        await page.wait_for_timeout(1_200)
+    return last
+
+
+async def scrape_position(context, pos: str) -> list[dict]:
+    """Scrape one position page and return rows whose rank label matches `pos`."""
+    url = URL_TEMPLATE.format(pos=pos)
+    page = await context.new_page()
+    try:
+        await page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+        total = await _load_all_rows(page)
+        raw = await page.evaluate(_EXTRACT_JS)
+    finally:
+        await page.close()
+
+    pos_upper = pos.upper()
+    rows: list[dict] = []
+    seen: set[str] = set()
+    for r in raw:
+        if r.get("pos") != pos_upper:
+            continue
+        name = (r.get("name") or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        rows.append(
+            {
+                "name": name,
+                "position": pos_upper,
+                # Site values assume a $200 cap; this league is $400 -> x2.
+                "ds_auction_value": r["ds"] * 2 if r.get("ds") is not None else None,
+                "market_auction_value": r["market"] * 2 if r.get("market") is not None else None,
+            }
+        )
+    print(f"  {pos_upper}: {len(rows)} rows kept (of {total} loaded)")
+    return rows
+
+
+async def scrape_all(positions: list[str]) -> list[dict]:
+    rows: list[dict] = []
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True)
+        context = await browser.new_context(user_agent=USER_AGENT)
+        try:
+            for pos in positions:
+                rows.extend(await scrape_position(context, pos))
+        finally:
+            await browser.close()
+    return rows
+
+
+def build_player_lookup(supabase) -> dict[tuple[str, str], str]:
+    """Return (normalized_name, position) -> player_id, mirroring backfill_draft_capital."""
+    db_rows = fetch_all_rows(supabase, "players", "id, name, position")
+    lookup: dict[tuple[str, str], str] = {}
+    for r in db_rows:
+        if not r.get("name") or not r.get("position"):
+            continue
+        lookup.setdefault((normalize_player_name(r["name"]), r["position"]), r["id"])
+    return lookup
+
+
+def match_rows(
+    scraped: list[dict], lookup: dict[tuple[str, str], str], season: int
+) -> tuple[list[dict], list[dict]]:
+    matched: list[dict] = []
+    unmatched: list[dict] = []
+    for r in scraped:
+        player_id = lookup.get((normalize_player_name(r["name"]), r["position"]))
+        if player_id:
+            matched.append(
+                {
+                    "player_id": player_id,
+                    "season": season,
+                    "ds_auction_value": r["ds_auction_value"],
+                    "market_auction_value": r["market_auction_value"],
+                }
+            )
+        else:
+            unmatched.append(r)
+    return matched, unmatched
+
+
+def upsert_values(supabase, rows: list[dict]) -> None:
+    if not rows:
+        print("  No rows to upsert.")
+        return
+    batch_size = 200
+    for i in range(0, len(rows), batch_size):
+        batch = rows[i : i + batch_size]
+        supabase.table("draft_sharks_values").upsert(
+            batch, on_conflict="player_id,season"
+        ).execute()
+    print(f"  Upserted {len(rows)} rows.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Scrape Draft Sharks Half-PPR Superflex auction values."
+    )
+    # Draft Sharks publishes auction values for the *upcoming* season, so the
+    # default tags them as SEASON + 1 (the projection year the web app reads).
+    default_season = SEASON + 1
+    parser.add_argument(
+        "--season", type=int, default=default_season,
+        help=f"Season to tag the values with (default: {default_season})",
+    )
+    parser.add_argument(
+        "--positions", nargs="+", default=POSITIONS,
+        choices=POSITIONS,
+        help="Positions to scrape (default: qb rb wr te)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Scrape and match without writing to the database",
+    )
+    args = parser.parse_args()
+
+    print(
+        f"Draft Sharks scrape (season={args.season}, "
+        f"positions={args.positions}, dry_run={args.dry_run})"
+    )
+
+    print("\nScraping Draft Sharks...")
+    scraped = asyncio.run(scrape_all(args.positions))
+    print(f"  {len(scraped)} total player rows scraped")
+
+    supabase = get_supabase_client()
+    print("\nBuilding player lookup from DB...")
+    lookup = build_player_lookup(supabase)
+    print(f"  {len(lookup)} (name, position) keys")
+
+    matched, unmatched = match_rows(scraped, lookup, args.season)
+    print(f"\nMatched: {len(matched)}")
+    print(f"Unmatched: {len(unmatched)}")
+    for u in unmatched[:25]:
+        print(f"    UNMATCHED {u['name']} ({u['position']}) "
+              f"ds={u['ds_auction_value']} mkt={u['market_auction_value']}")
+
+    if args.dry_run:
+        print("\nDry run — no DB writes.")
+        return
+
+    print("\nUpserting matched values...")
+    upsert_values(supabase, matched)
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/app/arb-progress/page.tsx
+++ b/web/app/arb-progress/page.tsx
@@ -1,6 +1,6 @@
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { LEAGUE_ID, SEASON, NUM_TEAMS } from "@/lib/config";
-import { fetchAndMergeData, fetchProjectionMap, buildHoverDataMap, DEFAULT_PROJECTION_YEAR } from "@/lib/analysis";
+import { fetchAndMergeData, fetchHoverExtras, buildHoverDataMap } from "@/lib/analysis";
 import { getAuthenticatedUser } from "@/lib/auth";
 import {
   AllocationDetailRow,
@@ -61,8 +61,8 @@ export default async function ArbProgressPage() {
     getAuthenticatedUser(),
   ]);
 
-  const projMap = user?.hasProjectionsAccess ? await fetchProjectionMap(DEFAULT_PROJECTION_YEAR) : null;
-  const hoverDataMap = buildHoverDataMap(allPlayers, projMap);
+  const { projMap, dsMap } = await fetchHoverExtras(!!user?.hasProjectionsAccess);
+  const hoverDataMap = buildHoverDataMap(allPlayers, projMap, dsMap);
 
   const teams: TeamStatus[] = teamsRes.data ?? [];
   const allocationRows = (allocationsRes.data ?? []) as AllocationRow[];

--- a/web/app/arbitration-planner/page.tsx
+++ b/web/app/arbitration-planner/page.tsx
@@ -1,5 +1,5 @@
 import {
-  fetchProjectionMap,
+  fetchHoverExtras,
   buildHoverDataMap,
   analyzeArbitration,
   allocateArbitrationBudget,
@@ -11,7 +11,6 @@ import {
   ARB_MAX_PER_TEAM,
   ARB_MAX_PER_PLAYER_PER_TEAM,
   NUM_TEAMS,
-  DEFAULT_PROJECTION_YEAR,
 } from "@/lib/analysis";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getAuthenticatedUser } from "@/lib/auth";
@@ -33,10 +32,8 @@ export default async function ArbitrationPlannerPage() {
         .neq("adjustment", 0)
     : { data: [], error: null };
 
-  const projMap = user?.hasProjectionsAccess
-    ? await fetchProjectionMap(DEFAULT_PROJECTION_YEAR)
-    : null;
-  const hoverDataMap = buildHoverDataMap(allPlayers, projMap);
+  const { projMap, dsMap } = await fetchHoverExtras(!!user?.hasProjectionsAccess);
+  const hoverDataMap = buildHoverDataMap(allPlayers, projMap, dsMap);
 
   // Use raw values (no adjustments) so Value/Surplus columns match the arbitration page.
   // Adjustments are shown separately in the "Adj. Surplus" column.

--- a/web/app/arbitration-simulation/page.tsx
+++ b/web/app/arbitration-simulation/page.tsx
@@ -1,6 +1,6 @@
 import {
   fetchAndMergeProjectedData,
-  fetchProjectionMap,
+  fetchHoverExtras,
   buildHoverDataMap,
   fetchPlayersPreArb,
   SEASON,
@@ -53,6 +53,9 @@ export default async function ArbitrationSimulationPage({ searchParams }: Props)
 
   const label = isProjected ? DEFAULT_PROJECTION_YEAR : SEASON;
 
+  const { projMap, dsMap } = await fetchHoverExtras(!!user?.hasProjectionsAccess);
+  const hoverDataMap = buildHoverDataMap(rawPlayers, projMap, dsMap);
+
   return (
     <main className="min-h-screen bg-white dark:bg-black p-8">
       <div className="max-w-7xl mx-auto space-y-8">
@@ -88,12 +91,7 @@ export default async function ArbitrationSimulationPage({ searchParams }: Props)
         <SimulationControls
           initialPlayers={rawPlayers}
           initialAdjustments={initialAdjustments}
-          hoverDataMap={buildHoverDataMap(
-            rawPlayers,
-            user?.hasProjectionsAccess
-              ? await fetchProjectionMap(DEFAULT_PROJECTION_YEAR)
-              : null
-          )}
+          hoverDataMap={hoverDataMap}
         />
       </div>
     </main>

--- a/web/app/arbitration/page.tsx
+++ b/web/app/arbitration/page.tsx
@@ -1,7 +1,7 @@
 import {
   fetchPlayersWithProjectedPpg,
   fetchAndMergeProjectedData,
-  fetchProjectionMap,
+  fetchHoverExtras,
   buildHoverDataMap,
   analyzeArbitration,
   allocateArbitrationBudget,
@@ -114,10 +114,8 @@ export default async function ArbitrationPage({ searchParams }: Props) {
     allPlayers = await fetchPlayersWithProjectedPpg(fetchPlayersPreArb);
   }
 
-  const projMap = user?.hasProjectionsAccess
-    ? await fetchProjectionMap(DEFAULT_PROJECTION_YEAR)
-    : null;
-  const hoverDataMap = buildHoverDataMap(allPlayers, projMap);
+  const { projMap, dsMap } = await fetchHoverExtras(!!user?.hasProjectionsAccess);
+  const hoverDataMap = buildHoverDataMap(allPlayers, projMap, dsMap);
 
   const targets = analyzeArbitration(allPlayers, adjustments) as ProjectedTarget[];
 

--- a/web/app/players/[id]/page.tsx
+++ b/web/app/players/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { fetchPlayerDetail, fetchPlayerProjection } from "@/lib/data";
+import { fetchPlayerDetail, fetchPlayerProjection, fetchDraftSharksValue } from "@/lib/data";
 import { getAuthenticatedUser } from "@/lib/auth";
 import { notFound } from "next/navigation";
 import Link from "next/link";
@@ -32,9 +32,12 @@ export default async function PlayerCardPage({
 
     // Fetch auth + projection in parallel (auth returns null for unauthenticated)
     const user = await getAuthenticatedUser();
-    const projection = user?.hasProjectionsAccess
-        ? await fetchPlayerProjection(player.id)
-        : null;
+    const [projection, draftSharks] = user?.hasProjectionsAccess
+        ? await Promise.all([
+              fetchPlayerProjection(player.id),
+              fetchDraftSharksValue(player.id),
+          ])
+        : [null, null];
 
     const posColor = POSITION_COLORS[player.position as Position] ?? "#6B7280";
 
@@ -94,6 +97,26 @@ export default async function PlayerCardPage({
                                         </p>
                                         <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
                                             Salary
+                                        </p>
+                                    </div>
+                                )}
+                                {draftSharks?.ds_auction_value != null && (
+                                    <div className="text-center">
+                                        <p className="text-3xl font-bold text-violet-600 dark:text-violet-400 font-mono">
+                                            ${draftSharks.ds_auction_value}
+                                        </p>
+                                        <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                                            DS Value
+                                        </p>
+                                    </div>
+                                )}
+                                {draftSharks?.market_auction_value != null && (
+                                    <div className="text-center">
+                                        <p className="text-3xl font-bold text-violet-600 dark:text-violet-400 font-mono">
+                                            ${draftSharks.market_auction_value}
+                                        </p>
+                                        <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                                            Mkt Value
                                         </p>
                                     </div>
                                 )}

--- a/web/app/players/[id]/page.tsx
+++ b/web/app/players/[id]/page.tsx
@@ -106,7 +106,7 @@ export default async function PlayerCardPage({
                                             ${draftSharks.ds_auction_value}
                                         </p>
                                         <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                                            DS Value
+                                            DS Projected Value
                                         </p>
                                     </div>
                                 )}
@@ -116,7 +116,7 @@ export default async function PlayerCardPage({
                                             ${draftSharks.market_auction_value}
                                         </p>
                                         <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                                            Mkt Value
+                                            Benchmark Value
                                         </p>
                                     </div>
                                 )}

--- a/web/app/projected-salary/page.tsx
+++ b/web/app/projected-salary/page.tsx
@@ -1,12 +1,11 @@
 import {
   fetchAndMergeData,
-  fetchProjectionMap,
+  fetchHoverExtras,
   buildHoverDataMap,
   analyzeProjectedSalary,
   CAP_PER_TEAM,
   POSITIONS,
   MY_TEAM,
-  DEFAULT_PROJECTION_YEAR,
 } from "@/lib/analysis";
 import { getAuthenticatedUser } from "@/lib/auth";
 import ProjectedSalaryClient from "./ProjectedSalaryClient";
@@ -18,10 +17,8 @@ export default async function ProjectedSalaryPage() {
     getAuthenticatedUser(),
   ]);
   const roster = analyzeProjectedSalary(allPlayers);
-  const projMap = user?.hasProjectionsAccess
-    ? await fetchProjectionMap(DEFAULT_PROJECTION_YEAR)
-    : null;
-  const hoverDataMap = buildHoverDataMap(allPlayers, projMap);
+  const { projMap, dsMap } = await fetchHoverExtras(!!user?.hasProjectionsAccess);
+  const hoverDataMap = buildHoverDataMap(allPlayers, projMap, dsMap);
 
   if (roster.length === 0) {
     return (

--- a/web/app/rosters/page.tsx
+++ b/web/app/rosters/page.tsx
@@ -1,5 +1,5 @@
 import { fetchRosterData } from "@/lib/roster-reconstruction";
-import { fetchProjectionMap, DEFAULT_PROJECTION_YEAR } from "@/lib/analysis";
+import { fetchHoverExtras } from "@/lib/analysis";
 import { getAuthenticatedUser } from "@/lib/auth";
 import type { PlayerHoverData } from "@/lib/types";
 import RostersClient from "./RostersClient";
@@ -9,9 +9,7 @@ export default async function RostersPage() {
     fetchRosterData(),
     getAuthenticatedUser(),
   ]);
-  const projMap = user?.hasProjectionsAccess
-    ? await fetchProjectionMap(DEFAULT_PROJECTION_YEAR)
-    : null;
+  const { projMap, dsMap } = await fetchHoverExtras(!!user?.hasProjectionsAccess);
 
   // Build hoverDataMap from raw player + stats data
   const statsMap = new Map(data.stats.map((s) => [s.player_id, s]));
@@ -31,6 +29,12 @@ export default async function RostersPage() {
         ? {
             projected_ppg: projMap[player.id].ppg,
             projection_method: projMap[player.id].method,
+          }
+        : {}),
+      ...(dsMap?.[player.id]
+        ? {
+            ds_auction_value: dsMap[player.id].ds_auction_value,
+            market_auction_value: dsMap[player.id].market_auction_value,
           }
         : {}),
     };

--- a/web/app/surplus-adjustments/page.tsx
+++ b/web/app/surplus-adjustments/page.tsx
@@ -1,4 +1,4 @@
-import { fetchAndMergeProjectedData, fetchProjectionMap, buildHoverDataMap, calculateSurplus, fetchPlayersPreArb, SEASON, LEAGUE_ID, DEFAULT_PROJECTION_YEAR } from "@/lib/analysis";
+import { fetchAndMergeProjectedData, fetchHoverExtras, buildHoverDataMap, calculateSurplus, fetchPlayersPreArb, SEASON, LEAGUE_ID, DEFAULT_PROJECTION_YEAR } from "@/lib/analysis";
 import { computeDollarPerVorp } from "@/lib/surplus";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getAuthenticatedUser } from "@/lib/auth";
@@ -21,10 +21,8 @@ export default async function SurplusAdjustmentsPage() {
       : Promise.resolve({ data: [], error: null }),
   ]);
 
-  const projMap = user?.hasProjectionsAccess
-    ? await fetchProjectionMap(DEFAULT_PROJECTION_YEAR)
-    : null;
-  const hoverDataMap = buildHoverDataMap(allPlayers, projMap);
+  const { projMap, dsMap } = await fetchHoverExtras(!!user?.hasProjectionsAccess);
+  const hoverDataMap = buildHoverDataMap(allPlayers, projMap, dsMap);
 
   const surplusPlayers = calculateSurplus(allPlayers).filter(
     (p) => p.position !== "K"

--- a/web/app/surplus-value/page.tsx
+++ b/web/app/surplus-value/page.tsx
@@ -1,10 +1,9 @@
 import {
-  fetchProjectionMap,
+  fetchHoverExtras,
   buildHoverDataMap,
   calculateSurplus,
   MY_TEAM,
   SEASON,
-  DEFAULT_PROJECTION_YEAR,
 } from "@/lib/analysis";
 import { fetchPlayersEndOfSeason } from "@/lib/data";
 import { getAuthenticatedUser } from "@/lib/auth";
@@ -92,10 +91,8 @@ export default async function SurplusValuePage() {
     fetchPlayersEndOfSeason(),
     getAuthenticatedUser(),
   ]);
-  const projMap = user?.hasProjectionsAccess
-    ? await fetchProjectionMap(DEFAULT_PROJECTION_YEAR)
-    : null;
-  const hoverDataMap = buildHoverDataMap(allPlayers, projMap);
+  const { projMap, dsMap } = await fetchHoverExtras(!!user?.hasProjectionsAccess);
+  const hoverDataMap = buildHoverDataMap(allPlayers, projMap, dsMap);
   const surplusPlayers = calculateSurplus(allPlayers);
 
   if (surplusPlayers.length === 0) {

--- a/web/app/vorp/page.tsx
+++ b/web/app/vorp/page.tsx
@@ -1,5 +1,5 @@
 import {
-  fetchProjectionMap,
+  fetchHoverExtras,
   buildHoverDataMap,
   calculateVorp,
   POSITIONS,
@@ -7,7 +7,6 @@ import {
   MIN_GAMES,
   NUM_TEAMS,
   CAP_PER_TEAM,
-  DEFAULT_PROJECTION_YEAR,
 } from "@/lib/analysis";
 import { fetchPlayersEndOfSeason } from "@/lib/data";
 import { getAuthenticatedUser } from "@/lib/auth";
@@ -19,10 +18,8 @@ export default async function VorpPage() {
     getAuthenticatedUser(),
   ]);
   const { players, replacementPpg, replacementN } = calculateVorp(allPlayers);
-  const projMap = user?.hasProjectionsAccess
-    ? await fetchProjectionMap(DEFAULT_PROJECTION_YEAR)
-    : null;
-  const hoverDataMap = buildHoverDataMap(allPlayers, projMap);
+  const { projMap, dsMap } = await fetchHoverExtras(!!user?.hasProjectionsAccess);
+  const hoverDataMap = buildHoverDataMap(allPlayers, projMap, dsMap);
 
   if (players.length === 0) {
     return (

--- a/web/components/PlayerHoverCard.tsx
+++ b/web/components/PlayerHoverCard.tsx
@@ -83,6 +83,26 @@ export default function PlayerHoverCard({
                     </span>
                   </div>
                 )}
+                {hoverData.ds_auction_value != null && (
+                  <div className="flex justify-between">
+                    <span className="text-violet-600 dark:text-violet-400 font-medium">
+                      DS Value
+                    </span>
+                    <span className="font-mono font-medium text-violet-600 dark:text-violet-400">
+                      ${hoverData.ds_auction_value}
+                    </span>
+                  </div>
+                )}
+                {hoverData.market_auction_value != null && (
+                  <div className="flex justify-between">
+                    <span className="text-violet-600 dark:text-violet-400 font-medium">
+                      Mkt Value
+                    </span>
+                    <span className="font-mono font-medium text-violet-600 dark:text-violet-400">
+                      ${hoverData.market_auction_value}
+                    </span>
+                  </div>
+                )}
               </div>
             </div>
           ) : (

--- a/web/components/PlayerHoverCard.tsx
+++ b/web/components/PlayerHoverCard.tsx
@@ -86,7 +86,7 @@ export default function PlayerHoverCard({
                 {hoverData.ds_auction_value != null && (
                   <div className="flex justify-between">
                     <span className="text-violet-600 dark:text-violet-400 font-medium">
-                      DS Value
+                      DS Projected Value
                     </span>
                     <span className="font-mono font-medium text-violet-600 dark:text-violet-400">
                       ${hoverData.ds_auction_value}
@@ -96,7 +96,7 @@ export default function PlayerHoverCard({
                 {hoverData.market_auction_value != null && (
                   <div className="flex justify-between">
                     <span className="text-violet-600 dark:text-violet-400 font-medium">
-                      Mkt Value
+                      Benchmark Value
                     </span>
                     <span className="font-mono font-medium text-violet-600 dark:text-violet-400">
                       ${hoverData.market_auction_value}

--- a/web/lib/analysis.ts
+++ b/web/lib/analysis.ts
@@ -10,7 +10,7 @@
 
 import { supabase } from "./supabase";
 import { LEAGUE_ID, SEASON } from "./config";
-import { fetchPlayers } from "./data";
+import { fetchPlayers, fetchDraftSharksMap, type DraftSharksValue } from "./data";
 import type { Player, PlayerHoverData, BacktestPlayer, ProjectionModel, BacktestMetrics } from "./types";
 
 // Re-export from config/arb-logic for backward compatibility
@@ -219,7 +219,8 @@ export async function fetchProjectionMap(
  */
 export function buildHoverDataMap(
   players: Player[],
-  projMap: Record<string, { ppg: number; method: string }> | null = null
+  projMap: Record<string, { ppg: number; method: string }> | null = null,
+  dsMap: Record<string, DraftSharksValue> | null = null
 ): Record<string, PlayerHoverData> {
   return Object.fromEntries(
     players
@@ -240,9 +241,37 @@ export function buildHoverDataMap(
                 projection_method: projMap[p.player_id].method,
               }
             : {}),
+          ...(dsMap?.[p.player_id]
+            ? {
+                ds_auction_value: dsMap[p.player_id].ds_auction_value,
+                market_auction_value: dsMap[p.player_id].market_auction_value,
+              }
+            : {}),
         },
       ])
   );
+}
+
+/**
+ * Fetch the projection-access-gated extras (projection map + Draft Sharks map)
+ * used to enrich hover cards. Returns nulls when the user lacks access so
+ * callers can pass the result straight into buildHoverDataMap.
+ */
+export async function fetchHoverExtras(
+  hasProjectionsAccess: boolean,
+  season: number = DEFAULT_PROJECTION_YEAR
+): Promise<{
+  projMap: Record<string, { ppg: number; method: string }> | null;
+  dsMap: Record<string, DraftSharksValue> | null;
+}> {
+  if (!hasProjectionsAccess) {
+    return { projMap: null, dsMap: null };
+  }
+  const [projMap, dsMap] = await Promise.all([
+    fetchProjectionMap(season),
+    fetchDraftSharksMap(season),
+  ]);
+  return { projMap, dsMap };
 }
 
 export interface ProjectedPlayer extends Player {

--- a/web/lib/data.ts
+++ b/web/lib/data.ts
@@ -370,6 +370,69 @@ export async function fetchPlayerProjection(
   };
 }
 
+// ─── Draft Sharks Auction Values ──────────────────────────────────────────────
+//
+// Half-PPR Superflex auction values scraped from Draft Sharks, already scaled to
+// this league's $400 cap (the site publishes $200-cap values; the scraper x2's).
+// Gated behind projections access in the UI, same as projected PPG.
+
+export interface DraftSharksValue {
+  ds_auction_value: number | null;
+  market_auction_value: number | null;
+}
+
+/**
+ * Fetch a single player's Draft Sharks auction values for a given season.
+ */
+export async function fetchDraftSharksValue(
+  playerId: string,
+  season = 2026
+): Promise<DraftSharksValue | null> {
+  const { data, error } = await supabase
+    .from("draft_sharks_values")
+    .select("ds_auction_value, market_auction_value")
+    .eq("player_id", playerId)
+    .eq("season", season)
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  return {
+    ds_auction_value:
+      data.ds_auction_value != null ? Number(data.ds_auction_value) : null,
+    market_auction_value:
+      data.market_auction_value != null ? Number(data.market_auction_value) : null,
+  };
+}
+
+/**
+ * Build a player_id → Draft Sharks values map for bulk (hover-card) use.
+ */
+export async function fetchDraftSharksMap(
+  season = 2026
+): Promise<Record<string, DraftSharksValue>> {
+  const { data, error } = await supabase
+    .from("draft_sharks_values")
+    .select("player_id, ds_auction_value, market_auction_value")
+    .eq("season", season);
+
+  if (error || !data) return {};
+
+  return Object.fromEntries(
+    data.map((row) => [
+      row.player_id,
+      {
+        ds_auction_value:
+          row.ds_auction_value != null ? Number(row.ds_auction_value) : null,
+        market_auction_value:
+          row.market_auction_value != null
+            ? Number(row.market_auction_value)
+            : null,
+      },
+    ])
+  );
+}
+
 // ─── Active Projection Model ──────────────────────────────────────────────────
 
 export interface ActiveProjectionModel {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -299,6 +299,8 @@ export interface PlayerHoverData {
   games_played: number;
   projected_ppg?: number;
   projection_method?: string;
+  ds_auction_value?: number | null;
+  market_auction_value?: number | null;
 }
 
 // === Position Constants ===

--- a/web/types/supabase.ts
+++ b/web/types/supabase.ts
@@ -275,6 +275,41 @@ export type Database = {
           },
         ]
       }
+      draft_sharks_values: {
+        Row: {
+          ds_auction_value: number | null
+          id: string
+          market_auction_value: number | null
+          player_id: string
+          scraped_at: string
+          season: number
+        }
+        Insert: {
+          ds_auction_value?: number | null
+          id?: string
+          market_auction_value?: number | null
+          player_id: string
+          scraped_at?: string
+          season: number
+        }
+        Update: {
+          ds_auction_value?: number | null
+          id?: string
+          market_auction_value?: number | null
+          player_id?: string
+          scraped_at?: string
+          season?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "draft_sharks_values_player_id_fkey"
+            columns: ["player_id"]
+            isOneToOne: false
+            referencedRelation: "players"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       league_prices: {
         Row: {
           created_at: string


### PR DESCRIPTION
Scrape Draft Sharks Half-PPR Superflex auction values (both DS's own
recommended bid and the consensus market value) for QB/RB/WR/TE and show
them alongside Ottoneu salaries to users with projections access.

Backend:
- migration 027: new draft_sharks_values table (RLS + anon SELECT policy)
- scripts/scrape_draft_sharks.py: Playwright scraper that drives the
  lazy-loaded rankings table, reads each row's position from its rank
  label, multiplies site $200-cap values by 2 (this league is $400), and
  matches players by (normalized name, position). ~95% match rate.
- just scrape-draft-sharks recipe
- weekly GitHub Actions workflow (workflow_dispatch + Mondays 08:00 UTC)

Frontend (gated behind projections access, same as projected PPG):
- fetchDraftSharksValue / fetchDraftSharksMap in lib/data.ts
- player detail page shows DS Value + Mkt Value tiles
- PlayerHoverData + hover card show DS/Mkt values
- new fetchHoverExtras helper bundles the projection + DS maps; threaded
  through all hover-card pages

Docs: db-schema, COMMANDS, ARCHITECTURE updated; supabase TS types regenerated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
