### PR TITLE
fix: repair Backfill Player Stats dependency install

### DIFF
--- a/.github/workflows/backfill-player-stats.yml
+++ b/.github/workflows/backfill-player-stats.yml
@@ -21,17 +21,21 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
+        # Pinned to 3.9 to match the project's dependency stack (pandas==1.5.3 /
+        # numpy==1.26.4 ship no wheels for 3.12) and the local venv + run-tests.yml.
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.9"
           cache: pip
 
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install supabase python-dotenv nfl_data_py pandas numpy
-          # Install this repo as a package so `import scripts.*` resolves
-          pip install -e . --no-deps
+          # The backfill runs scripts/worker.py, which imports the full app stack
+          # (playwright, nfl_data_py, pandas, ...). Install the package WITH its
+          # pyproject-pinned dependencies so the versions stay a single source of
+          # truth rather than a hand-maintained list that drifts.
+          pip install -e .
 
       - name: Create .env
         run: |

--- a/scripts/tasks/pull_player_stats.py
+++ b/scripts/tasks/pull_player_stats.py
@@ -129,10 +129,14 @@ def run(params: dict, supabase: Client) -> TaskResult:
             .agg(agg_cols)
         )
 
-        # Match to DB players and build upsert rows
-        matched = 0
+        # Match to DB players, accumulating by (player_id, season). Distinct
+        # nflverse display names can normalize to the same Ottoneu player (name
+        # variants), so we merge their games and points here — otherwise the
+        # upsert would carry duplicate (player_id, season) rows and Postgres
+        # rejects the whole batch with "ON CONFLICT DO UPDATE command cannot
+        # affect row a second time".
         unmatched_names: set[str] = set()
-        upsert_rows: list[dict] = []
+        accum: dict[tuple[str, int], dict] = {}
 
         for _, row in combined.iterrows():
             raw_name = str(row.get("player_display_name", ""))
@@ -163,20 +167,29 @@ def run(params: dict, supabase: Client) -> TaskResult:
                 "fg_made_50_plus": _safe_int(row.get("fg_made_50_plus")),
                 "pat_made": _safe_int(row.get("pat_made")),
             }
-            total_points = round(_calc_points(raw_stats), 2)
+            total_points = _calc_points(raw_stats)
             games = _safe_int(row.get("games_played")) or 0
 
-            stat_row: dict = {
-                "player_id": player_uuid,
-                "season": season,
+            entry = accum.setdefault(
+                (player_uuid, season),
+                {"player_id": player_uuid, "season": season, "games": 0, "points": 0.0},
+            )
+            entry["games"] += games
+            entry["points"] += total_points
+
+        upsert_rows: list[dict] = []
+        for entry in accum.values():
+            games = entry["games"]
+            total_points = round(entry["points"], 2)
+            upsert_rows.append({
+                "player_id": entry["player_id"],
+                "season": entry["season"],
                 "games_played": games if games > 0 else None,
                 "total_points": total_points,
                 "ppg": round(total_points / games, 2) if games > 0 else 0.0,
-            }
+            })
 
-            upsert_rows.append(stat_row)
-            matched += 1
-
+        matched = len(upsert_rows)
         print(f"Matched {matched} player/season rows. Unmatched: {len(unmatched_names)}")
         if unmatched_names:
             sample = sorted(unmatched_names)[:20]

--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -34,6 +34,9 @@ class ScraperWorker:
         self.browser = None
         self.browser_context = None
         self.nfl_stats_cache: dict[int, pd.DataFrame] = {}
+        # Count of jobs that exhausted their retries and were marked 'failed'.
+        # Used to give the process a non-zero exit so CI surfaces silent failures.
+        self.failed_jobs = 0
 
     async def start(self, poll: bool = False, interval: int = 30):
         """Run the worker loop.
@@ -194,6 +197,7 @@ class ScraperWorker:
                 "last_error": error,
                 "completed_at": "now()",
             }).eq("id", job["id"]).execute()
+            self.failed_jobs += 1
             print(f"  Max attempts reached. Marked as failed.")
 
     def _enqueue_child_jobs(self, child_jobs: list[dict], parent_job: dict):
@@ -256,6 +260,13 @@ async def main():
 
     worker = ScraperWorker()
     await worker.start(poll=args.poll, interval=args.interval)
+
+    # Exit non-zero if any job exhausted its retries, so CI (which runs the
+    # worker as the final step) fails loudly instead of going green on a job
+    # that never actually wrote its data.
+    if worker.failed_jobs:
+        print(f"{worker.failed_jobs} job(s) failed after exhausting retries.")
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The workflow ran on Python 3.12 and installed an unpinned pandas, but
scripts/worker.py imports the full app stack (playwright, nfl_data_py,
pandas). nfl_data_py constrains pandas below 2, so pip backtracked to
pandas==1.5.3 — which has no 3.12 wheel and fails to build from source on
modern setuptools ("No module named 'pkg_resources'"). The workflow also
never installed playwright, which the worker imports at module load.

Pin the job to Python 3.9 (matching the project's pinned stack, the local
venv, and run-tests.yml) and install the package with its pyproject deps
so versions are a single source of truth instead of a drifting hand list.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
