### PR TITLE
docs: daily harness audit 2026-06-05

### DIFF
--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -14,8 +14,8 @@
 | Arb logic | `web/lib/arb-logic.ts` | Arbitration simulation logic |
 | API input schemas | `web/lib/schemas/` | Zod schemas for API route bodies (admin/users, arbitration-plans, surplus-adjustments) |
 | Request validation | `web/lib/validate.ts` | `parseJson(req, schema)` helper — returns typed data or a 400 response with Zod issues |
-| DB schema | `schema.sql` | Canonical schema definition |
-| Migrations | `migrations/` | Numbered SQL migration files |
+| DB schema | `schema.sql` | Periodic Supabase MCP dump — may lag the migrations directory; see [db-schema.md](generated/db-schema.md#schema-files) |
+| Migrations | `migrations/` | Numbered `NNN_snake_case.sql` files (source of intent); linted by `just check-migrations`. See [migrations/README.md](../migrations/README.md) |
 | Components | `web/components/` | Reusable React components |
 | Pages | `web/app/` | Next.js App Router pages |
 | Feature projections | `scripts/feature_projections/` | Feature-based projection system (features, combiner, runner, backtest, CLI) |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -93,6 +93,7 @@ Install `just` once with `brew install just`, then run any recipe from the repo 
 just                    # List all recipes
 just install            # Install all dependencies (Python + Node)
 just dev                # Start Next.js dev server on localhost:3000
+just dev-stop           # Kill the dev server + stray Turbopack/postcss workers
 just build              # Production build
 just lint               # ESLint
 just typecheck          # TypeScript type check
@@ -101,11 +102,13 @@ just test-python        # Python tests with coverage
 just test-web           # Jest tests with coverage
 just test-web-file <path>  # Run a single web test file (e.g. just test-web-file __tests__/lib/session.test.ts)
 just scrape             # Full scrape pipeline
-just analyze            # Run all analysis scripts
+just analyze            # Update player projections (active model + promote + rookie fallback)
 just check-db           # Verify database contents
-just check-arch         # Architectural/structural tests only
+just check-arch         # Architectural/structural tests (includes check-migrations)
+just check-migrations   # Lint migrations/ naming + sequence (offline; see migrations/README.md)
 just check-docs         # Documentation freshness check
 just ci                 # Full CI suite (lint + typecheck + tests + doc checks)
+just roster-context [season]  # Build the roster-question context pack (live league data); season defaults to 2026
 
 # Projection CLI
 just list-models                                    # List available models

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -81,9 +81,10 @@ Advanced receiving (added in migration 022, populated for 2018+ via nflverse `st
 
 ## Schema Files
 
-- **Canonical schema:** `schema.sql` (auto-generated via Supabase MCP)
-- **Migrations:** `migrations/` (numbered SQL migration files)
-- **Job queue:** `migrations/002_add_scraper_jobs.sql` defines the `scraper_jobs` table for the persistent job queue
+- **Migrations (source of intent):** `migrations/` — numbered `NNN_snake_case.sql` files. See [migrations/README.md](../../migrations/README.md) for naming and the apply-via-MCP workflow. Linted offline by `just check-migrations`.
+- **Remote system of record:** the `supabase_migrations.schema_migrations` table — audit via the `list_migrations` MCP tool.
+- **`schema.sql`:** a periodic Supabase MCP dump. It can lag the migrations directory (e.g. tables added via `apply_migration` or the dashboard without a numbered file, or migrations added after the last dump). Treat it as a convenience reference, not the source of truth.
+- **Job queue:** `migrations/002_add_scraper_jobs.sql` defines the `scraper_jobs` table for the persistent job queue.
 
 ## Row-Level Security
 


### PR DESCRIPTION
## Summary

Daily harness audit covering commits merged since 2026-06-02 (the last audit).

**Commits reviewed:**
- 9242d27 — `feat: lint migrations/ naming + document migration workflow` (added `just check-migrations`, `migrations/README.md`)
- 0c25817 — `feat: add just roster-context recipe`
- a7b0f4b — `docs: sync AGENTS.md and CLAUDE.md, improve doc freshness checker`

## Changes

- **`docs/COMMANDS.md`** — added the just recipes that landed since the last audit but never made it into the docs:
  - `just dev-stop` — kills dev server + stray Turbopack workers
  - `just check-migrations` — offline migration naming/sequence lint
  - `just roster-context [season]` — context pack for the `/ottoneu-roster-question` skill
  - Also fixed the `just analyze` description, which still claimed "Run all analysis scripts" — the Python analyze stack was removed in #513, so it now only runs `update_projections.py`.

- **`docs/generated/db-schema.md`** — clarified the schema-files section. `schema.sql` was last regenerated on 2026-04-19 (#442) and is currently missing 4 tables that have since been added (`draft_capital`, `draft_sharks_values`, `league_calendar`, `team_vegas_lines`). The prior wording — "Canonical schema: `schema.sql`" — was misleading agents into trusting a stale dump. The doc now points at `migrations/` as the source of intent and `supabase_migrations.schema_migrations` as the system of record, and labels `schema.sql` as a convenience snapshot that can lag.

- **`docs/CODE_ORGANIZATION.md`** — same `schema.sql` / `migrations/` clarification in the file-locations table (was previously labelled "Canonical schema definition").

## Items flagged for human follow-up

- **`schema.sql` is stale by 4 tables.** Regenerating it requires a Supabase MCP `generate_typescript_types`-equivalent dump that I can't do offline; left a doc warning so agents don't trust it blindly. Consider regenerating in a follow-up so the convenience snapshot at least covers the current schema.
- **`league_calendar` has no numbered migration file** under `migrations/`. It was applied via dashboard/MCP without a local file. `migrations/README.md` already documents that the local sequence doesn't have to map 1:1 with the remote, so this is allowed — but worth a backfill SQL file if/when convenient.

## Test plan

- [x] `python3 scripts/check_docs_freshness.py` passes (no broken links, no orphan files)
- [x] Every recipe added to COMMANDS.md exists in the Justfile
- [x] Schema-files copy still consistent across `db-schema.md` and `CODE_ORGANIZATION.md`

https://claude.ai/code/session_017iuRezvPpp5EFVsSzGEra1

---
_Generated by [Claude Code](https://claude.ai/code/session_017iuRezvPpp5EFVsSzGEra1)_