### PR TITLE
fix: set Turbopack root so dev server resolves shared config.json

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // The Next app lives in web/, but lib/config.ts imports the shared
+  // config.json from the repo root (../../config.json). Turbopack (the default
+  // bundler in Next 16) otherwise infers the workspace root as web/ — the only
+  // dir with a lockfile — and refuses to resolve files outside it, breaking the
+  // dev server. Point the root at the repo so the import resolves.
+  turbopack: {
+    root: path.join(__dirname, ".."),
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Next 16 uses Turbopack by default, which infers the workspace root from
the nearest lockfile — web/ here, since the repo root has none. It then
refuses to resolve imports outside that root, so lib/config.ts's
`import config from "../../config.json"` (the shared repo-root config)
failed with "Module not found", 500-ing every server-rendered page in
`npm run dev`.

Set `turbopack.root` to the repo root so the import resolves. Verified:
dev server now returns 200 for SSR pages and `next build` succeeds, both
with zero module-resolution errors.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
