### PR TITLE
feat: add date-driven season-cycle resolver foundation

### DIFF
--- a/.github/workflows/scrape-league-calendar.yml
+++ b/.github/workflows/scrape-league-calendar.yml
@@ -1,0 +1,64 @@
+name: Scrape League Calendar
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+
+  # Weekly — boundary dates change rarely, but the auction date gets set
+  # mid-cycle and the season label rolls over each January.
+  schedule:
+    - cron: "0 12 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install --only-binary pandas,numpy playwright supabase python-dotenv pandas numpy
+          # Install this repo as a package so `import scripts.*` resolves
+          pip install -e . --no-deps
+
+      - name: Install Playwright browsers
+        run: playwright install --with-deps chromium
+
+      - name: Create .env
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          FANGRAPHS_USERNAME: ${{ secrets.FANGRAPHS_USERNAME }}
+          FANGRAPHS_PASSWORD: ${{ secrets.FANGRAPHS_PASSWORD }}
+        run: |
+          python -c "
+          import os
+          keys = ['SUPABASE_URL', 'SUPABASE_KEY', 'FANGRAPHS_USERNAME', 'FANGRAPHS_PASSWORD']
+          with open('.env', 'w') as f:
+              for k in keys:
+                  f.write(f'{k}={os.environ[k]}\n')
+          "
+
+      - name: Scrape league calendar
+        run: python scripts/scrape_league_calendar.py
+
+      - name: Upload debug artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-screenshots
+          path: debug/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,8 @@ docs/
 │   ├── [feature-projections.md](docs/exec-plans/feature-projections.md)         # Feature-based player projection system
 │   ├── [market-projections.md](docs/exec-plans/market-projections.md)          # Market-based projection system (DEFERRED)
 │   ├── [projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md)  # 4-phase accuracy improvement roadmap
-│   └── [qb-usage-share.md](docs/exec-plans/qb-usage-share.md)              # QB Usage Share findings and next steps
+│   ├── [qb-usage-share.md](docs/exec-plans/qb-usage-share.md)              # QB Usage Share findings and next steps
+│   └── [season-cycle.md](docs/exec-plans/season-cycle.md)                # Cross-season data & UI scheme (date-driven season-cycle resolver)
 ├── generated/
 │   ├── [db-schema.md](docs/generated/db-schema.md)                   # Database tables, keys, relationships
 │   ├── [experiment-log.md](docs/generated/experiment-log.md)              # History of all model iteration attempts

--- a/Justfile
+++ b/Justfile
@@ -162,6 +162,10 @@ seed-win-totals *args:
 scrape-draft-sharks *args:
     {{python}} scripts/scrape_draft_sharks.py {{args}}
 
+# Scrape the Ottoneu finances Calendar into league_calendar (drives the season-cycle resolver)
+scrape-calendar *args:
+    {{python}} scripts/scrape_league_calendar.py {{args}}
+
 # ──────────────────────────────────────────────
 # Ad-hoc DB queries
 # ──────────────────────────────────────────────

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -124,6 +124,7 @@ just backfill-draft-capital [--since YYYY] [--dry-run] # Backfill draft_capital 
 just backfill-vegas [--since YYYY] [--dry-run]         # Backfill team_vegas_lines from nflverse games.csv
 just seed-win-totals --season YYYY                     # Upsert preseason sportsbook win totals (implied_total left NULL until schedule drops)
 just scrape-draft-sharks [--season YYYY] [--positions qb rb wr te] [--dry-run]  # Scrape Draft Sharks Half-PPR Superflex auction values (stored ×2 for the $400 cap)
+just scrape-calendar [--dry-run]                      # Scrape the Ottoneu finances Calendar into league_calendar (drives the season-cycle resolver)
 
 # Ad-hoc DB queries
 just py "<python-snippet>"                          # Run a one-off Python snippet against the project venv (read-only diagnostics)
@@ -145,3 +146,8 @@ just py "<python-snippet>"                          # Run a one-off Python snipp
   (Mondays 08:00 UTC) and on manual `workflow_dispatch`. Runs `scripts/scrape_draft_sharks.py`
   via Playwright; no in-season gate (auction values matter year-round). Requires the
   `SUPABASE_URL` / `SUPABASE_KEY` repo secrets.
+- `.github/workflows/scrape-league-calendar.yml` — scrapes the Ottoneu finances Calendar
+  weekly (Mondays 12:00 UTC) and on manual `workflow_dispatch`. Runs
+  `scripts/scrape_league_calendar.py` via Playwright (FanGraphs login required) to refresh
+  `league_calendar`, the source of truth for the season-cycle resolver. Requires the
+  `SUPABASE_URL` / `SUPABASE_KEY` / `FANGRAPHS_USERNAME` / `FANGRAPHS_PASSWORD` repo secrets.

