### PR TITLE
docs: daily harness audit 2026-06-03

### DIFF
--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -9,6 +9,10 @@
 | Shared config | `config.json` | **Single source of truth** for every constant shared across Python and TypeScript |
 | TS types | `web/lib/types.ts` | All shared TypeScript interfaces (`CorePlayer → RosteredPlayer → StatsPlayer → Player`) |
 | Data layer | `web/lib/data.ts` | **Unified data access** — all Supabase fetching goes through here |
+| Season resolver (Python) | `scripts/season.py` | `league_season`, `projection_season`, `stats_season`, `arbitration_season` — reads `league_calendar`, replaces the removed `SEASON` constant |
+| Season resolver (TS) | `web/lib/season.ts` | `getSeasonContextNow`, `getStatsSeason`, `getProjectionSeason`, `getArbitrationSeason`, `getSalarySnapshotDates` — server-side, React-cached per request |
+| Phase UI helpers | `web/lib/season-ui.ts` | Pure client-safe `PHASE_UI` map + `describeNextBoundary` (countdown). Powers `<PhaseBanner>` + the amber phase accent on `Navigation` |
+| Lineup logic | `web/lib/lineup.ts` | Superflex starting-lineup planner: slot definitions and greedy fill from a roster |
 | Scoring | `web/lib/scoring.ts` | Ottoneu Half PPR scoring formula (`calculateFantasyPoints`) |
 | Analysis math | `web/lib/analysis.ts` | Projection-enriched data + backtest fetching (builds on `data.ts`) |
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
@@ -54,7 +58,8 @@ manipulation is needed.** Import everything via the canonical `scripts.`
 namespace:
 
 ```python
-from scripts.config import get_supabase_client, SEASON
+from scripts.config import get_supabase_client, LEAGUE_ID
+from scripts.season import league_season  # resolver — replaces the removed SEASON constant
 from scripts.analysis_utils import fetch_multi_season_stats
 from scripts.feature_projections.runner import run_model
 ```

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -103,7 +103,8 @@ just test-web-file <path>  # Run a single web test file (e.g. just test-web-file
 just scrape             # Full scrape pipeline
 just analyze            # Run all analysis scripts
 just check-db           # Verify database contents
-just check-arch         # Architectural/structural tests only
+just check-arch         # Architectural/structural tests only (includes check-migrations)
+just check-migrations   # Lint migrations/ file names + sequence (offline; see migrations/README.md)
 just check-docs         # Documentation freshness check
 just ci                 # Full CI suite (lint + typecheck + tests + doc checks)
 
@@ -125,6 +126,9 @@ just backfill-vegas [--since YYYY] [--dry-run]         # Backfill team_vegas_lin
 just seed-win-totals --season YYYY                     # Upsert preseason sportsbook win totals (implied_total left NULL until schedule drops)
 just scrape-draft-sharks [--season YYYY] [--positions qb rb wr te] [--dry-run]  # Scrape Draft Sharks Half-PPR Superflex auction values (stored ×2 for the $400 cap)
 just scrape-calendar [--dry-run]                      # Scrape the Ottoneu finances Calendar into league_calendar (drives the season-cycle resolver)
+
+# Roster-question context pack (used by the /ottoneu-roster-question skill)
+just roster-context [season]                        # Build a live roster-economics snapshot (defaults to the resolver's season; e.g. just roster-context 2026)
 
 # Ad-hoc DB queries
 just py "<python-snippet>"                          # Run a one-off Python snippet against the project venv (read-only diagnostics)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -30,7 +30,7 @@ Several formerly-standalone pages were consolidated into **tabbed routes** using
 | Component | Purpose |
 |-----------|---------|
 | `Navigation.tsx` | Shared nav bar across all pages |
-| `Tabs` | URL-synced (`?tab=`) tab bar. Accepts `tabs: { id, label, content }[]`; renders all panels and hides inactive ones (so client state in a panel survives switches). Panels can be server-rendered sections passed as `content`. Used by `/players`, `/value`, `/arbitration`. |
+| `Tabs` | URL-synced (`?tab=`) tab bar. Accepts `tabs: { id, label, content }[]`; **only the active panel is rendered** — switching tabs unmounts the previous panel, so panels that need state to survive a switch must lift it into the URL (e.g. `ModeToggle` writes `?mode=`). The active tab is resolved server-side from `searchParams.tab` and passed in as `activeId`, so panels can be server components that fetch their own data. The lightweight client `TabBar` only receives serializable `{ id, label }` and updates the URL on click. Used by `/players`, `/value`, `/arbitration`. |
 | `DataTable` | Generic sortable table with type safety and highlight rules |
 | `SummaryCard` | Metric display cards with variant styles (default, positive, negative) |
 | `PositionFilter` | Position selection buttons with multi-select support |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -43,6 +43,7 @@ cd web && ./node_modules/.bin/tsc --noEmit
 - **`scripts/tests/test_learned_model_validation.py`** — Validates trained model JSON artifacts: structure, dimensions, coefficient reasonableness, overfitting detection
 - **`scripts/tests/test_cross_model_consistency.py`** — Cross-model checks: feature registry coverage, baseline existence, learned model files, no duplicates, known equivalences
 - **`scripts/tests/test_architecture.py`** — Structural/architectural enforcement tests
