### PR TITLE
fix: add Cameron Skattebo name alias for Draft Sharks scraper

### DIFF
--- a/scripts/name_utils.py
+++ b/scripts/name_utils.py
@@ -12,6 +12,7 @@ WHITESPACE_REGEX = re.compile(r'\s+')
 # Add entries when a player's common/NFL name differs from their Ottoneu name.
 NAME_ALIASES: dict[str, str] = {
     "Cam Ward": "Cameron Ward",
+    "Cameron Skattebo": "Cam Skattebo",
 }
 
 


### PR DESCRIPTION
## Problem
Cam Skattebo was missing Draft Sharks auction values on the site. Draft Sharks lists him as **\"Cameron Skattebo\"** while Ottoneu/our DB uses **\"Cam Skattebo\"**, so the scraper's `(normalized_name, position)` match failed and no `draft_sharks_values` row was ever written for him — identical to the existing `Cam Ward → Cameron Ward` case.

## Fix
Add a `Cameron Skattebo → Cam Skattebo` entry to `NAME_ALIASES` in `scripts/name_utils.py`.

After this, an RB scrape matches him (Matched 118 vs 117 prior) and writes `ds_auction_value=30`, `market_auction_value=22` (season 2026, $400 scale). Verified the row landed in `draft_sharks_values`.

## Note (not in this PR)
While debugging, I found the venv editable install had pinned the `scripts` package to a stale `.claude/worktrees/` path, so `venv/bin/python scripts/...` was running old source and masking the fix. Resolved locally by re-running `pip install -e .` from the main checkout — no repo change needed, but worth being aware of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)