### PR TITLE
fix: exclude free agents (FA) from rosters page teams

### DIFF
--- a/web/lib/roster-reconstruction.ts
+++ b/web/lib/roster-reconstruction.ts
@@ -103,6 +103,12 @@ interface PlayerState {
   acquisition_type: string;
 }
 
+// "FA" (and empty/null) in league_prices/transactions denotes free agents,
+// not a real fantasy team — those players are not on anyone's roster.
+function isRealTeam(team: string | null | undefined): team is string {
+  return team != null && team !== "" && team !== "FA";
+}
+
 export function reconstructRostersAtDate(
   transactions: RawTransaction[],
   players: RawPlayer[],
@@ -135,7 +141,7 @@ export function reconstructRostersAtDate(
 
     const teamMap = new Map<string, RosterEntry[]>();
     for (const lp of leaguePrices) {
-      if (!lp.team_name || lp.price == null) continue;
+      if (!isRealTeam(lp.team_name) || lp.price == null) continue;
       const player = playerMap.get(lp.player_id);
       if (!player) continue;
       const pStats = statsMap.get(lp.player_id);
@@ -198,7 +204,7 @@ export function reconstructRostersAtDate(
       type.includes("signed") ||
       type.includes("rostered")
     ) {
-      if (txn.team_name) {
+      if (isRealTeam(txn.team_name)) {
         playerStateMap.set(txn.player_id, {
           team: txn.team_name,
           salary: txn.salary ?? 0,
@@ -217,7 +223,7 @@ export function reconstructRostersAtDate(
   const teamMap = new Map<string, RosterEntry[]>();
 
   for (const [player_id, state] of playerStateMap.entries()) {
-    if (!state.team) continue;
+    if (!isRealTeam(state.team)) continue;
 
     const player = playerMap.get(player_id);
     if (!player) continue;


### PR DESCRIPTION
league_prices and transactions use the sentinel team_name "FA" for free
agents (774 players in our league), which the roster reconstruction
grouped as a giant bogus "team" alongside the real ones.

Add an isRealTeam() guard (rejects null/empty/"FA") and apply it in both
the current-prices and historical-replay paths so free agents are never
treated as a roster.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
