### PR TITLE
fix: use service key for CI scraper/projection DB writes

### DIFF
--- a/.github/workflows/backfill-player-stats.yml
+++ b/.github/workflows/backfill-player-stats.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Create .env
         run: |
           echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" > .env
-          echo "SUPABASE_KEY=${{ secrets.SUPABASE_KEY }}" >> .env
+          echo "SUPABASE_KEY=${{ secrets.SUPABASE_SECRET_KEY }}" >> .env
 
       - name: Enqueue and run player stats backfill
         run: |

--- a/.github/workflows/scrape-arbitration-progress.yml
+++ b/.github/workflows/scrape-arbitration-progress.yml
@@ -61,7 +61,7 @@ jobs:
         if: steps.season_gate.outputs.in_season == 'true'
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
           FANGRAPHS_USERNAME: ${{ secrets.FANGRAPHS_USERNAME }}
           FANGRAPHS_PASSWORD: ${{ secrets.FANGRAPHS_PASSWORD }}
         run: |

--- a/.github/workflows/scrape-draft-sharks.yml
+++ b/.github/workflows/scrape-draft-sharks.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Create .env
         run: |
           echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" > .env
-          echo "SUPABASE_KEY=${{ secrets.SUPABASE_KEY }}" >> .env
+          echo "SUPABASE_KEY=${{ secrets.SUPABASE_SECRET_KEY }}" >> .env
 
       - name: Scrape Draft Sharks auction values
         run: python scripts/scrape_draft_sharks.py

--- a/.github/workflows/scrape-league-calendar.yml
+++ b/.github/workflows/scrape-league-calendar.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Create .env
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
           FANGRAPHS_USERNAME: ${{ secrets.FANGRAPHS_USERNAME }}
           FANGRAPHS_PASSWORD: ${{ secrets.FANGRAPHS_PASSWORD }}
         run: |

--- a/.github/workflows/scrape-players.yml
+++ b/.github/workflows/scrape-players.yml
@@ -58,7 +58,7 @@ jobs:
         if: steps.season_gate.outputs.in_season == 'true'
         run: |
           echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" > .env
-          echo "SUPABASE_KEY=${{ secrets.SUPABASE_KEY }}" >> .env
+          echo "SUPABASE_KEY=${{ secrets.SUPABASE_SECRET_KEY }}" >> .env
 
       - name: Run scraper
         if: steps.season_gate.outputs.in_season == 'true'

--- a/.github/workflows/update-projections.yml
+++ b/.github/workflows/update-projections.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Run projections update script
       env:
         SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-        SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+        SUPABASE_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
       run: python scripts/update_projections.py

--- a/docs/references/environment-variables.md
+++ b/docs/references/environment-variables.md
@@ -5,7 +5,7 @@
 | Variable | Purpose |
 |----------|---------|
 | `SUPABASE_URL` | Supabase project URL |
-| `SUPABASE_KEY` | Supabase anon/service key |
+| `SUPABASE_KEY` | Supabase key used by `scripts/config.get_supabase_client()`. **Must be the service/secret key**, not the anon key: scrapers and the projection pipeline write to RLS-protected tables (e.g. `players`, `player_projections`, `draft_sharks_values`) that have only anon `SELECT` policies, so writes require a key that bypasses RLS. CI workflows source this from the `SUPABASE_SECRET_KEY` GitHub Actions secret. |
 | `FANGRAPHS_USERNAME` | FanGraphs login username (for arbitration progress scraper) |
 | `FANGRAPHS_PASSWORD` | FanGraphs login password (for arbitration progress scraper) |
 


### PR DESCRIPTION
Migrations 026/027 enabled RLS on draft_sharks_values, player_projections,
and other write targets with only anon SELECT policies, on the documented
assumption that writes use a service key that bypasses RLS. But the CI
workflows sourced SUPABASE_KEY from the anon-key secret, so every write to
an RLS-protected table failed with "new row violates row-level security
policy" (42501) — breaking the Draft Sharks scraper and Update Projections.

Point all writing workflows at the existing SUPABASE_SECRET_KEY secret
(the RLS-bypassing service key) instead of re-opening anon write access,
which would undo migration 026's rls_disabled_in_public fix. Also document
that SUPABASE_KEY must be the service key.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
