### PR TITLE
feat: migrate Python ingestion to the resolver + align arbitration season

### DIFF
--- a/docs/exec-plans/season-cycle.md
+++ b/docs/exec-plans/season-cycle.md
@@ -1,6 +1,6 @@
 # Season Cycle — cross-season data & UI scheme
 
-**Status:** In progress (PR #3 — phase-driven UI + roster snapshots)
+**Status:** In progress (PR #4 — Python ingestion + arbitration-season alignment)
 
 ## Problem
 
@@ -92,7 +92,7 @@ automatic.
    hardcoded `2026` projection year. The projections page now derives its
    selectable years from the resolver. Behavior-preserving today (statsSeason
    2025, projectionSeason 2026), but now rolls forward automatically.
-3. **Phase-driven UI + roster snapshots (this PR):**
+3. **Phase-driven UI + roster snapshots (done — PR #3):**
    - `web/lib/season-ui.ts` — pure, client-safe `PHASE_UI` map (label, blurb,
      featured nav group/links per phase) + `describeNextBoundary` for countdowns.
    - `PhaseBanner` (server component, in the root layout) shows the current
@@ -107,15 +107,24 @@ automatic.
      the keeper deadline has passed** (the `pre_draft` phase) — otherwise
      "Today". The rosters page resolves the context server-side and passes the
      config to `RostersClient`.
-4. **Python ingestion + arbitration-season alignment** — migrate the scrapers /
-   projection scripts off static `SEASON`, and fix arbitration-season tagging.
-   **Known issue surfaced during PR #2:** `arbitration_progress` rows are tagged
-   `season = 2025` (the scraper inherited the stale `SEASON`), even though the
-   2026-season arbitration ran Feb–Mar 2026. Because of this, `arb-progress`
-   page and the arbitration-progress read paths were intentionally **left on the
-   static `SEASON`** in PR #2 — switching them to `arbitrationSeason` (2026)
-   would read empty until the scraper tags by `arbitrationSeason` and existing
-   rows are re-tagged.
+4. **Python ingestion + arbitration-season alignment (done):**
+   - Python convenience accessors in `scripts/season.py` (`league_season`,
+     `projection_season`, `stats_season`, `arbitration_season`) mirroring the TS
+     ones, backed by `league_calendar`.
+   - Scrapers / enqueue resolve their season instead of inheriting static
+     `SEASON`: `scrape_arbitration_progress.py` → `arbitration_season`,
+     `scrape_draft_sharks.py` → `projection_season` (was `SEASON + 1`),
+     `enqueue.py` + the `scrape_roster` / `scrape_player_card` task fallbacks →
+     `league_season`. Each still accepts an explicit `--season`.
+   - `arb-progress` page now reads `arbitrationSeason`.
+   - **Data fix:** the 2026-season arbitration (run Feb–Mar 2026, scraped
+     2026-04-02) had been tagged `season = 2025` because the scraper inherited
+     the stale `SEASON`. Migration `retag_2026_arbitration_season` re-tagged
+     those rows (`arbitration_progress`, `_teams`, `_allocation_details`) to
+     2026 so they align with `arbitrationSeason`. Applied directly to the shared
+     Supabase project (no local migrations dir).
+   - Out of scope: `scripts/visualize_app.py` (a local Streamlit dev tool) still
+     references `SEASON`; left as-is.
 5. **Cleanup** — remove static `SEASON` / `SEASON_END_DATE` / `PRE_ARB_DATE`
    from `config.json` once nothing reads them.
 

--- a/scripts/enqueue.py
+++ b/scripts/enqueue.py
@@ -7,7 +7,8 @@ import uuid
 from dotenv import load_dotenv
 
 from scripts.tasks import PULL_NFL_STATS, PULL_PLAYER_STATS, SCRAPE_ROSTER, SCRAPE_PLAYER_CARD
-from scripts.config import POSITIONS, COLLEGE_POSITIONS, SEASON as DEFAULT_SEASON, LEAGUE_ID as DEFAULT_LEAGUE_ID, HISTORICAL_SEASONS, get_supabase_client as get_supabase
+from scripts.config import POSITIONS, COLLEGE_POSITIONS, LEAGUE_ID as DEFAULT_LEAGUE_ID, HISTORICAL_SEASONS, get_supabase_client as get_supabase
+from scripts.season import league_season
 
 load_dotenv()
 
@@ -201,7 +202,10 @@ def show_status(args):
 
 def main():
     parser = argparse.ArgumentParser(description="Enqueue scraper jobs")
-    parser.add_argument("--season", type=int, default=DEFAULT_SEASON)
+    parser.add_argument(
+        "--season", type=int, default=None,
+        help="Season to tag enqueued jobs with (default: resolved league season)",
+    )
     parser.add_argument("--league-id", type=int, default=DEFAULT_LEAGUE_ID)
 
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -238,6 +242,8 @@ def main():
     status_parser.add_argument("--limit", type=int, default=20)
 
     args = parser.parse_args()
+    if args.season is None:
+        args.season = league_season()
 
     commands = {
         "batch": enqueue_batch,

--- a/scripts/scrape_arbitration_progress.py
+++ b/scripts/scrape_arbitration_progress.py
@@ -26,7 +26,8 @@ import os
 
 from playwright.async_api import async_playwright
 
-from scripts.config import LEAGUE_ID, SEASON, get_supabase_client
+from scripts.config import LEAGUE_ID, get_supabase_client
+from scripts.season import arbitration_season
 
 DEBUG_SCREENSHOT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "debug")
 FANGRAPHS_LOGIN_URL = "https://blogs.fangraphs.com/wp-login.php"
@@ -655,10 +656,14 @@ def _parse_dollar(text: str) -> int | None:
 def main():
     parser = argparse.ArgumentParser(description="Scrape Ottoneu arbitration progress")
     parser.add_argument("--league-id", type=int, default=LEAGUE_ID)
-    parser.add_argument("--season", type=int, default=SEASON)
+    parser.add_argument(
+        "--season", type=int, default=None,
+        help="Season to tag arbitration data with (default: resolved arbitration season)",
+    )
     args = parser.parse_args()
 
-    asyncio.run(scrape_arbitration_progress(args.league_id, args.season))
+    season = args.season if args.season is not None else arbitration_season()
+    asyncio.run(scrape_arbitration_progress(args.league_id, season))
 
 
 if __name__ == "__main__":

--- a/scripts/scrape_draft_sharks.py
+++ b/scripts/scrape_draft_sharks.py
@@ -30,7 +30,8 @@ import asyncio
 
 from playwright.async_api import async_playwright
 
-from scripts.config import SEASON, fetch_all_rows, get_supabase_client
+from scripts.config import fetch_all_rows, get_supabase_client
+from scripts.season import projection_season
 from scripts.name_utils import normalize_player_name
 
 POSITIONS = ["qb", "rb", "wr", "te"]
@@ -186,12 +187,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Scrape Draft Sharks Half-PPR Superflex auction values."
     )
-    # Draft Sharks publishes auction values for the *upcoming* season, so the
-    # default tags them as SEASON + 1 (the projection year the web app reads).
-    default_season = SEASON + 1
+    # Draft Sharks publishes auction values for the *upcoming* season, which the
+    # season-cycle resolver reports as the projection season (the year the web
+    # app reads). Resolved lazily after parsing so an explicit --season skips it.
     parser.add_argument(
-        "--season", type=int, default=default_season,
-        help=f"Season to tag the values with (default: {default_season})",
+        "--season", type=int, default=None,
+        help="Season to tag the values with (default: resolved projection season)",
     )
     parser.add_argument(
         "--positions", nargs="+", default=POSITIONS,
@@ -203,9 +204,10 @@ def main() -> None:
         help="Scrape and match without writing to the database",
     )
     args = parser.parse_args()
+    season = args.season if args.season is not None else projection_season()
 
     print(
-        f"Draft Sharks scrape (season={args.season}, "
+        f"Draft Sharks scrape (season={season}, "
         f"positions={args.positions}, dry_run={args.dry_run})"
     )
 
@@ -218,7 +220,7 @@ def main() -> None:
     lookup = build_player_lookup(supabase)
     print(f"  {len(lookup)} (name, position) keys")
 
-    matched, unmatched = match_rows(scraped, lookup, args.season)
+    matched, unmatched = match_rows(scraped, lookup, season)
     print(f"\nMatched: {len(matched)}")
     print(f"Unmatched: {len(unmatched)}")
     for u in unmatched[:25]:

--- a/scripts/season.py
+++ b/scripts/season.py
@@ -180,6 +180,30 @@ def _fetch_calendar(league_id: int) -> list[dict]:
     )
 
 
+# === Convenience accessors (mirror web/lib/season.ts) ===
+# Each resolves the live context from the league_calendar table. Pass an
+# explicit season on the command line to skip resolution.
+
+def league_season() -> int:
+    """The league season whose roster we're managing (advancing pointer)."""
+    return get_season_context()["league_season"]
+
+
+def projection_season() -> int:
+    """Season that projections / Draft Sharks values target."""
+    return get_season_context()["projection_season"]
+
+
+def stats_season() -> int:
+    """Season whose actual NFL stats drive VORP / surplus / observed PPG."""
+    return get_season_context()["stats_season"]
+
+
+def arbitration_season() -> int:
+    """Season arbitration is being conducted for."""
+    return get_season_context()["arbitration_season"]
+
+
 if __name__ == "__main__":
     import json
     print(json.dumps(get_season_context(), indent=2, default=str))

--- a/scripts/tasks/scrape_player_card.py
+++ b/scripts/tasks/scrape_player_card.py
@@ -3,7 +3,8 @@
 import re
 from datetime import datetime
 
-from scripts.config import LEAGUE_ID, SEASON
+from scripts.config import LEAGUE_ID
+from scripts.season import league_season
 
 # Regex for cleaning salary strings (e.g., "$1,234" -> "1234")
 SALARY_REGEX = re.compile(r"[^\d]")
@@ -31,7 +32,7 @@ async def run(params: dict, context, supabase) -> TaskResult:
     player_name = params.get("player_name", "Unknown")
     player_uuid = params["player_uuid"]
     href = params["href"]
-    default_season = params.get("season", SEASON)
+    default_season = params.get("season") or league_season()
     league_id = params.get("league_id", LEAGUE_ID)
     fantasy_team = params.get("fantasy_team", "FA")
 

--- a/scripts/tasks/scrape_roster.py
+++ b/scripts/tasks/scrape_roster.py
@@ -6,7 +6,8 @@ import re
 
 import pandas as pd
 
-from scripts.config import LEAGUE_ID, SEASON, NFL_TEAM_CODES
+from scripts.config import LEAGUE_ID, NFL_TEAM_CODES
+from scripts.season import league_season
 from scripts.name_utils import normalize_player_name
 from scripts.tasks import SCRAPE_PLAYER_CARD, TaskResult
 
@@ -92,7 +93,9 @@ async def run(params: dict, context, supabase, nfl_stats: pd.DataFrame) -> TaskR
     Returns TaskResult with child_jobs for FA player card scrapes.
     """
     position = params["position"]
-    season = params.get("season", SEASON)
+    # Enqueue stamps the resolved league season into params; fall back to the
+    # resolver only if a job was created without one.
+    season = params.get("season") or league_season()
     league_id = params.get("league_id", LEAGUE_ID)
     level = params.get("level", "pro")  # "pro" or "college"
 

--- a/web/app/arb-progress/page.tsx
+++ b/web/app/arb-progress/page.tsx
@@ -1,5 +1,6 @@
 import { getSupabaseAdmin } from "@/lib/supabase";
-import { LEAGUE_ID, SEASON, NUM_TEAMS } from "@/lib/config";
+import { LEAGUE_ID, NUM_TEAMS } from "@/lib/config";
+import { getArbitrationSeason } from "@/lib/season";
 import { fetchAndMergeData, fetchHoverExtras, buildHoverDataMap } from "@/lib/analysis";
 import { getAuthenticatedUser } from "@/lib/auth";
 import {
@@ -38,25 +39,26 @@ function formatScrapedAt(iso: string | null): string | null {
 
 export default async function ArbProgressPage() {
   const supabase = getSupabaseAdmin();
+  const arbitrationSeason = await getArbitrationSeason();
 
   const [teamsRes, allocationsRes, detailsRes, allPlayers, user] = await Promise.all([
     supabase
       .from("arbitration_progress_teams")
       .select("team_name, is_complete, scraped_at")
       .eq("league_id", LEAGUE_ID)
-      .eq("season", SEASON)
+      .eq("season", arbitrationSeason)
       .order("team_name"),
     supabase
       .from("arbitration_progress")
       .select("player_name, ottoneu_id, team_name, current_salary, raise_amount, new_salary")
       .eq("league_id", LEAGUE_ID)
-      .eq("season", SEASON)
+      .eq("season", arbitrationSeason)
       .order("raise_amount", { ascending: false }),
     supabase
       .from("arbitration_allocation_details")
       .select("ottoneu_id, player_name, owner_team_name, allocating_team_name, amount")
       .eq("league_id", LEAGUE_ID)
-      .eq("season", SEASON),
+      .eq("season", arbitrationSeason),
     fetchAndMergeData(),
     getAuthenticatedUser(),
   ]);
@@ -86,7 +88,7 @@ export default async function ArbProgressPage() {
       <div className="max-w-7xl mx-auto space-y-8">
         <header>
           <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
-            Arbitration Progress ({SEASON})
+            Arbitration Progress ({arbitrationSeason})
           </h1>
           <p className="text-slate-500 dark:text-slate-400 mt-2">
             Live arbitration allocation status for League {LEAGUE_ID}.{" "}


### PR DESCRIPTION
PR #4 of the season-cycle scheme. Based on `main` (independent of #535).

Moves the Python ingestion path off the static config `SEASON` and onto the date-driven resolver, and fixes the mislabeled arbitration data flagged in PR #2.

## Python ingestion
- `scripts/season.py`: convenience accessors `league_season`, `projection_season`, `stats_season`, `arbitration_season` (mirror `season.ts`), backed by `league_calendar`.
- `scrape_arbitration_progress.py` `--season` default → `arbitration_season`.
- `scrape_draft_sharks.py` `--season` default → `projection_season` (was `SEASON + 1`).
- `enqueue.py` `--season` default → `league_season`; `scrape_roster` / `scrape_player_card` task fallbacks resolve `league_season` when params omit it. All still accept an explicit `--season`.

## Arbitration-season alignment
- web `arb-progress` page reads `arbitrationSeason` instead of static `SEASON`.
- **Data fix (already applied to the shared Supabase project):** the 2026-season arbitration (run Feb–Mar 2026, scraped 2026-04-02) was tagged `season=2025` because the scraper inherited the stale `SEASON`. Migration `retag_2026_arbitration_season` re-tagged `arbitration_progress` / `_teams` / `_allocation_details` rows to 2026. Verified: live resolver now reports `arbitration_season = 2026`, matching the data.

## Verification
- 773 Python tests pass; web typecheck + 239 tests + lint clean.
- Live resolver sanity: `arb 2026 · proj 2026 · league 2026 · stats 2025`.

⚠️ Because the re-tag is already live, the currently-deployed `arb-progress` page (still reading `SEASON`=2025) will show empty until this PR deploys. Low impact: offseason, completed cycle.

Remaining: PR #5 — remove the static `SEASON` / `SEASON_END_DATE` / `PRE_ARB_DATE` from `config.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)