### PR TITLE
retro: document dev-server verify loop, Turbopack root, and cwd gotcha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ Run `just check-arch` to validate these rules locally.
 - **Never commit directly to `main`.** All changes go through pull requests.
 - **Always create a PR.** Every task must end with `gh pr create --fill`.
 - **Start from updated main:** `git checkout main && git pull origin main` before branching.
+- **Bash cwd persists between calls.** A `cd web && …` leaves the shell in `web/`, so a later repo-root-relative path (e.g. `git add web/next.config.ts`) silently fails. Prefer absolute paths, `git -C <repo-root>`, or re-`cd` explicitly rather than assuming the working directory.
 - See [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md) for full details.
 
 ## Projection Model Update Requirements

--- a/Justfile
+++ b/Justfile
@@ -27,6 +27,10 @@ install:
 dev:
     cd web && npm run dev
 
+# Stop any running Next dev server and stray Turbopack/postcss workers
+dev-stop:
+    -pkill -f "next-server" 2>/dev/null; pkill -f "next dev" 2>/dev/null; pkill -f ".next/dev/build" 2>/dev/null; true
+
 # Production build (validates correctness)
 build:
     cd web && npm run build

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -78,3 +78,35 @@ Analysis math is ported to `web/lib/analysis.ts` (TS equivalent of `scripts/anal
 ## Configuration
 
 Frontend constants in `web/lib/config.ts` — **must stay in sync with `scripts/config.py`**.
+
+`web/lib/config.ts` imports the shared `config.json` from the **repo root**
+(`../../config.json`), which is outside the `web/` app dir. Next 16 uses
+Turbopack by default, and Turbopack infers the workspace root from the nearest
+lockfile (`web/`) and refuses to resolve files outside it — which 500s every
+SSR page in dev. `web/next.config.ts` sets `turbopack.root` to the repo root to
+fix this; **don't remove it**, and keep `config.json` at the repo root (it's
+shared with the Python side).
+
+## Local dev & verification
+
+- **Run:** `just dev` (foreground) starts the server on `localhost:3000`.
+- **Stop:** `just dev-stop` kills the dev server plus stray Turbopack/postcss
+  workers (a plain Ctrl-C sometimes leaves `.next/dev/build/postcss.js`
+  processes behind).
+- **Headless verify loop** (for confirming a change actually renders): start the
+  server in the background, poll its log for `Ready in`, then hit pages with
+  `curl -s -o /dev/null -w '%{http_code}'` or drive them with the puppeteer MCP
+  tools (navigate → click → screenshot), then `just dev-stop`. Auth-gated routes
+  redirect (307) for anonymous requests — that's expected, not a failure.
+- **Verifying responsive / auth-conditional UI** (e.g. the nav): check it at
+  multiple viewport widths *and* both auth states — logged-out and authenticated
+  render different item sets and collapse at different breakpoints.
+
+### Lint gotcha: `react-hooks/set-state-in-effect`
+
+ESLint errors on calling `setState` synchronously in a `useEffect` body (e.g.
+closing a menu on route change via `useEffect(() => setOpen(false), [pathname])`).
+Close UI state from event handlers instead — an `onClick` on each link, or a
+document `mousedown` / `Escape` listener registered inside the effect (calling
+`setState` from the listener callback is fine; calling it directly in the effect
+body is not).


### PR DESCRIPTION
## What triggered this retro

A multi-feature session: Draft Sharks auction values (#521), rosters hover salary (#522), search relevance ranking (#523), responsive nav (#524), the Turbopack dev-server fix (#525), the collapsed-nav redesign (on #524), and the FA-team rosters bug (#526). Several friction points recurred — most stemming from the local dev server being unusable for most of the session.

## Friction points

| # | What happened | Category | Root cause | Fix |
|---|--------------|----------|------------|-----|
| 1 | Dev server 500'd on every SSR page; couldn't visually verify UI work | missing-docs | Turbopack inferred `web/` as root, couldn't resolve `../../config.json` | Fixed in #525; documented in FRONTEND.md so it isn't reintroduced |
| 2 | No documented headless verify pattern → hand-rolled background `npm run dev` + `seq` polling + `pkill` (repeated approval gates) | approval-gate / missing-skill | `start-dev` is interactive only | `just dev-stop` recipe + "Local dev & verification" doc section |
| 3 | First nav pass collapsed when logged out + opened a full-bleed panel (user corrections) | agent-error | Designed without running the app (see #1); didn't reason about auth-conditional item counts | Doc note: verify responsive UI across widths AND auth states |
| 4 | `react-hooks/set-state-in-effect` lint error on close-menu effect | agent-error | Repo lint rule not documented | FRONTEND.md note + correct event-handler pattern |
| 5 | `git add web/next.config.ts` failed — cwd had drifted to `web/` | agent-error | Bash cwd persists across calls | AGENTS.md note: absolute paths / `git -C` |
| 6 | Reverse-engineered Draft Sharks DOM/scaling | missing-docs | New scrape source | Already documented in ARCHITECTURE.md during the task — no action |
| 7 | `timeout` not available on macOS | agent-error | Assumed GNU coreutils | One-off — no action |

## Files changed

- **justfile** — add `dev-stop` recipe (kills dev server + stray Turbopack/postcss workers), pre-approved via `Bash(just:*)` instead of raw `pkill` gates.
- **docs/FRONTEND.md** — explain the `turbopack.root` requirement (shared root `config.json`); add a "Local dev & verification" section (headless run/poll/curl/puppeteer loop, `just dev-stop`, verify across widths + auth states); document the `react-hooks/set-state-in-effect` rule and the correct pattern.
- **AGENTS.md** — note that Bash cwd persists across calls; use absolute paths or `git -C` after `cd web && …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)