### PR TITLE
Lint migrations/ naming + document migration workflow (#547)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,9 @@ The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year
 
 ### Database migration workflow
 
-After creating a new migration file in `migrations/` and applying it (via `mcp__supabase__apply_migration` or the Supabase dashboard):
+Migration files live in `migrations/` and follow the `NNN_snake_case.sql` convention (zero-padded, contiguous sequence) documented in [migrations/README.md](migrations/README.md). The naming and sequence are linted offline by `just check-migrations` (also run under `just check-arch` and `just test-python`). The remote `supabase_migrations.schema_migrations` table — auditable via the `list_migrations` MCP tool — is the system of record for what has actually been applied.
+
+After creating a new migration file in `migrations/` (numbered as the current highest + 1) and applying it (via `mcp__supabase__apply_migration` or the Supabase dashboard):
 
 1. **Regenerate TypeScript types** using `mcp__supabase__generate_typescript_types` (or `npx supabase gen types typescript`).
 2. **Update `web/types/supabase.ts`** with the regenerated output so the Supabase client recognizes the new table.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,9 @@ The `WeightedPPGFeature` applies an H2/H1 snap-per-game multiplier to first-year
 
 ### Database migration workflow
 
-After creating a new migration file in `migrations/` and applying it (via `mcp__supabase__apply_migration` or the Supabase dashboard):
+Migration files live in `migrations/` and follow the `NNN_snake_case.sql` convention (zero-padded, contiguous sequence) documented in [migrations/README.md](migrations/README.md). The naming and sequence are linted offline by `just check-migrations` (also run under `just check-arch` and `just test-python`). The remote `supabase_migrations.schema_migrations` table — auditable via the `list_migrations` MCP tool — is the system of record for what has actually been applied.
+
+After creating a new migration file in `migrations/` (numbered as the current highest + 1) and applying it (via `mcp__supabase__apply_migration` or the Supabase dashboard):
 
 1. **Regenerate TypeScript types** using `mcp__supabase__generate_typescript_types` (or `npx supabase gen types typescript`).
 2. **Update `web/types/supabase.ts`** with the regenerated output so the Supabase client recognizes the new table.

--- a/Justfile
+++ b/Justfile
@@ -87,9 +87,13 @@ roster-context season="2026":
 # ──────────────────────────────────────────────
 
 # Run architectural/structural tests only
-check-arch:
+check-arch: check-migrations
     {{pytest}} scripts/tests/test_architecture.py -v
     cd web && npx jest __tests__/lib/architecture.test.ts --no-coverage
+
+# Lint the migrations/ directory naming + sequence (offline; see migrations/README.md)
+check-migrations:
+    {{pytest}} scripts/tests/test_migrations.py -v
 
 # Check documentation freshness
 check-docs:

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,50 @@
+# Database migrations
+
+This directory holds the hand-authored SQL for every schema change, in
+apply-order. It is the **source of intent**; the **system of record** for what
+has actually been applied is the remote Supabase database
+(`supabase_migrations.schema_migrations`).
+
+## Naming convention
+
+Each file is named:
+
+```
+NNN_snake_case_description.sql
+```
+
+- `NNN` — a 3-digit, zero-padded sequence number (`001`, `002`, … `027`).
+- The sequence must be **contiguous** (no gaps) and **unique** (no duplicate
+  numbers).
+- The slug is lowercase `snake_case` describing the change
+  (e.g. `023_create_draft_capital.sql`).
+
+This convention is enforced offline by `scripts/tests/test_migrations.py`
+(run via `just check-migrations`, `just check-arch`, or the full
+`just test-python`), so a misnamed file, a gap, or a duplicate number fails CI.
+
+## Workflow
+
+1. Create the next file: `migrations/NNN_short_description.sql` (NNN = current
+   highest + 1).
+2. Apply it to the remote database via the Supabase MCP `apply_migration` tool
+   (or the Supabase dashboard). `apply_migration` records the change in
+   `supabase_migrations.schema_migrations`, which is the canonical audit trail.
+3. Follow the post-migration steps in
+   [CLAUDE.md → Database migration workflow](../CLAUDE.md): regenerate the
+   TypeScript types, update `web/types/supabase.ts`, and update
+   `docs/generated/db-schema.md`.
+
+## Local ↔ remote reconciliation
+
+The local files (`NNN_*.sql`) and the remote `schema_migrations` entries
+(Supabase stores them with `YYYYMMDDHHMMSS` version stamps) do **not** map 1:1
+by name — historically some remote entries carry the `NNN_` prefix and some
+don't. The local sequence is what we lint mechanically; the remote list is the
+source of truth for *applied* state.
+
+To audit the remote side, list the applied migrations with the Supabase MCP
+`list_migrations` tool and compare against this directory. There is no automated
+CI check for this because CI has no direct connection to the
+`supabase_migrations` schema (the PostgREST client only exposes the `public`
+schema).

--- a/scripts/tests/test_migrations.py
+++ b/scripts/tests/test_migrations.py
@@ -1,0 +1,91 @@
+"""Structural tests that keep the local ``migrations/`` directory consistent.
+
+The remote database is the system of record for *which* migrations have been
+applied (Supabase tracks them in ``supabase_migrations.schema_migrations``,
+auditable via the ``list_migrations`` MCP tool). The local ``migrations/*.sql``
+files are the hand-authored *source of intent*. These tests prevent the local
+side from drifting in the ways we can catch offline — bad filenames, gaps, or
+duplicate numbers — so new files always map cleanly to a tracked version.
+
+See: migrations/README.md for the full convention and workflow.
+"""
+
+import re
+from pathlib import Path
+
+# Resolve project root (two levels up from this test file)
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+MIGRATIONS_DIR = PROJECT_ROOT / "migrations"
+
+# Canonical migration filename: 3-digit zero-padded sequence number, an
+# underscore, then a lowercase snake_case slug, then ``.sql``.
+#   e.g. 027_create_draft_sharks_values.sql
+MIGRATION_RE = re.compile(r"^(\d{3})_[a-z0-9]+(?:_[a-z0-9]+)*\.sql$")
+
+
+def _migration_files() -> list[Path]:
+    """Return all ``.sql`` files in the migrations directory, sorted by name."""
+    return sorted(MIGRATIONS_DIR.glob("*.sql"))
+
+
+class TestMigrationNaming:
+    """Enforce the ``NNN_snake_case.sql`` convention and a gapless sequence."""
+
+    def test_migrations_directory_exists(self):
+        assert MIGRATIONS_DIR.is_dir(), (
+            f"Expected a migrations directory at {MIGRATIONS_DIR}.\n"
+            "Migration files are the hand-authored source of intent for schema "
+            "changes — see migrations/README.md."
+        )
+
+    def test_filenames_follow_convention(self):
+        """Every migration must be named ``NNN_snake_case.sql``.
+
+        WHY: A consistent, zero-padded, sortable name lets a human (or agent)
+        match a local file to its remote ``schema_migrations`` entry at a glance
+        and keeps the directory listing in apply-order.
+
+        FIX: Rename the offending file to ``NNN_lowercase_snake_case.sql`` where
+        NNN is the next sequential number.
+        """
+        offenders = [
+            p.name for p in _migration_files() if not MIGRATION_RE.match(p.name)
+        ]
+        assert not offenders, (
+            "Migration filenames must match `NNN_snake_case.sql` "
+            "(3-digit number, underscore, lowercase snake_case slug).\n"
+            f"Offending files: {offenders}\n"
+            "FIX: Rename them to the convention documented in migrations/README.md."
+        )
+
+    def test_numbers_are_sequential_with_no_gaps_or_duplicates(self):
+        """Migration numbers must be 001, 002, … N with no gaps or repeats.
+
+        WHY: A gap means a migration was lost; a duplicate means two files claim
+        the same slot and will apply in an ambiguous order. Either is a sign the
+        local directory has drifted from what was actually applied.
+
+        FIX: Renumber so the sequence is contiguous starting at 001. If a number
+        is duplicated, bump the later file(s) to the next free number.
+        """
+        numbers = [
+            int(MIGRATION_RE.match(p.name).group(1))
+            for p in _migration_files()
+            if MIGRATION_RE.match(p.name)
+        ]
+        assert numbers, "No migration files found — expected at least one."
+
+        duplicates = sorted({n for n in numbers if numbers.count(n) > 1})
+        assert not duplicates, (
+            f"Duplicate migration numbers found: {duplicates}.\n"
+            "FIX: Two files share a sequence number — bump the later one."
+        )
+
+        expected = list(range(1, len(numbers) + 1))
+        actual = sorted(numbers)
+        assert actual == expected, (
+            "Migration numbers must form a gapless sequence starting at 001.\n"
+            f"Expected {expected[0]:03d}..{expected[-1]:03d}, "
+            f"but found gaps/jumps: {[f'{n:03d}' for n in actual]}.\n"
+            "FIX: Renumber so the sequence is contiguous."
+        )


### PR DESCRIPTION
Closes #547.

## Context

Spun out of #126 (closed): migration *tracking* is already handled by Supabase's `schema_migrations` (auditable via `list_migrations`). The remaining gap was **naming drift** — the local `migrations/NNN_*.sql` files are the source of intent, but nothing mechanically guarded them from gaps, duplicate numbers, or off-convention names.

CI has no direct connection to the `supabase_migrations` schema (the PostgREST client only exposes `public`), so a remote-vs-local comparison can't run offline. This PR delivers the parts that *can* be enforced offline, plus documentation of the manual remote reconciliation step.

## Changes

- **`scripts/tests/test_migrations.py`** — structural test enforcing:
  - filenames match `NNN_snake_case.sql` (3-digit zero-padded, lowercase snake_case)
  - numbers form a contiguous sequence starting at `001` with no gaps or duplicates

  Failures carry teaching-style WHY/FIX messages, matching `test_architecture.py`.
- **`migrations/README.md`** — documents the naming convention, the apply-via-MCP workflow, and how local ↔ remote reconciliation works (use `list_migrations`; no CI check, and why).
- **`just check-migrations`** recipe (also wired into `just check-arch`; runs under `just test-python` too).
- **CLAUDE.md / AGENTS.md** — migration-workflow sections now point at the convention, the linter, and `list_migrations` as the system of record.

## Verification

- `just check-migrations` → 3 passed (current `001`–`027` all conform)
- `just check-docs` → all documentation checks passed
- `scripts/tests/test_architecture.py` → 20 passed (docs-exist rule happy with the new `migrations/README.md` link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)