### PR TITLE
feat: phase-driven UI and season-aware roster snapshots

### DIFF
--- a/docs/exec-plans/season-cycle.md
+++ b/docs/exec-plans/season-cycle.md
@@ -1,6 +1,6 @@
 # Season Cycle — cross-season data & UI scheme
 
-**Status:** In progress (PR #2 — web read-path migration)
+**Status:** In progress (PR #3 — phase-driven UI + roster snapshots)
 
 ## Problem
 
@@ -92,10 +92,21 @@ automatic.
    hardcoded `2026` projection year. The projections page now derives its
    selectable years from the resolver. Behavior-preserving today (statsSeason
    2025, projectionSeason 2026), but now rolls forward automatically.
-3. **Phase-driven UI** — featured nav/landing per phase, roster snapshot default
-   & bounds (`roster-reconstruction.ts`: `eq("season", SEASON)` and the
-   hardcoded `2025-09-01`/`today` window), phase banner with next-boundary
-   countdown.
+3. **Phase-driven UI + roster snapshots (this PR):**
+   - `web/lib/season-ui.ts` — pure, client-safe `PHASE_UI` map (label, blurb,
+     featured nav group/links per phase) + `describeNextBoundary` for countdowns.
+   - `PhaseBanner` (server component, in the root layout) shows the current
+     phase, blurb, and a countdown to the next league deadline.
+   - `Navigation` accents the phase-featured nav group/links with an amber dot
+     (resolved in `NavigationWrapper` and passed down).
+   - `roster-reconstruction.ts` — transactions now follow `getLeagueSeason()`,
+     stats follow `getStatsSeason()` (was static `SEASON`). `getDateRange` is
+     replaced by the pure `buildRosterSnapshots(ctx)`, which anchors the
+     quick-jump weeks to the league season's kickoff, derives the date-range
+     bounds from the calendar, and **defaults the snapshot to "Pre-Draft" once
+     the keeper deadline has passed** (the `pre_draft` phase) — otherwise
+     "Today". The rosters page resolves the context server-side and passes the
+     config to `RostersClient`.
 4. **Python ingestion + arbitration-season alignment** — migrate the scrapers /
    projection scripts off static `SEASON`, and fix arbitration-season tagging.
    **Known issue surfaced during PR #2:** `arbitration_progress` rows are tagged

--- a/web/__tests__/lib/season-ui.test.ts
+++ b/web/__tests__/lib/season-ui.test.ts
@@ -1,0 +1,73 @@
+jest.mock("@/lib/supabase", () => ({ supabase: {} }));
+
+import { describeNextBoundary, PHASE_UI } from "@/lib/season-ui";
+import { buildRosterSnapshots } from "@/lib/roster-reconstruction";
+
+const DEADLINES = {
+  season_start: "2026-01-03",
+  arb_start: "2026-02-15",
+  arb_end: "2026-03-31",
+  keeper_deadline: "2026-07-31",
+  regular_season_start: "2026-09-04",
+};
+
+describe("describeNextBoundary", () => {
+  it("labels the next boundary and counts days until it", () => {
+    const next = describeNextBoundary(
+      { nextBoundary: "2026-07-31", deadlines: DEADLINES },
+      "2026-06-01"
+    );
+    expect(next).toEqual({ label: "keeper deadline", date: "2026-07-31", daysUntil: 60 });
+  });
+
+  it("returns null when there is no upcoming boundary", () => {
+    expect(
+      describeNextBoundary({ nextBoundary: null, deadlines: {} }, "2026-06-01")
+    ).toBeNull();
+  });
+});
+
+describe("PHASE_UI", () => {
+  it("defines a label and featured links for every phase", () => {
+    for (const phase of ["in_season", "pre_arb", "pre_keeper", "pre_draft"] as const) {
+      expect(PHASE_UI[phase].label).toBeTruthy();
+      expect(PHASE_UI[phase].featuredLinks.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("buildRosterSnapshots", () => {
+  it("anchors weeks to kickoff and defaults to Today outside pre_draft", () => {
+    const cfg = buildRosterSnapshots(
+      { phase: "pre_keeper", leagueSeason: 2026, deadlines: DEADLINES },
+      "2026-06-01"
+    );
+    expect(cfg.defaultDate).toBe("2026-06-01");
+    expect(cfg.dateRange).toEqual({ min: "2026-01-03", max: "2026-06-01" });
+    expect(cfg.quickDates).toEqual([
+      { label: "Pre-Draft", date: "2026-09-03" },
+      { label: "Wk 1", date: "2026-09-04" },
+      { label: "Wk 8", date: "2026-10-23" },
+      { label: "Wk 16", date: "2026-12-18" },
+      { label: "Today", date: "2026-06-01" },
+    ]);
+  });
+
+  it("defaults to the Pre-Draft snapshot during the pre_draft phase", () => {
+    const cfg = buildRosterSnapshots(
+      { phase: "pre_draft", leagueSeason: 2026, deadlines: DEADLINES },
+      "2026-08-20"
+    );
+    expect(cfg.defaultDate).toBe("2026-09-03");
+  });
+
+  it("degrades gracefully when calendar dates are missing", () => {
+    const cfg = buildRosterSnapshots(
+      { phase: "in_season", leagueSeason: 2026, deadlines: {} },
+      "2026-10-01"
+    );
+    expect(cfg.quickDates).toEqual([{ label: "Today", date: "2026-10-01" }]);
+    expect(cfg.dateRange).toEqual({ min: "2026-01-01", max: "2026-10-01" });
+    expect(cfg.defaultDate).toBe("2026-10-01");
+  });
+});

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import NavigationWrapper from "@/components/NavigationWrapper";
+import PhaseBanner from "@/components/PhaseBanner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,6 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <NavigationWrapper />
+        <PhaseBanner />
         {children}
       </body>
     </html>

--- a/web/app/rosters/RostersClient.tsx
+++ b/web/app/rosters/RostersClient.tsx
@@ -3,20 +3,12 @@
 import { useMemo, useState } from "react";
 import {
   reconstructRostersAtDate,
-  getDateRange,
   type RosterData,
+  type RosterSnapshot,
 } from "@/lib/roster-reconstruction";
 import { CAP_PER_TEAM, NUM_TEAMS } from "@/lib/arb-logic";
 import type { PlayerHoverData } from "@/lib/types";
 import TeamRosterSection from "./TeamRosterSection";
-
-const QUICK_DATES = [
-  { label: "Pre-Draft", date: "2025-08-31" },
-  { label: "Wk 1", date: "2025-09-07" },
-  { label: "Wk 8", date: "2025-10-26" },
-  { label: "Wk 16", date: "2025-12-10" },
-  { label: "Today", date: new Date().toISOString().slice(0, 10) },
-];
 
 export default function RostersClient({
   transactions,
@@ -24,9 +16,17 @@ export default function RostersClient({
   stats,
   leaguePrices,
   hoverDataMap,
-}: RosterData & { hoverDataMap?: Record<string, PlayerHoverData> | null }) {
-  const { min, max } = getDateRange();
-  const [selectedDate, setSelectedDate] = useState(new Date().toISOString().slice(0, 10));
+  quickDates,
+  dateRange,
+  defaultDate,
+}: RosterData & {
+  hoverDataMap?: Record<string, PlayerHoverData> | null;
+  quickDates: RosterSnapshot[];
+  dateRange: { min: string; max: string };
+  defaultDate: string;
+}) {
+  const { min, max } = dateRange;
+  const [selectedDate, setSelectedDate] = useState(defaultDate);
 
   const rosters = useMemo(
     () => reconstructRostersAtDate(transactions, players, stats, selectedDate, leaguePrices),
@@ -75,7 +75,7 @@ export default function RostersClient({
               <span className="text-sm text-slate-500 dark:text-slate-400">
                 Quick:
               </span>
-              {QUICK_DATES.map(({ label, date }) => (
+              {quickDates.map(({ label, date }) => (
                 <button
                   key={label}
                   onClick={() => setSelectedDate(date)}

--- a/web/app/rosters/page.tsx
+++ b/web/app/rosters/page.tsx
@@ -1,14 +1,17 @@
-import { fetchRosterData } from "@/lib/roster-reconstruction";
+import { fetchRosterData, buildRosterSnapshots } from "@/lib/roster-reconstruction";
 import { fetchHoverExtras } from "@/lib/analysis";
+import { getSeasonContextNow } from "@/lib/season";
 import { getAuthenticatedUser } from "@/lib/auth";
 import type { PlayerHoverData } from "@/lib/types";
 import RostersClient from "./RostersClient";
 
 export default async function RostersPage() {
-  const [data, user] = await Promise.all([
+  const [data, user, ctx] = await Promise.all([
     fetchRosterData(),
     getAuthenticatedUser(),
+    getSeasonContextNow(),
   ]);
+  const snapshots = buildRosterSnapshots(ctx);
   const { projMap, dsMap } = await fetchHoverExtras(!!user?.hasProjectionsAccess);
 
   // Build hoverDataMap from raw player + stats data
@@ -45,5 +48,13 @@ export default async function RostersPage() {
     };
   }
 
-  return <RostersClient {...data} hoverDataMap={hoverDataMap} />;
+  return (
+    <RostersClient
+      {...data}
+      hoverDataMap={hoverDataMap}
+      quickDates={snapshots.quickDates}
+      dateRange={snapshots.dateRange}
+      defaultDate={snapshots.defaultDate}
+    />
+  );
 }

--- a/web/components/Navigation.tsx
+++ b/web/components/Navigation.tsx
@@ -70,14 +70,29 @@ const PRIVATE_GROUPS = [
   },
 ];
 
+/** Small amber dot marking the phase-featured nav item. */
+function FeaturedDot() {
+  return (
+    <span
+      className="h-1.5 w-1.5 rounded-full bg-amber-500"
+      title="Featured this part of the season"
+      aria-hidden="true"
+    />
+  );
+}
+
 function NavDropdown({
   label,
   links,
   pathname,
+  featured,
+  featuredLinks,
 }: {
   label: string;
   links: { href: string; label: string }[];
   pathname: string;
+  featured?: boolean;
+  featuredLinks?: string[];
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -115,6 +130,7 @@ function NavDropdown({
       >
         <Lock size={12} className={hasActiveChild ? "opacity-80" : "opacity-60"} aria-hidden="true" />
         {label}
+        {featured && <FeaturedDot />}
         <ChevronDown
           size={14}
           className={`transition-transform ${open ? "rotate-180" : ""}`}
@@ -133,12 +149,13 @@ function NavDropdown({
                 key={link.href}
                 href={link.href}
                 onClick={() => setOpen(false)}
-                className={`block px-4 py-2 text-sm transition-colors ${isActive
+                className={`flex items-center gap-1.5 px-4 py-2 text-sm transition-colors ${isActive
                   ? "bg-blue-600 text-white"
                   : "text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800"
                   }`}
               >
                 {link.label}
+                {featuredLinks?.includes(link.href) && !isActive && <FeaturedDot />}
               </Link>
             );
           })}
@@ -151,9 +168,18 @@ function NavDropdown({
 interface NavigationProps {
   isAuthenticated: boolean;
   isAdmin: boolean;
+  /** Hrefs to accent as "featured" for the current season phase. */
+  featuredLinks?: string[];
+  /** Nav dropdown group label to accent for the current season phase. */
+  featuredGroup?: string | null;
 }
 
-export default function Navigation({ isAuthenticated, isAdmin }: NavigationProps) {
+export default function Navigation({
+  isAuthenticated,
+  isAdmin,
+  featuredLinks = [],
+  featuredGroup = null,
+}: NavigationProps) {
   const pathname = usePathname();
   const router = useRouter();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
@@ -224,6 +250,7 @@ export default function Navigation({ isAuthenticated, isAdmin }: NavigationProps
               {PUBLIC_LINKS.map((link) => (
                 <Link key={link.href} href={link.href} className={navItemClass(pathname === link.href)}>
                   {link.label}
+                  {featuredLinks.includes(link.href) && pathname !== link.href && <FeaturedDot />}
                 </Link>
               ))}
 
@@ -243,6 +270,7 @@ export default function Navigation({ isAuthenticated, isAdmin }: NavigationProps
                 AUTHENTICATED_LINKS.map((link) => (
                   <Link key={link.href} href={link.href} className={navItemClass(pathname === link.href)}>
                     {link.label}
+                    {featuredLinks.includes(link.href) && pathname !== link.href && <FeaturedDot />}
                   </Link>
                 ))}
 
@@ -254,6 +282,8 @@ export default function Navigation({ isAuthenticated, isAdmin }: NavigationProps
                     label={group.label}
                     links={group.links}
                     pathname={pathname}
+                    featured={featuredGroup === group.label}
+                    featuredLinks={featuredLinks}
                   />
                 ))}
 
@@ -316,6 +346,7 @@ export default function Navigation({ isAuthenticated, isAdmin }: NavigationProps
               className={mobileItemClass(pathname === link.href)}
             >
               {link.label}
+              {featuredLinks.includes(link.href) && pathname !== link.href && <FeaturedDot />}
             </Link>
           ))}
 

--- a/web/components/NavigationWrapper.tsx
+++ b/web/components/NavigationWrapper.tsx
@@ -1,12 +1,20 @@
 import { getAuthenticatedUser } from "@/lib/auth";
+import { getSeasonContextNow } from "@/lib/season";
+import { PHASE_UI } from "@/lib/season-ui";
 import Navigation from "./Navigation";
 
 export default async function NavigationWrapper() {
-  const user = await getAuthenticatedUser();
+  const [user, ctx] = await Promise.all([
+    getAuthenticatedUser(),
+    getSeasonContextNow(),
+  ]);
+  const ui = PHASE_UI[ctx.phase];
   return (
     <Navigation
       isAuthenticated={user !== null}
       isAdmin={user?.isAdmin ?? false}
+      featuredLinks={ui.featuredLinks}
+      featuredGroup={ui.featuredGroup ?? null}
     />
   );
 }

--- a/web/components/PhaseBanner.tsx
+++ b/web/components/PhaseBanner.tsx
@@ -1,0 +1,36 @@
+import { getSeasonContextNow } from "@/lib/season";
+import { PHASE_UI, describeNextBoundary } from "@/lib/season-ui";
+
+/**
+ * Thin season-cycle banner shown under the nav. Surfaces the current phase,
+ * a one-line blurb, and a countdown to the next league deadline so the site
+ * orients the user to where we are in the Ottoneu year.
+ */
+export default async function PhaseBanner() {
+  const ctx = await getSeasonContextNow();
+  const ui = PHASE_UI[ctx.phase];
+  const next = describeNextBoundary(ctx);
+
+  return (
+    <div className="border-b border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-950">
+      <div className="px-4 sm:px-6 lg:px-8 py-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+        <span className="inline-flex items-center gap-1.5 font-semibold text-amber-700 dark:text-amber-400">
+          <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden="true" />
+          {ui.label}
+          <span className="text-slate-400 dark:text-slate-500 font-normal">
+            · {ctx.leagueSeason} season
+          </span>
+        </span>
+        <span className="text-slate-500 dark:text-slate-400 hidden sm:inline">
+          {ui.blurb}
+        </span>
+        {next && (
+          <span className="ml-auto text-slate-500 dark:text-slate-400 whitespace-nowrap">
+            Next: <span className="font-medium text-slate-700 dark:text-slate-300">{next.label}</span>{" "}
+            {next.daysUntil <= 0 ? "today" : `in ${next.daysUntil} day${next.daysUntil === 1 ? "" : "s"}`}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/lib/roster-reconstruction.ts
+++ b/web/lib/roster-reconstruction.ts
@@ -1,5 +1,6 @@
 import { supabase } from "./supabase";
-import { LEAGUE_ID, SEASON, CAP_PER_TEAM } from "./config";
+import { LEAGUE_ID, CAP_PER_TEAM } from "./config";
+import { getLeagueSeason, getStatsSeason, type SeasonContext } from "./season";
 
 // === Types ===
 
@@ -68,18 +69,24 @@ export interface RosterData {
 // === Data Fetching ===
 
 export async function fetchRosterData(): Promise<RosterData> {
+  // Transactions follow the league season we're managing (the roster timeline);
+  // player stats follow the most recent completed NFL season (PPG context).
+  const [leagueSeason, statsSeason] = await Promise.all([
+    getLeagueSeason(),
+    getStatsSeason(),
+  ]);
   const [txnRes, playersRes, statsRes, pricesRes] = await Promise.all([
     supabase
       .from("transactions")
       .select("player_id, transaction_type, team_name, salary, transaction_date")
       .eq("league_id", LEAGUE_ID)
-      .eq("season", SEASON)
+      .eq("season", leagueSeason)
       .order("transaction_date", { ascending: true }),
     supabase.from("players").select("id, ottoneu_id, name, position, nfl_team").gt("ottoneu_id", 0),
     supabase
       .from("player_stats")
       .select("player_id, ppg, pps, games_played, snaps")
-      .eq("season", SEASON),
+      .eq("season", statsSeason),
     supabase
       .from("league_prices")
       .select("player_id, price, team_name")
@@ -272,7 +279,51 @@ export function getRosterForTeam(rosters: TeamRoster[], teamName: string): TeamR
   return rosters.find((r) => r.team_name === teamName);
 }
 
-export function getDateRange(): { min: string; max: string } {
-  const today = new Date().toISOString().slice(0, 10);
-  return { min: "2025-09-01", max: today };
+export interface RosterSnapshot {
+  label: string;
+  date: string;
+}
+
+export interface RosterSnapshotConfig {
+  dateRange: { min: string; max: string };
+  quickDates: RosterSnapshot[];
+  defaultDate: string;
+}
+
+/** Add `days` to a YYYY-MM-DD date, returning a YYYY-MM-DD string. */
+function addDays(iso: string, days: number): string {
+  return new Date(Date.parse(iso) + days * 86_400_000).toISOString().slice(0, 10);
+}
+
+/**
+ * Build the season-aware roster-snapshot scaffolding (date range, quick-jump
+ * buttons, and the phase-appropriate default) from the resolved season context.
+ *
+ * Pure (no DB access) so it stays client-bundle-safe; the rosters page resolves
+ * the context server-side and passes the result down. Weeks are anchored to the
+ * league season's kickoff; the default snapshot flips to "Pre-Draft" once the
+ * keeper deadline has passed (the pre_draft phase), per the season-cycle spec.
+ */
+export function buildRosterSnapshots(
+  ctx: Pick<SeasonContext, "phase" | "leagueSeason" | "deadlines">,
+  today: string = new Date().toISOString().slice(0, 10),
+): RosterSnapshotConfig {
+  const kickoff = ctx.deadlines.regular_season_start ?? null;
+  const seasonStart = ctx.deadlines.season_start ?? null;
+  const preDraftDate = kickoff ? addDays(kickoff, -1) : null;
+
+  const quickDates: RosterSnapshot[] = [];
+  if (preDraftDate) quickDates.push({ label: "Pre-Draft", date: preDraftDate });
+  if (kickoff) {
+    quickDates.push({ label: "Wk 1", date: kickoff });
+    quickDates.push({ label: "Wk 8", date: addDays(kickoff, 49) });
+    quickDates.push({ label: "Wk 16", date: addDays(kickoff, 105) });
+  }
+  quickDates.push({ label: "Today", date: today });
+
+  const min = seasonStart ?? preDraftDate ?? `${ctx.leagueSeason}-01-01`;
+  const defaultDate =
+    ctx.phase === "pre_draft" && preDraftDate ? preDraftDate : today;
+
+  return { dateRange: { min, max: today }, quickDates, defaultDate };
 }

--- a/web/lib/season-ui.ts
+++ b/web/lib/season-ui.ts
@@ -1,0 +1,83 @@
+/**
+ * Phase-driven UI configuration for the season cycle.
+ *
+ * Pure, client-safe config (no DB access): maps each cycle phase to a label,
+ * a one-line blurb, and which navigation areas to feature. The phase itself is
+ * resolved server-side via web/lib/season.ts (getSeasonContextNow) and passed
+ * down as a prop. Keep this in sync with scripts/season.py phase semantics.
+ */
+
+import type { Phase, SeasonContext } from "./season";
+
+export interface PhaseUi {
+  /** Human-readable phase name for banners and badges. */
+  label: string;
+  /** One-line description of what matters during this phase. */
+  blurb: string;
+  /** Label of the nav dropdown group to highlight (matches PRIVATE_GROUPS). */
+  featuredGroup?: string;
+  /** Hrefs to accent as "featured now" in the nav. */
+  featuredLinks: string[];
+}
+
+export const PHASE_UI: Record<Phase, PhaseUi> = {
+  in_season: {
+    label: "In-Season",
+    blurb: "NFL games are being played — track live VORP, lineups, and standings.",
+    featuredLinks: ["/", "/lineup"],
+  },
+  pre_arb: {
+    label: "Pre-Arbitration",
+    blurb: "Arbitration is upcoming — plan allocations and watch the league's progress.",
+    featuredGroup: "Arbitration",
+    featuredLinks: ["/arbitration", "/arbitration-planner", "/arb-progress"],
+  },
+  pre_keeper: {
+    label: "Pre-Keeper",
+    blurb: "Keep-or-cut decisions ahead — review surplus value and projected salaries.",
+    featuredGroup: "Value",
+    featuredLinks: ["/surplus-value", "/projected-salary"],
+  },
+  pre_draft: {
+    label: "Pre-Draft",
+    blurb: "Auction prep — study projections and pre-draft roster snapshots.",
+    featuredGroup: "Projections",
+    featuredLinks: ["/projections", "/rosters"],
+  },
+};
+
+/** Friendly labels for each league_calendar deadline key. */
+const DEADLINE_LABELS: Record<string, string> = {
+  season_start: "season start",
+  arb_start: "arbitration opens",
+  arb_end: "arbitration deadline",
+  keeper_deadline: "keeper deadline",
+  auction_date: "auction draft",
+  regular_season_start: "kickoff",
+  trade_deadline: "trade deadline",
+  last_auction_date: "last auction",
+};
+
+export interface NextBoundary {
+  label: string;
+  date: string;
+  daysUntil: number;
+}
+
+/** Describe the next upcoming calendar boundary for countdown UI. */
+export function describeNextBoundary(
+  ctx: Pick<SeasonContext, "nextBoundary" | "deadlines">,
+  now: Date | string = new Date(),
+): NextBoundary | null {
+  if (!ctx.nextBoundary) return null;
+  const today = (typeof now === "string" ? now : now.toISOString()).slice(0, 10);
+  const key = Object.entries(ctx.deadlines).find(([, v]) => v === ctx.nextBoundary)?.[0];
+  const daysUntil = Math.round(
+    (Date.parse(ctx.nextBoundary) - Date.parse(today)) / 86_400_000,
+  );
+  return {
+    label: (key && DEADLINE_LABELS[key]) ?? "next deadline",
+    date: ctx.nextBoundary,
+    daysUntil,
+  };
+}

--- a/web/lib/season.ts
+++ b/web/lib/season.ts
@@ -199,3 +199,8 @@ export async function getProjectionSeason(): Promise<number> {
 export async function getArbitrationSeason(): Promise<number> {
   return (await getSeasonContextNow()).arbitrationSeason;
 }
+
+/** The league season whose roster we are currently managing (the advancing pointer). */
+export async function getLeagueSeason(): Promise<number> {
+  return (await getSeasonContextNow()).leagueSeason;
+}


### PR DESCRIPTION
PR #3 of the season-cycle scheme. **Stacked on #534** (the read-path PR) — merge #534 into `main` first, then re-target/merge this.

Makes the site visibly reconfigure itself across the Ottoneu cycle, driven by the date-based resolver.

## Phase-driven UI
- `web/lib/season-ui.ts` — pure, client-safe `PHASE_UI` map (label, blurb, featured nav group/links per phase) + `describeNextBoundary` for countdowns.
- `PhaseBanner` (server component, in the root layout) — current phase, blurb, and a countdown to the next league deadline.
- `Navigation` accents the phase-featured nav group/links with an amber dot (resolved in `NavigationWrapper`, passed down).

## Season-aware roster snapshots
- `season.ts`: new `getLeagueSeason()` accessor.
- `roster-reconstruction.ts`: transactions follow `getLeagueSeason()`, stats follow `getStatsSeason()` (was static `SEASON`). `getDateRange` → pure `buildRosterSnapshots(ctx)`: quick-jump weeks anchored to the league season's kickoff, range bounds from the calendar, and the default snapshot flips to **"Pre-Draft" once the keeper deadline has passed** (the `pre_draft` phase) — otherwise "Today". The rosters page resolves context server-side and passes it down.

## Verification
- Typecheck clean, 245 web tests pass (6 new), lint clean on changed files.
- **Full production build passes** — validates the new server components and the server/client boundary (`cache` usage).

See `docs/exec-plans/season-cycle.md`. Remaining: PR #4 (Python ingestion + arbitration-season alignment), PR #5 (remove static `SEASON` from config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)