### PR TITLE
feat: migrate web read-path to the season-cycle resolver

### DIFF
--- a/docs/exec-plans/season-cycle.md
+++ b/docs/exec-plans/season-cycle.md
@@ -1,6 +1,6 @@
 # Season Cycle — cross-season data & UI scheme
 
-**Status:** In progress (PR #1 of 4 — foundation)
+**Status:** In progress (PR #2 — web read-path migration)
 
 ## Problem
 
@@ -80,17 +80,33 @@ automatic.
 
 ## Sequencing (one PR each)
 
-1. **Foundation (this PR):** `league_calendar` table + scraper
+1. **Foundation (done — PR #1):** `league_calendar` table + scraper
    (`scripts/scrape_league_calendar.py`, `just scrape-calendar`) + resolvers
    (`scripts/season.py`, `web/lib/season.ts`) with override + tests.
    Behavior-preserving — nothing consumes the resolver yet.
-2. **Migrate call sites** off static `SEASON` → `statsSeason` /
-   `projectionSeason` / `arbitrationSeason`. Removes the three-way "now" split.
+2. **Web read-path migration (this PR):** server accessors in `season.ts`
+   (`getSeasonContextNow`, `getStatsSeason`, `getProjectionSeason`,
+   `getArbitrationSeason`, React-cached per request). Migrate the data/analysis
+   layer (`data.ts`, `analysis.ts`) and the VORP / surplus / projections /
+   arbitration / surplus-adjustments pages off the static `SEASON` and the
+   hardcoded `2026` projection year. The projections page now derives its
+   selectable years from the resolver. Behavior-preserving today (statsSeason
+   2025, projectionSeason 2026), but now rolls forward automatically.
 3. **Phase-driven UI** — featured nav/landing per phase, roster snapshot default
-   & bounds (`roster-reconstruction.ts` hardcoded `2025-09-01`/`today`), phase
-   banner with next-boundary countdown.
-4. **Cleanup** — remove static `SEASON` / `SEASON_END_DATE` / `PRE_ARB_DATE`
-   from `config.json`.
+   & bounds (`roster-reconstruction.ts`: `eq("season", SEASON)` and the
+   hardcoded `2025-09-01`/`today` window), phase banner with next-boundary
+   countdown.
+4. **Python ingestion + arbitration-season alignment** — migrate the scrapers /
+   projection scripts off static `SEASON`, and fix arbitration-season tagging.
+   **Known issue surfaced during PR #2:** `arbitration_progress` rows are tagged
+   `season = 2025` (the scraper inherited the stale `SEASON`), even though the
+   2026-season arbitration ran Feb–Mar 2026. Because of this, `arb-progress`
+   page and the arbitration-progress read paths were intentionally **left on the
+   static `SEASON`** in PR #2 — switching them to `arbitrationSeason` (2026)
+   would read empty until the scraper tags by `arbitrationSeason` and existing
+   rows are re-tagged.
+5. **Cleanup** — remove static `SEASON` / `SEASON_END_DATE` / `PRE_ARB_DATE`
+   from `config.json` once nothing reads them.
 
 ## Wiring
 

--- a/web/app/arbitration-simulation/page.tsx
+++ b/web/app/arbitration-simulation/page.tsx
@@ -3,10 +3,9 @@ import {
   fetchHoverExtras,
   buildHoverDataMap,
   fetchPlayersPreArb,
-  SEASON,
   LEAGUE_ID,
-  DEFAULT_PROJECTION_YEAR,
 } from "@/lib/analysis";
+import { getStatsSeason, getProjectionSeason } from "@/lib/season";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getAuthenticatedUser } from "@/lib/auth";
 import SimulationControls from "./SimulationControls";
@@ -27,10 +26,14 @@ export default async function ArbitrationSimulationPage({ searchParams }: Props)
   const isAdjusted = mode === "adjusted";
   const isProjected = mode === "projected";
 
-  const user = await getAuthenticatedUser();
+  const [user, statsSeason, projectionSeason] = await Promise.all([
+    getAuthenticatedUser(),
+    getStatsSeason(),
+    getProjectionSeason(),
+  ]);
   const [rawPlayers, adjRes] = await Promise.all([
     isProjected
-      ? fetchAndMergeProjectedData(DEFAULT_PROJECTION_YEAR, fetchPlayersPreArb)
+      ? fetchAndMergeProjectedData(projectionSeason, fetchPlayersPreArb)
       : fetchPlayersPreArb(),
     user
       ? getSupabaseAdmin()
@@ -51,7 +54,7 @@ export default async function ArbitrationSimulationPage({ searchParams }: Props)
     );
   }
 
-  const label = isProjected ? DEFAULT_PROJECTION_YEAR : SEASON;
+  const label = isProjected ? projectionSeason : statsSeason;
 
   const { projMap, dsMap } = await fetchHoverExtras(!!user?.hasProjectionsAccess);
   const hoverDataMap = buildHoverDataMap(rawPlayers, projMap, dsMap);

--- a/web/app/arbitration/page.tsx
+++ b/web/app/arbitration/page.tsx
@@ -11,11 +11,10 @@ import {
   ARB_MAX_PER_TEAM,
   ARB_MAX_PER_PLAYER_PER_TEAM,
   NUM_TEAMS,
-  SEASON,
   LEAGUE_ID,
-  DEFAULT_PROJECTION_YEAR,
   getHistoricalSeasonsForYear,
 } from "@/lib/analysis";
+import { getStatsSeason, getProjectionSeason } from "@/lib/season";
 import type { ArbitrationTarget, Column, HighlightRule } from "@/lib/types";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getAuthenticatedUser } from "@/lib/auth";
@@ -86,7 +85,11 @@ export default async function ArbitrationPage({ searchParams }: Props) {
   const isAdjusted = mode === "adjusted";
 
   // Fetch adjustments in all modes (needed for indicator dot)
-  const user = await getAuthenticatedUser();
+  const [user, statsSeason, projectionSeason] = await Promise.all([
+    getAuthenticatedUser(),
+    getStatsSeason(),
+    getProjectionSeason(),
+  ]);
   const adjRes = user
     ? await getSupabaseAdmin()
         .from("surplus_adjustments")
@@ -108,7 +111,7 @@ export default async function ArbitrationPage({ searchParams }: Props) {
   // Fetch players with pre-arbitration salaries (after auto bump, before arb results)
   let allPlayers;
   if (isProjected) {
-    allPlayers = await fetchAndMergeProjectedData(DEFAULT_PROJECTION_YEAR, fetchPlayersPreArb);
+    allPlayers = await fetchAndMergeProjectedData(projectionSeason, fetchPlayersPreArb);
   } else {
     // Raw mode uses projected PPG as the base
     allPlayers = await fetchPlayersWithProjectedPpg(fetchPlayersPreArb);
@@ -154,7 +157,7 @@ export default async function ArbitrationPage({ searchParams }: Props) {
     })()
     : sortedTeams;
 
-  const projectionYear = DEFAULT_PROJECTION_YEAR;
+  const projectionYear = projectionSeason;
   const historicalSeasons = getHistoricalSeasonsForYear(projectionYear);
   const mostRecentSeason = Math.max(...historicalSeasons);
   const columns = isProjected ? buildProjectedColumns(hoverDataMap) : buildBaseColumns(hoverDataMap);
@@ -166,7 +169,7 @@ export default async function ArbitrationPage({ searchParams }: Props) {
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
               <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
-                Arbitration Targets ({isProjected ? projectionYear : SEASON})
+                Arbitration Targets ({isProjected ? projectionYear : statsSeason})
               </h1>
               <p className="text-slate-500 dark:text-slate-400 mt-2">
                 {isProjected ? (

--- a/web/app/projections/ProjectionsClient.tsx
+++ b/web/app/projections/ProjectionsClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { POSITIONS, PROJECTION_YEARS, SEASON } from "@/lib/analysis";
+import { POSITIONS } from "@/lib/analysis";
 import PositionFilter from "@/components/PositionFilter";
 import ProjectionYearSelector from "@/components/ProjectionYearSelector";
 import DataTable from "@/components/DataTable";
@@ -27,6 +27,8 @@ export interface ProjectionRow {
 interface Props {
   initialData: ProjectionRow[];
   projectionYear: number;
+  statsSeason: number;
+  projectionYears: readonly number[];
 }
 
 /** College fallback badge for players with no NFL track record. */
@@ -41,7 +43,10 @@ function ProjectionBadges({ method }: { method: string }) {
   return null;
 }
 
-function getProjectionColumns(projectionYear: number): Column<ProjectionRow>[] {
+function getProjectionColumns(
+  projectionYear: number,
+  statsSeason: number
+): Column<ProjectionRow>[] {
   return [
     {
       key: "name",
@@ -65,13 +70,13 @@ function getProjectionColumns(projectionYear: number): Column<ProjectionRow>[] {
     { key: "nfl_team", label: "Team" },
     { key: "team_name", label: "Owner" },
     { key: "price", label: "Salary", format: "currency" },
-    { key: "observed_ppg", label: `${SEASON} PPG`, format: "decimal" },
+    { key: "observed_ppg", label: `${statsSeason} PPG`, format: "decimal" },
     { key: "projected_ppg", label: `Proj ${projectionYear}`, format: "decimal" },
-    { key: "ppg_delta", label: `Δ ${projectionYear} vs ${SEASON}`, format: "decimal" },
+    { key: "ppg_delta", label: `Δ ${projectionYear} vs ${statsSeason}`, format: "decimal" },
   ];
 }
 
-export default function ProjectionsClient({ initialData, projectionYear }: Props) {
+export default function ProjectionsClient({ initialData, projectionYear, statsSeason, projectionYears }: Props) {
   const [selectedPositions, setSelectedPositions] = useState<Position[]>([
     ...POSITIONS,
   ]);
@@ -93,7 +98,7 @@ export default function ProjectionsClient({ initialData, projectionYear }: Props
   const filteredData = initialData
     .filter((p) => selectedPositions.includes(p.position as Position));
 
-  const columns = getProjectionColumns(projectionYear);
+  const columns = getProjectionColumns(projectionYear, statsSeason);
 
   return (
     <section>
@@ -101,7 +106,7 @@ export default function ProjectionsClient({ initialData, projectionYear }: Props
         <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
           All Players
         </h2>
-        <ProjectionYearSelector currentYear={projectionYear} years={PROJECTION_YEARS} />
+        <ProjectionYearSelector currentYear={projectionYear} years={projectionYears} />
         <PositionFilter
           positions={POSITIONS}
           selectedPositions={selectedPositions}

--- a/web/app/projections/page.tsx
+++ b/web/app/projections/page.tsx
@@ -1,10 +1,8 @@
 import {
   fetchAndMergeProjectedData,
-  PROJECTION_YEARS,
-  DEFAULT_PROJECTION_YEAR,
   getHistoricalSeasonsForYear,
-  SEASON,
 } from "@/lib/analysis";
+import { getStatsSeason, getProjectionSeason } from "@/lib/season";
 import ActiveModelCard from "@/components/ActiveModelCard";
 import ProjectionsClient from "./ProjectionsClient";
 
@@ -16,10 +14,21 @@ interface Props {
 
 export default async function ProjectionsPage({ searchParams }: Props) {
   const params = await searchParams;
+  const [statsSeason, projectionSeason] = await Promise.all([
+    getStatsSeason(),
+    getProjectionSeason(),
+  ]);
+  // Selectable projection years: the just-completed season (backtest view) and
+  // the upcoming projection season (forward-looking). Deduped when they coincide
+  // (during the in-season phase, statsSeason === projectionSeason).
+  const projectionYears = Array.from(
+    new Set([statsSeason, projectionSeason])
+  ).sort((a, b) => a - b);
+
   const rawYear = Number(params.year);
-  const projectionYear = (PROJECTION_YEARS as readonly number[]).includes(rawYear)
+  const projectionYear = projectionYears.includes(rawYear)
     ? rawYear
-    : DEFAULT_PROJECTION_YEAR;
+    : projectionSeason;
 
   const players = await fetchAndMergeProjectedData(projectionYear);
   const historicalSeasons = getHistoricalSeasonsForYear(projectionYear);
@@ -60,9 +69,9 @@ export default async function ProjectionsPage({ searchParams }: Props) {
             Player Projections — {projectionYear}
           </h1>
           <p className="text-slate-500 dark:text-slate-400 mt-2">
-            {projectionYear > SEASON ? (
+            {projectionYear > statsSeason ? (
               <>
-                <strong>Forward-looking:</strong> {SEASON} actual PPG vs.
+                <strong>Forward-looking:</strong> {statsSeason} actual PPG vs.
                 projected {projectionYear} performance, built from{" "}
                 {historicalSeasons.join(", ")} history. Use this for arbitration
                 and keeper decisions.
@@ -71,7 +80,7 @@ export default async function ProjectionsPage({ searchParams }: Props) {
               <>
                 <strong>Backtest:</strong> What the model would have projected
                 for {projectionYear} using {historicalSeasons.join(", ")} history,
-                compared to actual {SEASON} results. Green = outperformed
+                compared to actual {projectionYear} results. Green = outperformed
                 projection; red = underperformed.
               </>
             )}
@@ -92,15 +101,20 @@ export default async function ProjectionsPage({ searchParams }: Props) {
                 fallback set to the position-average rookie PPG.
               </p>
               <p className="text-xs text-slate-500 dark:text-slate-400 pt-1">
-                <strong>{SEASON} PPG</strong> — actual {SEASON} season stats &nbsp;·&nbsp;{" "}
+                <strong>{statsSeason} PPG</strong> — actual {statsSeason} season stats &nbsp;·&nbsp;{" "}
                 <strong>Proj {projectionYear}</strong> — model output for {projectionYear} &nbsp;·&nbsp;{" "}
-                <strong>Δ</strong> — Proj minus {SEASON} PPG
+                <strong>Δ</strong> — Proj minus {statsSeason} PPG
               </p>
             </>
           }
         />
 
-        <ProjectionsClient initialData={rows} projectionYear={projectionYear} />
+        <ProjectionsClient
+          initialData={rows}
+          projectionYear={projectionYear}
+          statsSeason={statsSeason}
+          projectionYears={projectionYears}
+        />
       </div>
     </main>
   );

--- a/web/app/surplus-adjustments/AdjustmentsTable.tsx
+++ b/web/app/surplus-adjustments/AdjustmentsTable.tsx
@@ -21,6 +21,7 @@ interface AdjustmentsTableProps {
   projectedValues: Record<string, ProjectedValueEntry>;
   dollarPerVorp: number;
   hoverDataMap?: Record<string, PlayerHoverData> | null;
+  projectionSeason: number;
 }
 
 const POSITIONS = ["ALL", "QB", "RB", "WR", "TE"];
@@ -59,6 +60,7 @@ export default function AdjustmentsTable({
   projectedValues,
   dollarPerVorp,
   hoverDataMap,
+  projectionSeason,
 }: AdjustmentsTableProps) {
   const [adjustments, setAdjustments] = useState<Record<string, AdjustmentEntry>>(() => {
     const init: Record<string, AdjustmentEntry> = {};
@@ -555,7 +557,7 @@ export default function AdjustmentsTable({
         <span className="inline-block w-2 h-2 rounded-sm bg-blue-100 dark:bg-blue-950 border border-blue-300 mr-0.5" />
         {" "}saved non-zero adjustment.{" "}
         ★ = your team.{" "}
-        <span className="text-purple-600 dark:text-purple-400">Purple columns</span> = 2026 projected values.
+        <span className="text-purple-600 dark:text-purple-400">Purple columns</span> = {projectionSeason} projected values.
       </p>
     </div>
   );

--- a/web/app/surplus-adjustments/page.tsx
+++ b/web/app/surplus-adjustments/page.tsx
@@ -1,4 +1,5 @@
-import { fetchAndMergeProjectedData, fetchHoverExtras, buildHoverDataMap, calculateSurplus, fetchPlayersPreArb, SEASON, LEAGUE_ID, DEFAULT_PROJECTION_YEAR } from "@/lib/analysis";
+import { fetchAndMergeProjectedData, fetchHoverExtras, buildHoverDataMap, calculateSurplus, fetchPlayersPreArb, LEAGUE_ID } from "@/lib/analysis";
+import { getStatsSeason, getProjectionSeason } from "@/lib/season";
 import { computeDollarPerVorp } from "@/lib/surplus";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getAuthenticatedUser } from "@/lib/auth";
@@ -9,9 +10,13 @@ export const revalidate = 0;
 
 export default async function SurplusAdjustmentsPage() {
   const user = await getAuthenticatedUser();
+  const [statsSeason, projectionSeason] = await Promise.all([
+    getStatsSeason(),
+    getProjectionSeason(),
+  ]);
   const [allPlayers, projectedPlayers, adjRes] = await Promise.all([
     fetchPlayersPreArb(),
-    fetchAndMergeProjectedData(DEFAULT_PROJECTION_YEAR, fetchPlayersPreArb),
+    fetchAndMergeProjectedData(projectionSeason, fetchPlayersPreArb),
     user
       ? getSupabaseAdmin()
           .from("surplus_adjustments")
@@ -58,7 +63,7 @@ export default async function SurplusAdjustmentsPage() {
       <div className="max-w-7xl mx-auto space-y-6">
         <header>
           <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
-            Surplus Value Adjustments ({SEASON})
+            Surplus Value Adjustments ({statsSeason})
           </h1>
           <p className="text-slate-500 dark:text-slate-400 mt-2">
             Adjust player values by entering a target PPG or target surplus — the system
@@ -74,7 +79,7 @@ export default async function SurplusAdjustmentsPage() {
             pages by toggling to &ldquo;Adjusted&rdquo; mode.
           </p>
           <p className="text-slate-400 dark:text-slate-500 mt-1 text-sm">
-            <strong>Proj. Value</strong> and <strong>Proj. Surplus</strong> show {DEFAULT_PROJECTION_YEAR} projected
+            <strong>Proj. Value</strong> and <strong>Proj. Surplus</strong> show {projectionSeason} projected
             dollar values based on recency-weighted PPG projections. <strong>Δ</strong> = projected minus observed value.
           </p>
         </header>
@@ -91,6 +96,7 @@ export default async function SurplusAdjustmentsPage() {
           projectedValues={projectedValues}
           dollarPerVorp={dollarPerVorp}
           hoverDataMap={hoverDataMap}
+          projectionSeason={projectionSeason}
         />
       </div>
     </main>

--- a/web/app/surplus-value/page.tsx
+++ b/web/app/surplus-value/page.tsx
@@ -3,8 +3,8 @@ import {
   buildHoverDataMap,
   calculateSurplus,
   MY_TEAM,
-  SEASON,
 } from "@/lib/analysis";
+import { getStatsSeason } from "@/lib/season";
 import { fetchPlayersEndOfSeason } from "@/lib/data";
 import { getAuthenticatedUser } from "@/lib/auth";
 import DataTable from "@/components/DataTable";
@@ -87,9 +87,10 @@ const TEAM_SUMMARY_RULES: HighlightRule<TeamSummaryRow>[] = [
 ];
 
 export default async function SurplusValuePage() {
-  const [allPlayers, user] = await Promise.all([
+  const [allPlayers, user, statsSeason] = await Promise.all([
     fetchPlayersEndOfSeason(),
     getAuthenticatedUser(),
+    getStatsSeason(),
   ]);
   const { projMap, dsMap } = await fetchHoverExtras(!!user?.hasProjectionsAccess);
   const hoverDataMap = buildHoverDataMap(allPlayers, projMap, dsMap);
@@ -174,7 +175,7 @@ export default async function SurplusValuePage() {
       <div className="max-w-7xl mx-auto space-y-8">
         <header>
           <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
-            Surplus Value Rankings ({SEASON})
+            Surplus Value Rankings ({statsSeason})
           </h1>
           <p className="text-slate-500 dark:text-slate-400 mt-2">
             Dollar value (from VORP) minus current salary. Positive surplus =

--- a/web/app/vorp/page.tsx
+++ b/web/app/vorp/page.tsx
@@ -3,19 +3,20 @@ import {
   buildHoverDataMap,
   calculateVorp,
   POSITIONS,
-  SEASON,
   MIN_GAMES,
   NUM_TEAMS,
   CAP_PER_TEAM,
 } from "@/lib/analysis";
+import { getStatsSeason } from "@/lib/season";
 import { fetchPlayersEndOfSeason } from "@/lib/data";
 import { getAuthenticatedUser } from "@/lib/auth";
 import VorpClient from "./VorpClient";
 
 export default async function VorpPage() {
-  const [allPlayers, user] = await Promise.all([
+  const [allPlayers, user, statsSeason] = await Promise.all([
     fetchPlayersEndOfSeason(),
     getAuthenticatedUser(),
+    getStatsSeason(),
   ]);
   const { players, replacementPpg, replacementN } = calculateVorp(allPlayers);
   const { projMap, dsMap } = await fetchHoverExtras(!!user?.hasProjectionsAccess);
@@ -72,7 +73,7 @@ export default async function VorpPage() {
       <div className="max-w-7xl mx-auto space-y-8">
         <header>
           <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
-            VORP Analysis ({SEASON})
+            VORP Analysis ({statsSeason})
           </h1>
           <p className="text-slate-500 dark:text-slate-400 mt-2">
             Value Over Replacement Player — measures positional scarcity.

--- a/web/lib/analysis.ts
+++ b/web/lib/analysis.ts
@@ -9,7 +9,8 @@
  */
 
 import { supabase } from "./supabase";
-import { LEAGUE_ID, SEASON } from "./config";
+import { LEAGUE_ID } from "./config";
+import { getStatsSeason, getProjectionSeason } from "./season";
 import { fetchPlayers, fetchDraftSharksMap, type DraftSharksValue } from "./data";
 import type { Player, PlayerHoverData, BacktestPlayer, ProjectionModel, BacktestMetrics } from "./types";
 
@@ -32,9 +33,10 @@ export {
 export const fetchAndMergeData = fetchPlayers;
 
 // === Projection Year Config ===
-export const PROJECTION_YEARS = [2025, 2026] as const;
-export type ProjectionYear = typeof PROJECTION_YEARS[number];
-export const DEFAULT_PROJECTION_YEAR: ProjectionYear = 2026;
+// The active projection season is resolved dynamically via the season-cycle
+// resolver (see web/lib/season.ts: getProjectionSeason). Pages derive their
+// selectable projection years from { statsSeason, projectionSeason } rather
+// than a hardcoded list.
 
 export function getHistoricalSeasonsForYear(year: number): number[] {
   return [year - 3, year - 2, year - 1]; // e.g. 2026 → [2023, 2024, 2025]
@@ -259,7 +261,7 @@ export function buildHoverDataMap(
  */
 export async function fetchHoverExtras(
   hasProjectionsAccess: boolean,
-  season: number = DEFAULT_PROJECTION_YEAR
+  season?: number
 ): Promise<{
   projMap: Record<string, { ppg: number; method: string }> | null;
   dsMap: Record<string, DraftSharksValue> | null;
@@ -267,9 +269,10 @@ export async function fetchHoverExtras(
   if (!hasProjectionsAccess) {
     return { projMap: null, dsMap: null };
   }
+  const resolvedSeason = season ?? (await getProjectionSeason());
   const [projMap, dsMap] = await Promise.all([
-    fetchProjectionMap(season),
-    fetchDraftSharksMap(season),
+    fetchProjectionMap(resolvedSeason),
+    fetchDraftSharksMap(resolvedSeason),
   ]);
   return { projMap, dsMap };
 }
@@ -297,7 +300,7 @@ export async function fetchPlayersWithProjectedPpg(
     throw new Error("Failed to fetch current players data for projection mapping");
   }
 
-  const projectionMap = await buildProjectionMap(SEASON);
+  const projectionMap = await buildProjectionMap(await getStatsSeason());
 
   return currentPlayers.map((player) => {
     const projEntry = projectionMap.get(player.player_id);
@@ -387,7 +390,7 @@ export async function fetchBacktestData(
  *   Use `fetchPlayersPreArb` for pre-arbitration salary context.
  */
 export async function fetchAndMergeProjectedData(
-  projectionYear: number = DEFAULT_PROJECTION_YEAR,
+  projectionYear?: number,
   baseFetcher: () => Promise<Player[]> = fetchPlayers
 ): Promise<ProjectedPlayer[]> {
   const currentPlayers = await baseFetcher();
@@ -396,7 +399,9 @@ export async function fetchAndMergeProjectedData(
     throw new Error("Failed to fetch current players data for projection mapping");
   }
 
-  const projectionMap = await buildProjectionMap(projectionYear);
+  const projectionMap = await buildProjectionMap(
+    projectionYear ?? (await getProjectionSeason())
+  );
 
   const projected: ProjectedPlayer[] = [];
   for (const player of currentPlayers) {

--- a/web/lib/data.ts
+++ b/web/lib/data.ts
@@ -10,7 +10,8 @@
  */
 
 import { supabase } from "./supabase";
-import { LEAGUE_ID, SEASON, SEASON_END_DATE, PRE_ARB_DATE } from "./config";
+import { LEAGUE_ID, SEASON_END_DATE, PRE_ARB_DATE } from "./config";
+import { getStatsSeason, getProjectionSeason } from "./season";
 import type {
   Player,
   PlayerListItem,
@@ -91,9 +92,10 @@ async function buildSalaryMapAtDate(
  * Use `PRE_ARB_DATE` for pre-arbitration analysis (arb targets, simulation).
  */
 export async function fetchPlayersAtDate(salaryDate: string): Promise<Player[]> {
+  const statsSeason = await getStatsSeason();
   const [playersRes, statsRes, salaryMap] = await Promise.all([
     supabase.from("players").select("*").gt("ottoneu_id", 0),
-    supabase.from("player_stats").select("*").eq("season", SEASON),
+    supabase.from("player_stats").select("*").eq("season", statsSeason),
     buildSalaryMapAtDate(salaryDate),
   ]);
 
@@ -158,9 +160,10 @@ export function fetchPlayersPreArb(): Promise<Player[]> {
  * Salary comes exclusively from `league_prices`.
  */
 export async function fetchPlayers(): Promise<Player[]> {
+  const statsSeason = await getStatsSeason();
   const [playersRes, statsRes, pricesRes] = await Promise.all([
     supabase.from("players").select("*").gt("ottoneu_id", 0),
-    supabase.from("player_stats").select("*").eq("season", SEASON),
+    supabase.from("player_stats").select("*").eq("season", statsSeason),
     supabase.from("league_prices").select("*").eq("league_id", LEAGUE_ID),
   ]);
 
@@ -215,6 +218,7 @@ export async function fetchPlayers(): Promise<Player[]> {
  * Salary comes exclusively from `league_prices` — no transaction override.
  */
 export async function fetchPlayerList(): Promise<PlayerListItem[]> {
+  const statsSeason = await getStatsSeason();
   const [playersRes, statsRes, pricesRes] = await Promise.all([
     supabase
       .from("players")
@@ -224,7 +228,7 @@ export async function fetchPlayerList(): Promise<PlayerListItem[]> {
     supabase
       .from("player_stats")
       .select("player_id, total_points, games_played, ppg")
-      .eq("season", SEASON),
+      .eq("season", statsSeason),
     supabase
       .from("league_prices")
       .select("player_id, price, team_name")
@@ -353,13 +357,13 @@ export async function fetchPublicArbPlayers(): Promise<PublicArbPlayer[]> {
  */
 export async function fetchPlayerProjection(
   playerId: string,
-  season = 2026
+  season?: number
 ): Promise<{ projected_ppg: number; projection_method: string } | null> {
   const { data, error } = await supabase
     .from("player_projections")
     .select("projected_ppg, projection_method")
     .eq("player_id", playerId)
-    .eq("season", season)
+    .eq("season", season ?? (await getProjectionSeason()))
     .maybeSingle();
 
   if (error || !data) return null;
@@ -386,13 +390,13 @@ export interface DraftSharksValue {
  */
 export async function fetchDraftSharksValue(
   playerId: string,
-  season = 2026
+  season?: number
 ): Promise<DraftSharksValue | null> {
   const { data, error } = await supabase
     .from("draft_sharks_values")
     .select("ds_auction_value, market_auction_value")
     .eq("player_id", playerId)
-    .eq("season", season)
+    .eq("season", season ?? (await getProjectionSeason()))
     .maybeSingle();
 
   if (error || !data) return null;
@@ -409,12 +413,12 @@ export async function fetchDraftSharksValue(
  * Build a player_id → Draft Sharks values map for bulk (hover-card) use.
  */
 export async function fetchDraftSharksMap(
-  season = 2026
+  season?: number
 ): Promise<Record<string, DraftSharksValue>> {
   const { data, error } = await supabase
     .from("draft_sharks_values")
     .select("player_id, ds_auction_value, market_auction_value")
-    .eq("season", season);
+    .eq("season", season ?? (await getProjectionSeason()));
 
   if (error || !data) return {};
 

--- a/web/lib/season.ts
+++ b/web/lib/season.ts
@@ -18,6 +18,7 @@
  * Override: SEASON_OVERRIDE / PHASE_OVERRIDE env vars short-circuit the result.
  */
 
+import { cache } from "react";
 import { supabase } from "./supabase";
 import { LEAGUE_ID } from "./config";
 
@@ -174,4 +175,27 @@ export async function resolveSeasonContext(
     .select("*")
     .eq("league_id", leagueId);
   return getSeasonContext((data as LeagueCalendarRow[]) ?? [], now, leagueId);
+}
+
+/**
+ * Resolve the current season context once per server request (React-cached).
+ * This is the entry point server components and the data layer should use.
+ */
+export const getSeasonContextNow = cache(
+  (): Promise<SeasonContext> => resolveSeasonContext(),
+);
+
+/** Season whose actual NFL stats drive VORP / surplus / observed PPG. */
+export async function getStatsSeason(): Promise<number> {
+  return (await getSeasonContextNow()).statsSeason;
+}
+
+/** Season that projections / Draft Sharks values target. */
+export async function getProjectionSeason(): Promise<number> {
+  return (await getSeasonContextNow()).projectionSeason;
+}
+
+/** Season arbitration is being conducted for. */
+export async function getArbitrationSeason(): Promise<number> {
+  return (await getSeasonContextNow()).arbitrationSeason;
 }


### PR DESCRIPTION
Re-targets the PR #533 work onto `main`. The original PR #533 was stacked on the PR #1 branch and merged into that branch rather than `main`, so its changes never landed on `main` after PR #1 (#532) squash-merged. This re-applies the same commit against `main`.

Replaces the static `SEASON` constant and the hardcoded `2026` projection year across the web data/analysis layer and analysis pages with the date-driven resolver from PR #1.

- Adds React-cached server accessors to `web/lib/season.ts`: `getSeasonContextNow`, `getStatsSeason`, `getProjectionSeason`, `getArbitrationSeason`.
- `data.ts`: stats queries use `statsSeason`; projection / Draft Sharks fetchers default to `projectionSeason`.
- `analysis.ts`: projection map + hover extras + `fetchAndMergeProjectedData` resolve dynamically; drops the hardcoded `PROJECTION_YEARS` / `DEFAULT_PROJECTION_YEAR` constants.
- VORP, surplus-value, surplus-adjustments, arbitration, arbitration-simulation, and projections pages resolve season(s) and pass them to client components. The projections page derives its selectable years from the resolver.

Behavior-preserving today (statsSeason 2025, projectionSeason 2026) but now rolls forward automatically. `arb-progress` and `roster-reconstruction` intentionally stay on static `SEASON` — see `docs/exec-plans/season-cycle.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)