### PR TITLE
docs: daily harness audit 2026-06-04

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -93,6 +93,7 @@ Install `just` once with `brew install just`, then run any recipe from the repo 
 just                    # List all recipes
 just install            # Install all dependencies (Python + Node)
 just dev                # Start Next.js dev server on localhost:3000
+just dev-stop           # Kill the dev server + stray Turbopack/postcss workers
 just build              # Production build
 just lint               # ESLint
 just typecheck          # TypeScript type check
@@ -103,7 +104,9 @@ just test-web-file <path>  # Run a single web test file (e.g. just test-web-file
 just scrape             # Full scrape pipeline
 just analyze            # Run all analysis scripts
 just check-db           # Verify database contents
-just check-arch         # Architectural/structural tests only
+just roster-context [season]  # Build the roster-question context pack (live league data; default season 2026)
+just check-arch         # Architectural/structural tests only (includes check-migrations)
+just check-migrations   # Lint migrations/ naming + sequence (offline; see migrations/README.md)
 just check-docs         # Documentation freshness check
 just ci                 # Full CI suite (lint + typecheck + tests + doc checks)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -43,6 +43,7 @@ cd web && ./node_modules/.bin/tsc --noEmit
 - **`scripts/tests/test_learned_model_validation.py`** — Validates trained model JSON artifacts: structure, dimensions, coefficient reasonableness, overfitting detection
 - **`scripts/tests/test_cross_model_consistency.py`** — Cross-model checks: feature registry coverage, baseline existence, learned model files, no duplicates, known equivalences
 - **`scripts/tests/test_architecture.py`** — Structural/architectural enforcement tests
+- **`scripts/tests/test_migrations.py`** — Enforces `migrations/` naming (`NNN_snake_case.sql`) and contiguous, duplicate-free sequence (see [migrations/README.md](../migrations/README.md))
 - **`scripts/tests/test_projection_methods.py`** — Legacy projection method tests
 
 ## Coupled Test Data
@@ -60,7 +61,8 @@ Harness engineering tests that enforce architectural rules mechanically. Each te
 - **TypeScript:** `web/__tests__/lib/architecture.test.ts` — layer boundaries, type locations, config sync
 
 ```bash
-just check-arch    # Run architectural tests only
+just check-arch         # Run architectural tests only (includes check-migrations)
+just check-migrations   # Lint migrations/ naming + sequence only (offline)
 ```
 
 ## Documentation Freshness Check


### PR DESCRIPTION
## Summary

Daily harness audit for 2026-06-04. Three Justfile recipes shipped recently without making it into `docs/COMMANDS.md`, and the new `test_migrations.py` wasn't called out in `docs/TESTING.md`.

## Commits reviewed (since previous audit `b6759d9`)

- `9242d27` feat: lint `migrations/` naming + document migration workflow (#547) — added `just check-migrations` recipe and `scripts/tests/test_migrations.py`.
- `0c25817` feat: add `just roster-context` recipe (#546) — added recipe wrapping `scripts/roster_context_pack.py`.
- `a7b0f4b` docs: sync AGENTS.md and CLAUDE.md, improve doc freshness checker (#545) — covered in last audit's follow-ups.

## Changes made

**`docs/COMMANDS.md` — just recipes block:**
- Added `just dev-stop` (was already in Justfile + referenced from FRONTEND.md, never in COMMANDS).
- Added `just roster-context [season]` (introduced in #546).
- Added `just check-migrations` and called out that `just check-arch` runs it as a dep (per #547).

**`docs/TESTING.md`:**
- Added `scripts/tests/test_migrations.py` to the **Key Test Files** list with a link back to `migrations/README.md`.
- Updated the structural-tests code block to surface `just check-migrations` alongside `just check-arch`.

## Schema doc check

- Migrations directory currently runs `001` → `027` contiguous (latest: `027_create_draft_sharks_values.sql`).
- `docs/generated/db-schema.md` already documents `draft_sharks_values` and `league_calendar` and counts twenty-one tables — matches reality. No drift.
- `python scripts/check_docs_freshness.py` passes after edits.

## Items flagged for human follow-up

None — the harness docs are otherwise in sync with the codebase.

## Test plan

- [x] `python scripts/check_docs_freshness.py` passes.
- [x] All three documented `just` recipes exist in the Justfile.
- [x] `scripts/tests/test_migrations.py` exists at the documented path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CeKjBVBSpgEYoLHHbVgvPQ)_