### PR TITLE
feat: add lineup planner page

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -11,6 +11,7 @@ Next.js App Router. Most pages are server components that fetch live data from S
 | `/` | Player Efficiency scatter chart (PPG/PPS vs salary) |
 | `/players` | Searchable player directory |
 | `/rosters` | League-wide roster view |
+| `/lineup` | Lineup planner: build a starting lineup from any team's current roster and see the projected total (by projected PPG or last-season PPG) |
 | `/arb-progress` | Public arbitration progress: team completion status and allocation details |
 | `/arb-planner-public` | Public (read-only) arbitration planner view |
 | `/projected-salary` | Keep vs cut decisions for The Witchcraft |

--- a/web/app/lineup/LineupClient.tsx
+++ b/web/app/lineup/LineupClient.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import PositionBadge from "@/components/PositionBadge";
+import {
+  LINEUP_SLOTS,
+  SLOT_IDS,
+  emptyLineup,
+  optimizeLineup,
+  lineupTotal,
+  getMetricScore,
+  isEligible,
+  type Lineup,
+  type LineupMetric,
+  type LineupPlayer,
+  type SlotId,
+} from "@/lib/lineup";
+import type { LineupTeam } from "./page";
+
+interface Props {
+  teams: LineupTeam[];
+  hasProjections: boolean;
+  defaultTeam: string | null;
+}
+
+const fmt = (n: number) => n.toFixed(1);
+
+export default function LineupClient({ teams, hasProjections, defaultTeam }: Props) {
+  const [teamName, setTeamName] = useState<string>(
+    defaultTeam ?? teams[0]?.team_name ?? ""
+  );
+  const [metric, setMetric] = useState<LineupMetric>(
+    hasProjections ? "projected" : "last_season"
+  );
+  const [lineup, setLineup] = useState<Lineup>(emptyLineup());
+
+  const team = useMemo(
+    () => teams.find((t) => t.team_name === teamName) ?? null,
+    [teams, teamName]
+  );
+
+  const playerMap = useMemo(() => {
+    const m = new Map<string, LineupPlayer>();
+    for (const p of team?.players ?? []) m.set(p.player_id, p);
+    return m;
+  }, [team]);
+
+  // Switching team or metric resets the lineup so we never reference a player
+  // who is not on the selected roster.
+  const changeTeam = (name: string) => {
+    setTeamName(name);
+    setLineup(emptyLineup());
+  };
+
+  const optimize = () => {
+    if (team) setLineup(optimizeLineup(team.players, metric));
+  };
+  const clear = () => setLineup(emptyLineup());
+
+  // Set a slot's player, removing that player from any other slot it occupies.
+  const assign = (slotId: SlotId, playerId: string | null) => {
+    setLineup((prev) => {
+      const next = { ...prev };
+      if (playerId) {
+        for (const id of SLOT_IDS) {
+          if (next[id] === playerId) next[id] = null;
+        }
+      }
+      next[slotId] = playerId;
+      return next;
+    });
+  };
+
+  const total = useMemo(
+    () => lineupTotal(lineup, playerMap, metric),
+    [lineup, playerMap, metric]
+  );
+
+  const starterIds = useMemo(
+    () => new Set(SLOT_IDS.map((id) => lineup[id]).filter(Boolean) as string[]),
+    [lineup]
+  );
+
+  const bench = useMemo(
+    () =>
+      (team?.players ?? [])
+        .filter((p) => !starterIds.has(p.player_id))
+        .sort((a, b) => getMetricScore(b, metric) - getMetricScore(a, metric)),
+    [team, starterIds, metric]
+  );
+
+  const metricLabel = metric === "projected" ? "Projected PPG" : "2025 PPG";
+
+  return (
+    <main className="min-h-screen bg-white dark:bg-black p-8">
+      <div className="max-w-5xl mx-auto space-y-8">
+        <header>
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+            Lineup Planner
+          </h1>
+          <p className="text-slate-500 dark:text-slate-400 mt-2">
+            Build a starting lineup from any team&apos;s current roster and see
+            the projected total. Scores are per-game — using each player&apos;s{" "}
+            {hasProjections ? "projected PPG or " : ""}actual PPG from last
+            season.
+          </p>
+        </header>
+
+        {/* Controls */}
+        <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-5 border border-slate-200 dark:border-slate-800 flex flex-wrap items-end gap-6">
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="team-select"
+              className="text-sm font-medium text-slate-700 dark:text-slate-300"
+            >
+              Team
+            </label>
+            <select
+              id="team-select"
+              value={teamName}
+              onChange={(e) => changeTeam(e.target.value)}
+              className="rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-3 py-2 text-sm text-slate-900 dark:text-white"
+            >
+              {teams.map((t) => (
+                <option key={t.team_name} value={t.team_name}>
+                  {t.team_name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+              Score by
+            </span>
+            <div className="inline-flex rounded-md border border-slate-300 dark:border-slate-700 overflow-hidden">
+              <button
+                type="button"
+                onClick={() => hasProjections && setMetric("projected")}
+                disabled={!hasProjections}
+                title={
+                  hasProjections
+                    ? undefined
+                    : "Projections require an account with projections access"
+                }
+                className={`px-3 py-2 text-sm font-medium transition-colors ${
+                  metric === "projected"
+                    ? "bg-blue-600 text-white"
+                    : "bg-white dark:bg-slate-950 text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-900"
+                } disabled:opacity-40 disabled:cursor-not-allowed`}
+              >
+                Projected PPG
+              </button>
+              <button
+                type="button"
+                onClick={() => setMetric("last_season")}
+                className={`px-3 py-2 text-sm font-medium transition-colors border-l border-slate-300 dark:border-slate-700 ${
+                  metric === "last_season"
+                    ? "bg-blue-600 text-white"
+                    : "bg-white dark:bg-slate-950 text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-900"
+                }`}
+              >
+                2025 PPG
+              </button>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 ml-auto">
+            <button
+              type="button"
+              onClick={optimize}
+              className="px-4 py-2 text-sm font-medium rounded-md bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+            >
+              Optimize
+            </button>
+            <button
+              type="button"
+              onClick={clear}
+              className="px-4 py-2 text-sm font-medium rounded-md border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-900 transition-colors"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+
+        {/* Total */}
+        <div className="rounded-lg border border-blue-200 dark:border-blue-900 bg-blue-50 dark:bg-blue-950/40 px-5 py-4 flex items-baseline justify-between">
+          <span className="text-sm font-medium text-blue-900 dark:text-blue-200">
+            Projected lineup total ({metricLabel})
+          </span>
+          <span className="text-3xl font-bold tabular-nums text-blue-700 dark:text-blue-300">
+            {fmt(total)}
+          </span>
+        </div>
+
+        {/* Starting lineup */}
+        <section>
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+            Starting Lineup
+          </h2>
+          <div className="divide-y divide-slate-200 dark:divide-slate-800 border border-slate-200 dark:border-slate-800 rounded-lg overflow-hidden">
+            {LINEUP_SLOTS.map((slot) => {
+              const selectedId = lineup[slot.id];
+              const selected = selectedId ? playerMap.get(selectedId) : null;
+              const options = (team?.players ?? [])
+                .filter((p) => isEligible(slot, p.position))
+                .filter(
+                  (p) =>
+                    p.player_id === selectedId ||
+                    !starterIds.has(p.player_id)
+                )
+                .sort(
+                  (a, b) => getMetricScore(b, metric) - getMetricScore(a, metric)
+                );
+              return (
+                <div
+                  key={slot.id}
+                  className="flex items-center gap-3 px-4 py-2.5 bg-white dark:bg-slate-950"
+                >
+                  <span className="w-24 shrink-0 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    {slot.label}
+                  </span>
+                  <select
+                    value={selectedId ?? ""}
+                    onChange={(e) =>
+                      assign(slot.id, e.target.value || null)
+                    }
+                    className="flex-1 min-w-0 rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-2 py-1.5 text-sm text-slate-900 dark:text-white"
+                  >
+                    <option value="">— empty —</option>
+                    {options.map((p) => (
+                      <option key={p.player_id} value={p.player_id}>
+                        {p.name} ({p.position}, {p.nfl_team}) ·{" "}
+                        {fmt(getMetricScore(p, metric))}
+                      </option>
+                    ))}
+                  </select>
+                  <span className="w-14 shrink-0 text-right text-sm font-semibold tabular-nums text-slate-900 dark:text-white">
+                    {selected ? fmt(getMetricScore(selected, metric)) : "—"}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Bench */}
+        <section>
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+            Bench{" "}
+            <span className="text-sm font-normal text-slate-500 dark:text-slate-400">
+              ({bench.length})
+            </span>
+          </h2>
+          {bench.length === 0 ? (
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              No players available.
+            </p>
+          ) : (
+            <div className="border border-slate-200 dark:border-slate-800 rounded-lg overflow-hidden divide-y divide-slate-200 dark:divide-slate-800">
+              {bench.map((p) => (
+                <div
+                  key={p.player_id}
+                  className="flex items-center gap-3 px-4 py-2 bg-white dark:bg-slate-950 text-sm"
+                >
+                  <PositionBadge position={p.position} size="sm" />
+                  <span className="flex-1 min-w-0 truncate text-slate-900 dark:text-white">
+                    {p.name}
+                  </span>
+                  <span className="text-slate-400 dark:text-slate-500 text-xs">
+                    {p.nfl_team}
+                  </span>
+                  <span className="w-14 text-right tabular-nums font-medium text-slate-700 dark:text-slate-300">
+                    {fmt(getMetricScore(p, metric))}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/web/app/lineup/page.tsx
+++ b/web/app/lineup/page.tsx
@@ -1,0 +1,54 @@
+import {
+  fetchRosterData,
+  reconstructRostersAtDate,
+} from "@/lib/roster-reconstruction";
+import { fetchHoverExtras } from "@/lib/analysis";
+import { getAuthenticatedUser } from "@/lib/auth";
+import { MY_TEAM } from "@/lib/config";
+import type { LineupPlayer } from "@/lib/lineup";
+import LineupClient from "./LineupClient";
+
+export const revalidate = 3600;
+
+export interface LineupTeam {
+  team_name: string;
+  players: LineupPlayer[];
+}
+
+export default async function LineupPage() {
+  const [data, user] = await Promise.all([
+    fetchRosterData(),
+    getAuthenticatedUser(),
+  ]);
+  const hasProjections = !!user?.hasProjectionsAccess;
+  const { projMap } = await fetchHoverExtras(hasProjections);
+
+  const today = new Date().toISOString().slice(0, 10);
+  const rosters = reconstructRostersAtDate(
+    data.transactions,
+    data.players,
+    data.stats,
+    today,
+    data.leaguePrices
+  );
+
+  const teams: LineupTeam[] = rosters.map((r) => ({
+    team_name: r.team_name,
+    players: r.players.map((p) => ({
+      player_id: p.player_id,
+      name: p.name,
+      position: p.position,
+      nfl_team: p.nfl_team,
+      ppg: p.ppg ?? 0,
+      projected_ppg: projMap?.[p.player_id]?.ppg ?? 0,
+    })),
+  }));
+
+  return (
+    <LineupClient
+      teams={teams}
+      hasProjections={hasProjections}
+      defaultTeam={teams.some((t) => t.team_name === MY_TEAM) ? MY_TEAM : null}
+    />
+  );
+}

--- a/web/components/Navigation.tsx
+++ b/web/components/Navigation.tsx
@@ -39,6 +39,7 @@ const SOFA_LEAGUE_LINK = {
 
 const AUTHENTICATED_LINKS = [
   { href: "/arb-planner-public", label: "Arb Planner" },
+  { href: "/lineup", label: "Lineup" },
 ];
 
 const PRIVATE_GROUPS = [

--- a/web/lib/lineup.ts
+++ b/web/lib/lineup.ts
@@ -1,0 +1,130 @@
+/**
+ * Lineup planning logic for the Superflex starting lineup.
+ *
+ * Ottoneu League 309 starting lineup (9 starters):
+ *   1 QB, 2 RB, 2 WR, 1 TE, 1 FLEX (RB/WR/TE), 1 SUPERFLEX (QB/RB/WR/TE), 1 K.
+ *
+ * Scores are per-game (PPG) — either each player's projected PPG or their
+ * actual PPG from last season. The lineup "score" is the sum of the starters'
+ * chosen metric (i.e. projected points for one week's lineup).
+ */
+
+export type SlotId =
+  | "QB"
+  | "RB1"
+  | "RB2"
+  | "WR1"
+  | "WR2"
+  | "TE"
+  | "FLEX"
+  | "SUPERFLEX"
+  | "K";
+
+export interface SlotDef {
+  id: SlotId;
+  /** Display label (multiple slots can share a label, e.g. two "RB"). */
+  label: string;
+  /** Positions eligible to fill this slot. */
+  eligible: readonly string[];
+}
+
+/**
+ * Slot order is also the display order. Eligibility forms a laminar family
+ * ({RB} ⊂ {RB,WR,TE} ⊂ {QB,RB,WR,TE}, {QB} ⊂ superflex, {K} disjoint), which
+ * is what makes the greedy optimizer below provably optimal.
+ */
+export const LINEUP_SLOTS: readonly SlotDef[] = [
+  { id: "QB", label: "QB", eligible: ["QB"] },
+  { id: "RB1", label: "RB", eligible: ["RB"] },
+  { id: "RB2", label: "RB", eligible: ["RB"] },
+  { id: "WR1", label: "WR", eligible: ["WR"] },
+  { id: "WR2", label: "WR", eligible: ["WR"] },
+  { id: "TE", label: "TE", eligible: ["TE"] },
+  { id: "FLEX", label: "FLEX", eligible: ["RB", "WR", "TE"] },
+  { id: "SUPERFLEX", label: "SUPERFLEX", eligible: ["QB", "RB", "WR", "TE"] },
+  { id: "K", label: "K", eligible: ["K"] },
+];
+
+export const SLOT_IDS: readonly SlotId[] = LINEUP_SLOTS.map((s) => s.id);
+
+export interface LineupPlayer {
+  player_id: string;
+  name: string;
+  position: string;
+  nfl_team: string;
+  /** Actual PPG from last season (0 if the player did not play). */
+  ppg: number;
+  /** Projected PPG (0 when projections are unavailable). */
+  projected_ppg: number;
+}
+
+export type LineupMetric = "projected" | "last_season";
+
+export type Lineup = Record<SlotId, string | null>;
+
+export function emptyLineup(): Lineup {
+  return SLOT_IDS.reduce((acc, id) => {
+    acc[id] = null;
+    return acc;
+  }, {} as Lineup);
+}
+
+/** Score accessor for a player under the chosen metric. */
+export function getMetricScore(p: LineupPlayer, metric: LineupMetric): number {
+  return metric === "projected" ? p.projected_ppg : p.ppg;
+}
+
+export function isEligible(slot: SlotDef, position: string): boolean {
+  return slot.eligible.includes(position);
+}
+
+/**
+ * Greedy optimal lineup. Processes slots from the most restrictive (smallest
+ * eligible set) to the least restrictive, assigning the best remaining
+ * eligible player to each. Optimal because the eligibility family is laminar.
+ */
+export function optimizeLineup(
+  players: readonly LineupPlayer[],
+  metric: LineupMetric
+): Lineup {
+  const lineup = emptyLineup();
+  const used = new Set<string>();
+  const order = [...LINEUP_SLOTS].sort(
+    (a, b) => a.eligible.length - b.eligible.length
+  );
+
+  for (const slot of order) {
+    let best: LineupPlayer | null = null;
+    let bestScore = -Infinity;
+    for (const p of players) {
+      if (used.has(p.player_id)) continue;
+      if (!isEligible(slot, p.position)) continue;
+      const score = getMetricScore(p, metric);
+      if (score > bestScore) {
+        bestScore = score;
+        best = p;
+      }
+    }
+    if (best) {
+      lineup[slot.id] = best.player_id;
+      used.add(best.player_id);
+    }
+  }
+  return lineup;
+}
+
+/** Total of the starters' chosen metric. */
+export function lineupTotal(
+  lineup: Lineup,
+  playerMap: Map<string, LineupPlayer>,
+  metric: LineupMetric
+): number {
+  let total = 0;
+  for (const id of SLOT_IDS) {
+    const pid = lineup[id];
+    if (!pid) continue;
+    const p = playerMap.get(pid);
+    if (p) total += getMetricScore(p, metric);
+  }
+  return total;
+}


### PR DESCRIPTION
Add a /lineup page to build a starting lineup from any team's current
roster and see the projected total score. Players can be scored by their
projected PPG or their actual PPG from last season.

The Superflex starting lineup (1 QB, 2 RB, 2 WR, 1 TE, 1 FLEX, 1
SUPERFLEX, 1 K) is modeled in web/lib/lineup.ts, including a greedy
optimizer that is optimal given the laminar slot-eligibility structure.
The page works for any team and falls back to last-season PPG when the
viewer lacks projections access.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