+- **`scripts/tests/test_migrations.py`** — Enforces `migrations/` naming (`NNN_snake_case.sql`) and gap/duplicate-free sequence (run via `just check-migrations`; also gated by `just check-arch` and `just test-python`). See `migrations/README.md` for the convention.
 - **`scripts/tests/test_projection_methods.py`** — Legacy projection method tests
 
 ## Coupled Test Data
@@ -60,7 +61,8 @@ Harness engineering tests that enforce architectural rules mechanically. Each te
 - **TypeScript:** `web/__tests__/lib/architecture.test.ts` — layer boundaries, type locations, config sync
 
 ```bash
-just check-arch    # Run architectural tests only
+just check-arch          # Run architectural tests only (includes check-migrations)
+just check-migrations    # Lint migrations/ file names + sequence only
 ```
 
 ## Documentation Freshness Check

--- a/docs/references/environment-variables.md
+++ b/docs/references/environment-variables.md
@@ -6,8 +6,10 @@
 |----------|---------|
 | `SUPABASE_URL` | Supabase project URL |
 | `SUPABASE_KEY` | Supabase key used by `scripts/config.get_supabase_client()`. **Must be the service/secret key**, not the anon key: scrapers and the projection pipeline write to RLS-protected tables (e.g. `players`, `player_projections`, `draft_sharks_values`) that have only anon `SELECT` policies, so writes require a key that bypasses RLS. CI workflows source this from the `SUPABASE_SECRET_KEY` GitHub Actions secret. |
-| `FANGRAPHS_USERNAME` | FanGraphs login username (for arbitration progress scraper) |
-| `FANGRAPHS_PASSWORD` | FanGraphs login password (for arbitration progress scraper) |
+| `FANGRAPHS_USERNAME` | FanGraphs login username (required by the arbitration-progress and league-calendar scrapers — Ottoneu is hosted under FanGraphs auth) |
+| `FANGRAPHS_PASSWORD` | FanGraphs login password (same scrapers as above) |
+| `SEASON_OVERRIDE` | Optional. Short-circuits the date-driven season resolver — set to a season label (e.g. `2026`) for testing or off-schedule Ottoneu events. Read by both `scripts/season.py` and `web/lib/season.ts` (server-side), so a single env-var set covers Python + Next.js. |
+| `PHASE_OVERRIDE` | Optional. Short-circuits the resolver's phase (`pre_arb` / `pre_keeper` / `pre_draft` / `in_season`); pairs with `SEASON_OVERRIDE`. Same dual-consumer behavior as above. |
 
 ## `web/.env.local` (for Next.js)
 


### PR DESCRIPTION
## Summary

Daily sweep of the harness docs against `main` since the 2026-06-02 audit. Five fixes:

### Commits reviewed (last 25 hours)

- **#548 / #547** — feat: lint migrations/ naming + document migration workflow (adds `scripts/tests/test_migrations.py`, `just check-migrations`, `migrations/README.md`)
- **#546** — feat: add `just roster-context` recipe (was advertised by the `/ottoneu-roster-question` skill but never wired up)
- **#545** — docs: sync AGENTS.md and CLAUDE.md, improve doc freshness checker (anchor-stripping + bare-filename skip)
- **#544** — docs: daily harness audit 2026-06-02 (yesterday's run)

### Changes made

- **`docs/COMMANDS.md`** — add `just check-migrations` (new in #547) under "Harness checks" and `just roster-context` (new in #546) as a dedicated section. Both recipes existed in the `Justfile` but weren't listed for agents.
- **`docs/TESTING.md`** — document `scripts/tests/test_migrations.py` in "Key Test Files" and add `just check-migrations` to the structural-tests block.
- **`docs/CODE_ORGANIZATION.md`** — the Python import example still showed `from scripts.config import ..., SEASON`, but the `SEASON` constant was deleted in #537. Replaced with `LEAGUE_ID` + `scripts.season.league_season` so the example actually runs. Also added `scripts/season.py`, `web/lib/season.ts`, `web/lib/season-ui.ts`, and `web/lib/lineup.ts` to the file-locations table; they're high-traffic now but weren't enumerated.
- **`docs/FRONTEND.md`** — the `Tabs` component description claimed it "renders all panels and hides inactive ones (so client state in a panel survives switches)". The actual implementation (`web/components/Tabs.tsx`) renders only `active.content`, so client state in non-active tabs is unmounted on switch. Corrected the description and pointed at the URL-state-lifting workaround (e.g. `ModeToggle`'s `?mode=`).
- **`docs/references/environment-variables.md`** — extended the `FANGRAPHS_*` note to cover the new league-calendar scraper (#532), and added `SEASON_OVERRIDE` / `PHASE_OVERRIDE` — they're consumed by both `scripts/season.py` and `web/lib/season.ts` but were only documented inside the season-cycle exec plan.

### Schema drift check

- Latest migration is `migrations/027_create_draft_sharks_values.sql`. `docs/generated/db-schema.md` already lists `draft_sharks_values` (added in PR #524) and `league_calendar` (added in #532); the "Twenty-one tables" count is correct. No schema doc updates required this run.

### Flagged for human follow-up

- None. All freshness-check (`just check-docs`) categories pass after these edits.

## Test plan

- [x] `python3 scripts/check_docs_freshness.py` passes
- [x] Cross-referenced every doc edit against the linked code (`Justfile`, `scripts/season.py`, `web/components/Tabs.tsx`, `scripts/tests/test_migrations.py`)

https://claude.ai/code/session_01LZ6K2PD9ddbvPh6oN2seqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZ6K2PD9ddbvPh6oN2seqS)_