### PR TITLE
fix: show real salary in rosters page hover cards

### DIFF
--- a/web/app/rosters/page.tsx
+++ b/web/app/rosters/page.tsx
@@ -13,16 +13,21 @@ export default async function RostersPage() {
 
   // Build hoverDataMap from raw player + stats data
   const statsMap = new Map(data.stats.map((s) => [s.player_id, s]));
+  // Current salary/team come from league_prices (source of truth for the
+  // current-roster view). The table can also show salary at a past date, but
+  // the hover card is rendered server-side, so it reflects current salary.
+  const priceMap = new Map(data.leaguePrices.map((lp) => [lp.player_id, lp]));
   const hoverDataMap: Record<string, PlayerHoverData> = {};
   for (const player of data.players) {
     const pStats = statsMap.get(player.id);
     if (!player.ottoneu_id) continue;
+    const lp = priceMap.get(player.id);
     hoverDataMap[player.id] = {
       ottoneu_id: player.ottoneu_id,
       position: player.position,
       nfl_team: player.nfl_team,
-      price: 0, // salary varies by date — will show 0 as placeholder
-      team_name: null,
+      price: lp?.price ?? 0,
+      team_name: lp?.team_name ?? null,
       ppg: pStats?.ppg ?? 0,
       games_played: pStats?.games_played ?? 0,
       ...(projMap?.[player.id]


### PR DESCRIPTION
The rosters page built its player hover-card data with a hardcoded
`price: 0` placeholder (and null team), so every hover card showed
"$0" salary even though the table salaries were correct.

Populate price and team_name from league_prices (the current-roster
source of truth), keyed by player_id. The hover card is rendered
server-side so it reflects current salary; the table's date-slider view
is unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