--- a/docs/exec-plans/season-cycle.md
+++ b/docs/exec-plans/season-cycle.md
@@ -1,0 +1,102 @@
+# Season Cycle — cross-season data & UI scheme
+
+**Status:** In progress (PR #1 of 4 — foundation)
+
+## Problem
+
+The Ottoneu year is continuous: an NFL in-season plus a multi-stage offseason
+(arbitration, keeper/cut, auction draft). The site must flip between seasons
+seamlessly as the calendar advances while keeping prior-season data accessible.
+Today "which season is current" is a hand-maintained `config.json` constant
+(`SEASON`) plus two hand-typed dates — which go stale (as of 2026-06-01 the
+config still said `SEASON: 2025`). Projection year was inconsistently
+`SEASON+1` (Python) vs hardcoded `2026` (web) vs `eq("season", SEASON)` = 2025
+(stats/VORP) — three different notions of "now".
+
+## Core idea: one date-driven resolver; everything derives from it
+
+Ottoneu's **finances page** (`/football/{league}/finances`) publishes a Calendar
+section that *declares the current season label and every boundary date*:
+
+```
+These are the important dates for the 2026 season
+Start of Season         - January 3, 2026     (annual rollover)
+Start of Arbitration    - February 15, 2026
+End of Arbitration      - March 31, 2026
+Keeper Deadline         - July 31, 2026
+Auction Draft           - (often "not set yet")
+Start of Regular Season - September 4, 2026    (NFL Week 1)
+Trade Deadline          - November 25, 2026
+Last day to start auctions - December 30, 2026
+```
+
+So the Ottoneu "2026 season" runs **Jan 3 2026 → Jan 3 2027**. We scrape these
+dates into a `league_calendar` table; a resolver maps `today → { phase,
+leagueSeason, statsSeason, projectionSeason, … }`. The season is never inferred
+— Ottoneu states it.
+
+### The one advancing pointer — `leagueSeason`
+
+`leagueSeason` = the Ottoneu season label = the row whose
+`[season_start, next season_start)` window contains today. It increments once a
+year at **Start of Season**. Everything else derives:
+
+| Field | Rule |
+|---|---|
+| `leagueSeason` | calendar row with latest `season_start` ≤ today |
+| `projectionSeason` | = `leagueSeason` (what projections target) |
+| `statsSeason` | = `leagueSeason` if NFL games have started (≥ `regular_season_start`), else `leagueSeason − 1` (last completed) |
+| `arbitrationSeason` | = `leagueSeason` |
+
+### Phases (4, matching the offseason → in-season cycle)
+
+Within season label Y:
+
+| Phase | Window | Roster snapshot default | Featured |
+|---|---|---|---|
+| `pre_arb` | `season_start` → `arb_end` | today | arbitration planner (`arbWindowOpen` once ≥ `arb_start`) |
+| `pre_keeper` | `arb_end` → `keeper_deadline` | today | keeper / cut tools |
+| `pre_draft` | `keeper_deadline` → `regular_season_start` | **pre-draft** | auction / draft tools |
+| `in_season` | `regular_season_start` → next `season_start` | today | live VORP / standings |
+
+Snapshot flips to "pre-draft" exactly at the keeper deadline, per the spec.
+`arbitrationSeason` data resets for free at rollover: arb tables are
+season-scoped, so the resolver simply repoints to the new `leagueSeason`; the
+prior season persists as history.
+
+### Override
+
+`SEASON_OVERRIDE` / `PHASE_OVERRIDE` env vars short-circuit the date math
+(testing or off-schedule Ottoneu events). Date-driven by default, manual escape
+hatch always available — this is the antidote to the stale-config problem.
+
+## Data model — `league_calendar`
+
+`(league_id, season)` PK. Columns: `season_start`, `arb_start`, `arb_end`,
+`keeper_deadline`, `auction_date` (nullable), `regular_season_start`,
+`trade_deadline`, `last_auction_date`, `raw` (jsonb label→string map for
+resilience), `scraped_at`. Prior cycles persist as rows → historical access is
+automatic.
+
+## Sequencing (one PR each)
+
+1. **Foundation (this PR):** `league_calendar` table + scraper
+   (`scripts/scrape_league_calendar.py`, `just scrape-calendar`) + resolvers
+   (`scripts/season.py`, `web/lib/season.ts`) with override + tests.
+   Behavior-preserving — nothing consumes the resolver yet.
+2. **Migrate call sites** off static `SEASON` → `statsSeason` /
+   `projectionSeason` / `arbitrationSeason`. Removes the three-way "now" split.
+3. **Phase-driven UI** — featured nav/landing per phase, roster snapshot default
+   & bounds (`roster-reconstruction.ts` hardcoded `2025-09-01`/`today`), phase
+   banner with next-boundary countdown.
+4. **Cleanup** — remove static `SEASON` / `SEASON_END_DATE` / `PRE_ARB_DATE`
+   from `config.json`.
+
+## Wiring
+
+- Scraper logs in via FanGraphs (`FANGRAPHS_USERNAME`/`PASSWORD`), parses the
+  finances Calendar section, upserts one row per season label. Add to the cron
+  pipeline alongside the other scrapers.
+- Resolvers read `league_calendar` (web via Supabase client, Python via the
+  shared client) with an in-memory fallback so a missing/partial row degrades to
+  month-based phase inference rather than hard-failing.

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -37,6 +37,7 @@ The Supabase project (`OttoneuDB`, ref `rbinbcwinchphipvcfqk`) is **shared with 
 | `arbitration_allocation_details` | Per-team individual allocation breakdowns (which team allocated how much to which player) | `(league_id, season, ottoneu_id, allocating_team_name)` |
 | `draft_capital` | NFL draft pick metadata sourced from nflverse `draft_picks` (FK -> `players`) | `(player_id)` |
 | `draft_sharks_values` | Draft Sharks Half-PPR Superflex auction values, scraped per player per season by `scripts/scrape_draft_sharks.py` and stored at $400-cap scale (site values are ×2). Columns: `ds_auction_value`, `market_auction_value` (FK -> `players`) | `(player_id, season)` |
+| `league_calendar` | Per-season Ottoneu boundary dates (`season_start`, `arb_start`, `arb_end`, `keeper_deadline`, `auction_date`, `regular_season_start`, `trade_deadline`, `last_auction_date`, `raw` jsonb). Scraped from the league finances page by `scripts/scrape_league_calendar.py`; the source of truth for the season-cycle resolver (`scripts/season.py`, `web/lib/season.ts`). | `(league_id, season)` |
 | `team_vegas_lines` | Per-team-season Vegas implied total + win total. `implied_total` is aggregated per-game from nflverse `games.csv` and is **nullable** (migration 025) — preseason win totals publish months before the NFL schedule, so the column stays NULL until per-game lines are available. `win_total` is Pythagorean (back-calculated from per-game implied totals) for past seasons, or the sportsbook preseason consensus seeded via `scripts/seed_preseason_win_totals.py` for upcoming seasons. | `(team, season)` |
 
 ### Projection tables detail
@@ -88,7 +89,7 @@ Advanced receiving (added in migration 022, populated for 2018+ via nflverse `st
 
 All public tables have RLS enabled. Server-side code uses the Supabase **service key** (Python via `scripts.config.get_supabase_client()`, Next.js writes via `web/lib/supabase.supabaseAdmin`) which bypasses RLS. The anon key is restricted to read-only access on a curated set of public reference data.
 
-**Tables with an anon SELECT policy** (web reads via the anon client): `players`, `player_stats`, `nfl_stats`, `league_prices`, `transactions`, `surplus_adjustments`, `player_projections`, `projection_models`, `model_projections`, `backtest_results`, `arbitration_progress`, `arbitration_progress_teams`, `arbitration_allocation_details`, `team_vegas_lines`, `draft_sharks_values`.
+**Tables with an anon SELECT policy** (web reads via the anon client): `players`, `player_stats`, `nfl_stats`, `league_prices`, `transactions`, `surplus_adjustments`, `player_projections`, `projection_models`, `model_projections`, `backtest_results`, `arbitration_progress`, `arbitration_progress_teams`, `arbitration_allocation_details`, `team_vegas_lines`, `draft_sharks_values`, `league_calendar`.
 
 **Tables with no anon policy** (server-only, anon fully blocked): `users`, `arbitration_plans`, `arbitration_plan_allocations`, `scraper_jobs`, `draft_capital`.
 

--- a/scripts/scrape_league_calendar.py
+++ b/scripts/scrape_league_calendar.py
@@ -1,0 +1,160 @@
+"""Scrape the Ottoneu finances page Calendar section into `league_calendar`.
+
+Usage:
+    venv/bin/python scripts/scrape_league_calendar.py
+    venv/bin/python scripts/scrape_league_calendar.py --dry-run
+
+Requires FANGRAPHS_USERNAME and FANGRAPHS_PASSWORD env vars (the finances page is
+only visible to logged-in league members).
+
+The finances page (https://ottoneu.fangraphs.com/football/{league_id}/finances)
+has a "Calendar" section that declares the current season label and every
+boundary date, e.g.:
+
+    These are the important dates for the 2026 season
+    Start of Season - January 3, 2026
+    Start of Arbitration - February 15, 2026
+    End of Arbitration - March 31, 2026
+    Keeper Deadline - July 31, 2026 11:59 PM EDT
+    Auction Draft - Draft day has not been set yet
+    Start of Regular Season - September 4, 2026
+    Trade Deadline - November 25, 2026 11:59 PM EST
+    Last day to start auctions - December 30, 2026
+
+We upsert one row per season label into `league_calendar`, the source of truth
+for the season-cycle resolver (scripts/season.py, web/lib/season.ts).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+import sys
+from datetime import datetime
+
+from playwright.async_api import async_playwright
+
+from scripts.config import LEAGUE_ID, get_supabase_client
+from scripts.scrape_arbitration_progress import _login_to_fangraphs, _save_debug_screenshot
+
+FINANCES_URL_TEMPLATE = "https://ottoneu.fangraphs.com/football/{league_id}/finances"
+
+# Ottoneu calendar label -> league_calendar column.
+LABEL_TO_COLUMN = {
+    "Start of Season": "season_start",
+    "Start of Arbitration": "arb_start",
+    "End of Arbitration": "arb_end",
+    "Keeper Deadline": "keeper_deadline",
+    "Auction Draft": "auction_date",
+    "Start of Regular Season": "regular_season_start",
+    "Trade Deadline": "trade_deadline",
+    "Last day to start auctions": "last_auction_date",
+}
+
+SEASON_HEADER_REGEX = re.compile(r"important dates for the (\d{4}) season", re.IGNORECASE)
+# Matches "Month Day, Year" anywhere in the value (ignores trailing time/timezone).
+DATE_REGEX = re.compile(r"([A-Z][a-z]+ \d{1,2}, \d{4})")
+
+
+def _parse_date(value: str) -> str | None:
+    """Parse 'July 31, 2026 11:59 PM EDT' -> '2026-07-31'. Returns None if unset."""
+    match = DATE_REGEX.search(value)
+    if not match:
+        return None
+    try:
+        return datetime.strptime(match.group(1), "%B %d, %Y").date().isoformat()
+    except ValueError:
+        return None
+
+
+def parse_calendar(body_text: str) -> dict | None:
+    """Parse the finances page body text into a league_calendar row dict.
+
+    Returns None if the season header cannot be located.
+    """
+    header = SEASON_HEADER_REGEX.search(body_text)
+    if not header:
+        return None
+    season = int(header.group(1))
+
+    raw: dict[str, str] = {}
+    row: dict[str, object] = {"season": season}
+    for line in body_text.splitlines():
+        # Split on the first dash separator (hyphen or en dash): "Label - value".
+        parts = re.split(r"\s[-–]\s", line.strip(), maxsplit=1)
+        if len(parts) != 2:
+            continue
+        label, value = parts[0].strip(), parts[1].strip()
+        if label not in LABEL_TO_COLUMN:
+            continue
+        raw[label] = value
+        row[LABEL_TO_COLUMN[label]] = _parse_date(value)
+
+    if not raw:
+        return None
+    row["raw"] = raw
+    return row
+
+
+async def scrape_league_calendar(league_id: int) -> dict | None:
+    """Scrape the finances Calendar section; returns the parsed row dict."""
+    url = FINANCES_URL_TEMPLATE.format(league_id=league_id)
+    print(f"Scraping league calendar: {url}")
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        context = await browser.new_context(
+            user_agent=(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/120.0.0.0 Safari/537.36"
+            )
+        )
+        page = await context.new_page()
+        try:
+            await _login_to_fangraphs(page, url)
+            if "/finances" not in page.url:
+                await page.goto(url, timeout=60000)
+            await page.wait_for_timeout(2000)
+
+            body_text = await page.inner_text("body")
+            row = parse_calendar(body_text)
+            if row is None:
+                print("Could not locate the Calendar section on the finances page.")
+                await _save_debug_screenshot(page, "finances-calendar-missing")
+            return row
+        finally:
+            await browser.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scrape the Ottoneu league calendar.")
+    parser.add_argument("--league-id", type=int, default=LEAGUE_ID)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Parse and print without writing to the database.")
+    args = parser.parse_args()
+
+    row = asyncio.run(scrape_league_calendar(args.league_id))
+    if row is None:
+        sys.exit(1)
+
+    row["league_id"] = args.league_id
+    print(f"Parsed calendar for {row['season']} season:")
+    for key, value in row.items():
+        if key not in ("raw", "league_id"):
+            print(f"  {key}: {value}")
+
+    if args.dry_run:
+        print("Dry run — not writing to the database.")
+        return
+
+    supabase = get_supabase_client()
+    supabase.table("league_calendar").upsert(
+        row, on_conflict="league_id,season"
+    ).execute()
+    print(f"Upserted league_calendar row for league {args.league_id}, season {row['season']}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/season.py
+++ b/scripts/season.py
@@ -1,0 +1,185 @@
+"""Season-cycle resolver: map a date to the league's position in its annual cycle.
+
+The Ottoneu year is continuous (an NFL in-season plus a multi-stage offseason:
+arbitration, keeper/cut, auction draft). This module is the single source of
+truth for "what season are we in and what phase of the cycle" — every other
+script and the web app (see web/lib/season.ts, a TS twin of this logic) derive
+their season from it instead of a hand-maintained constant.
+
+Boundary dates come from the `league_calendar` table (scraped from the Ottoneu
+finances page by scripts/scrape_league_calendar.py). Ottoneu declares the season
+label itself, so the season is never inferred when calendar data exists.
+
+Phases (within season label Y):
+    pre_arb      season_start      -> arb_end              (arbitration window)
+    pre_keeper   arb_end           -> keeper_deadline      (keep/cut decisions)
+    pre_draft    keeper_deadline   -> regular_season_start (auction draft)
+    in_season    regular_season_start -> next season_start (NFL games played)
+
+Override: SEASON_OVERRIDE / PHASE_OVERRIDE env vars short-circuit the result
+(testing or off-schedule events). Date-driven by default, manual escape hatch
+always available.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+from typing import Optional
+
+from scripts.config import LEAGUE_ID
+
+PHASES = ("pre_arb", "pre_keeper", "pre_draft", "in_season")
+
+
+def _as_date(value) -> Optional[date]:
+    if value is None or value == "":
+        return None
+    if isinstance(value, date):
+        return value
+    return date.fromisoformat(str(value)[:10])
+
+
+def _phase_from_row(today: date, row: dict) -> str:
+    """Phase within the active calendar row, using its milestone dates."""
+    arb_end = _as_date(row.get("arb_end"))
+    keeper_deadline = _as_date(row.get("keeper_deadline"))
+    regular_season_start = _as_date(row.get("regular_season_start"))
+    if arb_end and today < arb_end:
+        return "pre_arb"
+    if keeper_deadline and today < keeper_deadline:
+        return "pre_keeper"
+    if regular_season_start and today < regular_season_start:
+        return "pre_draft"
+    return "in_season"
+
+
+def _fallback_context(today: date) -> dict:
+    """Month-based phase inference when no calendar row is available.
+
+    Uses typical Ottoneu football boundaries so the resolver degrades gracefully
+    rather than hard-failing on a missing/partial calendar.
+    """
+    year = today.year
+    month = today.month
+    if month >= 9:                 # Sep-Dec: NFL season
+        phase, league_season = "in_season", year
+    elif month < 4:               # Jan-Mar: arbitration window
+        phase, league_season = "pre_arb", year
+    elif month < 8:               # Apr-Jul: post-arb, pre-keeper
+        phase, league_season = "pre_keeper", year
+    else:                          # Aug: post-keeper, pre-draft
+        phase, league_season = "pre_draft", year
+    stats_season = league_season if phase == "in_season" else league_season - 1
+    return {
+        "phase": phase,
+        "league_season": league_season,
+        "projection_season": league_season,
+        "stats_season": stats_season,
+        "arbitration_season": league_season,
+        "arb_window_open": phase == "pre_arb",
+        "deadlines": {},
+        "next_boundary": None,
+        "source": "fallback",
+    }
+
+
+def get_season_context(
+    today: Optional[date] = None,
+    calendar_rows: Optional[list[dict]] = None,
+    league_id: int = LEAGUE_ID,
+) -> dict:
+    """Resolve the season context for a date.
+
+    Args:
+        today: Date to resolve (default: today). Pass a fixed date in tests.
+        calendar_rows: league_calendar rows; fetched from the DB if omitted.
+        league_id: League to resolve for.
+
+    Returns a dict with: phase, league_season, projection_season, stats_season,
+    arbitration_season, arb_window_open, deadlines, next_boundary, source.
+    """
+    if today is None:
+        today = date.today()
+
+    if calendar_rows is None:
+        calendar_rows = _fetch_calendar(league_id)
+
+    rows = [r for r in (calendar_rows or []) if r.get("league_id", league_id) == league_id]
+    # Active row: latest season_start on or before today.
+    dated = [(s, r) for r in rows if (s := _as_date(r.get("season_start"))) is not None]
+    active = max((r for s, r in dated if s <= today),
+                 key=lambda r: _as_date(r["season_start"]), default=None)
+
+    if active is None:
+        ctx = _fallback_context(today)
+    else:
+        phase = _phase_from_row(today, active)
+        league_season = int(active["season"])
+        regular_season_start = _as_date(active.get("regular_season_start"))
+        stats_season = (
+            league_season
+            if regular_season_start and today >= regular_season_start
+            else league_season - 1
+        )
+        arb_start = _as_date(active.get("arb_start"))
+        arb_end = _as_date(active.get("arb_end"))
+        deadlines = {
+            k: active.get(k)
+            for k in ("season_start", "arb_start", "arb_end", "keeper_deadline",
+                      "auction_date", "regular_season_start", "trade_deadline",
+                      "last_auction_date")
+            if active.get(k)
+        }
+        future = sorted(d for d in (_as_date(v) for v in deadlines.values()) if d and d > today)
+        ctx = {
+            "phase": phase,
+            "league_season": league_season,
+            "projection_season": league_season,
+            "stats_season": stats_season,
+            "arbitration_season": league_season,
+            "arb_window_open": bool(arb_start and arb_end and arb_start <= today < arb_end),
+            "deadlines": deadlines,
+            "next_boundary": future[0].isoformat() if future else None,
+            "source": "calendar",
+        }
+
+    return _apply_overrides(ctx)
+
+
+def _apply_overrides(ctx: dict) -> dict:
+    """Apply SEASON_OVERRIDE / PHASE_OVERRIDE env vars on top of the computed context."""
+    season_override = os.getenv("SEASON_OVERRIDE")
+    phase_override = os.getenv("PHASE_OVERRIDE")
+    if season_override:
+        season = int(season_override)
+        ctx["league_season"] = season
+        ctx["projection_season"] = season
+        ctx["arbitration_season"] = season
+        ctx["stats_season"] = season if ctx["phase"] == "in_season" else season - 1
+        ctx["source"] = "override"
+    if phase_override:
+        if phase_override not in PHASES:
+            raise ValueError(f"PHASE_OVERRIDE must be one of {PHASES}, got {phase_override!r}")
+        ctx["phase"] = phase_override
+        ctx["arb_window_open"] = phase_override == "pre_arb"
+        ctx["source"] = "override"
+    return ctx
+
+
+def _fetch_calendar(league_id: int) -> list[dict]:
+    from scripts.config import get_supabase_client
+    supabase = get_supabase_client()
+    return (
+        supabase.table("league_calendar")
+        .select("*")
+        .eq("league_id", league_id)
+        .execute()
+        .data
+        or []
+    )
+
+
+if __name__ == "__main__":
+    import json
+    print(json.dumps(get_season_context(), indent=2, default=str))

--- a/scripts/tests/test_season.py
+++ b/scripts/tests/test_season.py
@@ -1,0 +1,120 @@
+"""Tests for the season-cycle resolver (scripts/season.py).
+
+Pure logic: calendar rows and the date are injected, so no DB/network access.
+Kept in sync with web/__tests__/lib/season.test.ts (the TS twin).
+"""
+from datetime import date
+
+import pytest
+
+from scripts import season
+from scripts.season import get_season_context
+
+CAL_2026 = {
+    "league_id": 309,
+    "season": 2026,
+    "season_start": "2026-01-03",
+    "arb_start": "2026-02-15",
+    "arb_end": "2026-03-31",
+    "keeper_deadline": "2026-07-31",
+    "auction_date": None,
+    "regular_season_start": "2026-09-04",
+    "trade_deadline": "2026-11-25",
+    "last_auction_date": "2026-12-30",
+}
+CAL_2027 = {
+    **CAL_2026,
+    "season": 2027,
+    "season_start": "2027-01-03",
+    "arb_start": "2027-02-15",
+    "arb_end": "2027-03-31",
+    "keeper_deadline": "2027-07-31",
+    "regular_season_start": "2027-09-04",
+    "trade_deadline": "2027-11-25",
+    "last_auction_date": "2027-12-30",
+}
+CAL = [CAL_2026, CAL_2027]
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides(monkeypatch):
+    monkeypatch.delenv("SEASON_OVERRIDE", raising=False)
+    monkeypatch.delenv("PHASE_OVERRIDE", raising=False)
+
+
+def ctx(today: str):
+    return get_season_context(date.fromisoformat(today), calendar_rows=CAL)
+
+
+def test_pre_arb_during_arbitration_window():
+    c = ctx("2026-02-20")
+    assert c["phase"] == "pre_arb"
+    assert c["league_season"] == 2026
+    assert c["projection_season"] == 2026
+    assert c["stats_season"] == 2025  # no 2026 NFL games yet
+    assert c["arb_window_open"] is True
+
+
+def test_pre_keeper_between_arb_end_and_keeper_deadline():
+    c = ctx("2026-06-01")
+    assert c["phase"] == "pre_keeper"
+    assert c["stats_season"] == 2025
+    assert c["arb_window_open"] is False
+    assert c["next_boundary"] == "2026-07-31"
+
+
+def test_pre_draft_between_keeper_and_regular_season():
+    c = ctx("2026-08-15")
+    assert c["phase"] == "pre_draft"
+    assert c["stats_season"] == 2025
+
+
+def test_in_season_flips_stats_to_league_season():
+    c = ctx("2026-10-01")
+    assert c["phase"] == "in_season"
+    assert c["stats_season"] == 2026
+    assert c["projection_season"] == 2026
+
+
+def test_in_season_after_nfl_season_before_rollover():
+    c = ctx("2027-01-01")
+    assert c["phase"] == "in_season"
+    assert c["league_season"] == 2026  # not yet rolled
+    assert c["stats_season"] == 2026
+
+
+def test_rollover_at_start_of_season():
+    c = ctx("2027-01-03")
+    assert c["league_season"] == 2027
+    assert c["phase"] == "pre_arb"
+    assert c["projection_season"] == 2027
+    assert c["stats_season"] == 2026
+
+
+def test_fallback_with_no_calendar():
+    c = get_season_context(date(2026, 6, 1), calendar_rows=[])
+    assert c["source"] == "fallback"
+    assert c["phase"] == "pre_keeper"
+    assert c["league_season"] == 2026
+
+
+def test_season_override(monkeypatch):
+    monkeypatch.setenv("SEASON_OVERRIDE", "2030")
+    c = ctx("2026-06-01")
+    assert c["league_season"] == 2030
+    assert c["projection_season"] == 2030
+    assert c["stats_season"] == 2029
+    assert c["source"] == "override"
+
+
+def test_phase_override(monkeypatch):
+    monkeypatch.setenv("PHASE_OVERRIDE", "in_season")
+    c = ctx("2026-06-01")
+    assert c["phase"] == "in_season"
+    assert c["arb_window_open"] is False
+
+
+def test_invalid_phase_override(monkeypatch):
+    monkeypatch.setenv("PHASE_OVERRIDE", "nonsense")
+    with pytest.raises(ValueError):
+        ctx("2026-06-01")

--- a/web/__tests__/lib/season.test.ts
+++ b/web/__tests__/lib/season.test.ts
@@ -1,0 +1,115 @@
+// Mock the supabase client to prevent real initialization in Jest.
+jest.mock("@/lib/supabase", () => ({ supabase: {} }));
+
+import { getSeasonContext, LeagueCalendarRow } from "@/lib/season";
+
+const CAL_2026: LeagueCalendarRow = {
+  league_id: 309,
+  season: 2026,
+  season_start: "2026-01-03",
+  arb_start: "2026-02-15",
+  arb_end: "2026-03-31",
+  keeper_deadline: "2026-07-31",
+  auction_date: null,
+  regular_season_start: "2026-09-04",
+  trade_deadline: "2026-11-25",
+  last_auction_date: "2026-12-30",
+};
+const CAL_2027: LeagueCalendarRow = {
+  ...CAL_2026,
+  season: 2027,
+  season_start: "2027-01-03",
+  arb_start: "2027-02-15",
+  arb_end: "2027-03-31",
+  keeper_deadline: "2027-07-31",
+  regular_season_start: "2027-09-04",
+  trade_deadline: "2027-11-25",
+  last_auction_date: "2027-12-30",
+};
+const CAL = [CAL_2026, CAL_2027];
+
+describe("getSeasonContext", () => {
+  const ORIGINAL_ENV = process.env;
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.SEASON_OVERRIDE;
+    delete process.env.PHASE_OVERRIDE;
+  });
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("resolves pre_arb during the arbitration window", () => {
+    const ctx = getSeasonContext(CAL, "2026-02-20");
+    expect(ctx.phase).toBe("pre_arb");
+    expect(ctx.leagueSeason).toBe(2026);
+    expect(ctx.projectionSeason).toBe(2026);
+    expect(ctx.statsSeason).toBe(2025); // no 2026 NFL games yet
+    expect(ctx.arbWindowOpen).toBe(true);
+  });
+
+  it("resolves pre_keeper between arb end and keeper deadline", () => {
+    const ctx = getSeasonContext(CAL, "2026-06-01");
+    expect(ctx.phase).toBe("pre_keeper");
+    expect(ctx.leagueSeason).toBe(2026);
+    expect(ctx.statsSeason).toBe(2025);
+    expect(ctx.arbWindowOpen).toBe(false);
+    expect(ctx.nextBoundary).toBe("2026-07-31");
+  });
+
+  it("resolves pre_draft between keeper deadline and regular season", () => {
+    const ctx = getSeasonContext(CAL, "2026-08-15");
+    expect(ctx.phase).toBe("pre_draft");
+    expect(ctx.statsSeason).toBe(2025);
+  });
+
+  it("resolves in_season once NFL games start; stats flip to leagueSeason", () => {
+    const ctx = getSeasonContext(CAL, "2026-10-01");
+    expect(ctx.phase).toBe("in_season");
+    expect(ctx.statsSeason).toBe(2026);
+    expect(ctx.projectionSeason).toBe(2026);
+  });
+
+  it("stays in_season after the NFL season ends, before next rollover", () => {
+    const ctx = getSeasonContext(CAL, "2027-01-01");
+    expect(ctx.phase).toBe("in_season");
+    expect(ctx.leagueSeason).toBe(2026); // not yet rolled to 2027
+    expect(ctx.statsSeason).toBe(2026);
+  });
+
+  it("rolls leagueSeason forward at Start of Season", () => {
+    const ctx = getSeasonContext(CAL, "2027-01-03");
+    expect(ctx.leagueSeason).toBe(2027);
+    expect(ctx.phase).toBe("pre_arb");
+    expect(ctx.projectionSeason).toBe(2027); // now projecting next season
+    expect(ctx.statsSeason).toBe(2026);
+  });
+
+  it("falls back to month inference with no calendar rows", () => {
+    const ctx = getSeasonContext([], "2026-06-01");
+    expect(ctx.source).toBe("fallback");
+    expect(ctx.phase).toBe("pre_keeper");
+    expect(ctx.leagueSeason).toBe(2026);
+  });
+
+  it("honors SEASON_OVERRIDE", () => {
+    process.env.SEASON_OVERRIDE = "2030";
+    const ctx = getSeasonContext(CAL, "2026-06-01");
+    expect(ctx.leagueSeason).toBe(2030);
+    expect(ctx.projectionSeason).toBe(2030);
+    expect(ctx.statsSeason).toBe(2029);
+    expect(ctx.source).toBe("override");
+  });
+
+  it("honors PHASE_OVERRIDE", () => {
+    process.env.PHASE_OVERRIDE = "in_season";
+    const ctx = getSeasonContext(CAL, "2026-06-01");
+    expect(ctx.phase).toBe("in_season");
+    expect(ctx.arbWindowOpen).toBe(false);
+  });
+
+  it("rejects an invalid PHASE_OVERRIDE", () => {
+    process.env.PHASE_OVERRIDE = "nonsense";
+    expect(() => getSeasonContext(CAL, "2026-06-01")).toThrow();
+  });
+});

--- a/web/lib/season.ts
+++ b/web/lib/season.ts
@@ -1,0 +1,177 @@
+/**
+ * Season-cycle resolver — TypeScript twin of scripts/season.py.
+ *
+ * Single source of truth for "what season are we in and what phase of the
+ * annual cycle." Every page should derive its season from here instead of the
+ * static `SEASON` constant in config.ts.
+ *
+ * Boundary dates come from the `league_calendar` table (scraped from the Ottoneu
+ * finances page by scripts/scrape_league_calendar.py). Ottoneu declares the
+ * season label itself, so the season is never inferred when calendar data exists.
+ *
+ * Phases (within season label Y):
+ *   pre_arb      season_start         -> arb_end              (arbitration window)
+ *   pre_keeper   arb_end              -> keeper_deadline      (keep/cut decisions)
+ *   pre_draft    keeper_deadline      -> regular_season_start (auction draft)
+ *   in_season    regular_season_start -> next season_start    (NFL games played)
+ *
+ * Override: SEASON_OVERRIDE / PHASE_OVERRIDE env vars short-circuit the result.
+ */
+
+import { supabase } from "./supabase";
+import { LEAGUE_ID } from "./config";
+
+export const PHASES = ["pre_arb", "pre_keeper", "pre_draft", "in_season"] as const;
+export type Phase = (typeof PHASES)[number];
+
+export interface LeagueCalendarRow {
+  league_id?: number;
+  season: number;
+  season_start: string | null;
+  arb_start: string | null;
+  arb_end: string | null;
+  keeper_deadline: string | null;
+  auction_date: string | null;
+  regular_season_start: string | null;
+  trade_deadline: string | null;
+  last_auction_date: string | null;
+}
+
+export interface SeasonContext {
+  phase: Phase;
+  leagueSeason: number;
+  projectionSeason: number;
+  statsSeason: number;
+  arbitrationSeason: number;
+  arbWindowOpen: boolean;
+  deadlines: Record<string, string>;
+  nextBoundary: string | null;
+  source: "calendar" | "fallback" | "override";
+}
+
+/** Parse a date-ish value to a YYYY-MM-DD string, or null. */
+function asDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  return String(value).slice(0, 10);
+}
+
+function todayISO(now: Date | string = new Date()): string {
+  return (typeof now === "string" ? now : now.toISOString()).slice(0, 10);
+}
+
+function phaseFromRow(today: string, row: LeagueCalendarRow): Phase {
+  const arbEnd = asDate(row.arb_end);
+  const keeper = asDate(row.keeper_deadline);
+  const rss = asDate(row.regular_season_start);
+  if (arbEnd && today < arbEnd) return "pre_arb";
+  if (keeper && today < keeper) return "pre_keeper";
+  if (rss && today < rss) return "pre_draft";
+  return "in_season";
+}
+
+/** Month-based fallback when no calendar row is available. */
+function fallbackContext(today: string): SeasonContext {
+  const year = Number(today.slice(0, 4));
+  const month = Number(today.slice(5, 7));
+  let phase: Phase;
+  if (month >= 9) phase = "in_season";
+  else if (month < 4) phase = "pre_arb";
+  else if (month < 8) phase = "pre_keeper";
+  else phase = "pre_draft";
+  const statsSeason = phase === "in_season" ? year : year - 1;
+  return {
+    phase,
+    leagueSeason: year,
+    projectionSeason: year,
+    statsSeason,
+    arbitrationSeason: year,
+    arbWindowOpen: phase === "pre_arb",
+    deadlines: {},
+    nextBoundary: null,
+    source: "fallback",
+  };
+}
+
+function applyOverrides(ctx: SeasonContext): SeasonContext {
+  const seasonOverride = process.env.SEASON_OVERRIDE;
+  const phaseOverride = process.env.PHASE_OVERRIDE;
+  if (seasonOverride) {
+    const season = Number(seasonOverride);
+    ctx.leagueSeason = season;
+    ctx.projectionSeason = season;
+    ctx.arbitrationSeason = season;
+    ctx.statsSeason = ctx.phase === "in_season" ? season : season - 1;
+    ctx.source = "override";
+  }
+  if (phaseOverride) {
+    if (!(PHASES as readonly string[]).includes(phaseOverride)) {
+      throw new Error(`PHASE_OVERRIDE must be one of ${PHASES.join(", ")}, got "${phaseOverride}"`);
+    }
+    ctx.phase = phaseOverride as Phase;
+    ctx.arbWindowOpen = phaseOverride === "pre_arb";
+    ctx.source = "override";
+  }
+  return ctx;
+}
+
+/**
+ * Pure resolver: compute the season context from calendar rows and a date.
+ * Exported for testing; production code uses {@link resolveSeasonContext}.
+ */
+export function getSeasonContext(
+  calendarRows: LeagueCalendarRow[],
+  now: Date | string = new Date(),
+  leagueId: number = LEAGUE_ID,
+): SeasonContext {
+  const today = todayISO(now);
+  const rows = calendarRows.filter((r) => (r.league_id ?? leagueId) === leagueId);
+
+  // Active row: latest season_start on or before today.
+  const active = rows
+    .filter((r) => asDate(r.season_start) && asDate(r.season_start)! <= today)
+    .sort((a, b) => (asDate(a.season_start)! < asDate(b.season_start)! ? 1 : -1))[0];
+
+  if (!active) return applyOverrides(fallbackContext(today));
+
+  const phase = phaseFromRow(today, active);
+  const leagueSeason = Number(active.season);
+  const rss = asDate(active.regular_season_start);
+  const statsSeason = rss && today >= rss ? leagueSeason : leagueSeason - 1;
+  const arbStart = asDate(active.arb_start);
+  const arbEnd = asDate(active.arb_end);
+
+  const deadlineKeys: (keyof LeagueCalendarRow)[] = [
+    "season_start", "arb_start", "arb_end", "keeper_deadline",
+    "auction_date", "regular_season_start", "trade_deadline", "last_auction_date",
+  ];
+  const deadlines: Record<string, string> = {};
+  for (const k of deadlineKeys) {
+    const v = asDate(active[k] as string | null);
+    if (v) deadlines[k] = v;
+  }
+  const future = Object.values(deadlines).filter((d) => d > today).sort();
+
+  return applyOverrides({
+    phase,
+    leagueSeason,
+    projectionSeason: leagueSeason,
+    statsSeason,
+    arbitrationSeason: leagueSeason,
+    arbWindowOpen: !!(arbStart && arbEnd && arbStart <= today && today < arbEnd),
+    deadlines,
+    nextBoundary: future[0] ?? null,
+    source: "calendar",
+  });
+}
+
+/** Fetch the league calendar and resolve the current season context. */
+export async function resolveSeasonContext(
+  now: Date | string = new Date(),
+  leagueId: number = LEAGUE_ID,
+): Promise<SeasonContext> {
+  const { data } = await supabase
+    .from("league_calendar")
+    .select("*")
+    .eq("league_id", leagueId);
+  return getSeasonContext((data as LeagueCalendarRow[]) ?? [], now, leagueId);
+}

--- a/web/types/supabase.ts
+++ b/web/types/supabase.ts
@@ -14,6 +14,51 @@ export type Database = {
   }
   public: {
     Tables: {
+      league_calendar: {
+        Row: {
+          arb_end: string | null
+          arb_start: string | null
+          auction_date: string | null
+          keeper_deadline: string | null
+          last_auction_date: string | null
+          league_id: number
+          raw: Json | null
+          regular_season_start: string | null
+          scraped_at: string
+          season: number
+          season_start: string | null
+          trade_deadline: string | null
+        }
+        Insert: {
+          arb_end?: string | null
+          arb_start?: string | null
+          auction_date?: string | null
+          keeper_deadline?: string | null
+          last_auction_date?: string | null
+          league_id: number
+          raw?: Json | null
+          regular_season_start?: string | null
+          scraped_at?: string
+          season: number
+          season_start?: string | null
+          trade_deadline?: string | null
+        }
+        Update: {
+          arb_end?: string | null
+          arb_start?: string | null
+          auction_date?: string | null
+          keeper_deadline?: string | null
+          last_auction_date?: string | null
+          league_id?: number
+          raw?: Json | null
+          regular_season_start?: string | null
+          scraped_at?: string
+          season?: number
+          season_start?: string | null
+          trade_deadline?: string | null
+        }
+        Relationships: []
+      }
       arbitration_allocation_details: {
         Row: {
           allocating_team_name: string


### PR DESCRIPTION
Introduce a single source of truth for "what season are we in and what
phase of the Ottoneu annual cycle," replacing the hand-maintained
`SEASON` constant that goes stale.

- `league_calendar` table (+ RLS anon SELECT) scraped from the Ottoneu
  finances page Calendar section, which declares the season label and
  every boundary date.
- `scripts/scrape_league_calendar.py` + `just scrape-calendar` +
  weekly GitHub Actions workflow.
- Twin resolvers `scripts/season.py` and `web/lib/season.ts` mapping a
  date -> { phase, leagueSeason, statsSeason, projectionSeason,
  arbitrationSeason, deadlines, nextBoundary }, with SEASON_OVERRIDE /
  PHASE_OVERRIDE escape hatches and a month-based fallback.
- Tests for both resolvers (10 each).

Behavior-preserving: nothing consumes the resolver yet. PR #1 of 4; see
docs/exec-plans/season-cycle.md for the roadmap (migrate call sites,
phase-driven UI, config cleanup).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
