### PR TITLE
feat: scheduled offseason refresh of depth charts + Vegas lines (#555)

### DIFF
--- a/.github/workflows/offseason-data-refresh.yml
+++ b/.github/workflows/offseason-data-refresh.yml
@@ -1,0 +1,63 @@
+name: Offseason Data Refresh
+
+# Keeps the upcoming season's projections fresh through the offseason by
+# re-pulling the data sources that evolve before Week 1 — NFL depth charts
+# (camp battles, FA/draft role changes) and Vegas implied team totals (once the
+# schedule drops) — and then re-running the active projection model.
+#
+# Both backfills target only the current projection season (`--current`) and
+# upsert, so they are idempotent and safely no-op until the upcoming season's
+# nflverse data appears. The depth-chart loader freezes the tier at the
+# opening-day snapshot (cutoff ~Sept 7), so runs after Week 1 don't drift.
+#
+# GH #555. See docs/exec-plans/season-cycle.md for season resolution.
+
+on:
+  # Manual trigger (e.g. a one-off refresh after a notable depth-chart move).
+  workflow_dispatch:
+
+  # Daily at 9:00 AM UTC, April–September only. This window covers the
+  # post-draft / free-agency churn, the schedule release (Vegas lines, ~May),
+  # training camp + preseason (depth charts, Aug), and opening week (early
+  # Sept). Outside this window the inputs are static, so there's nothing to
+  # refresh.
+  schedule:
+    - cron: "0 9 * 4-9 *"
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          # Install this repo as a package so `import scripts.*` resolves.
+          pip install -e . --no-deps
+
+      - name: Create .env
+        run: |
+          echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" > .env
+          echo "SUPABASE_KEY=${{ secrets.SUPABASE_SECRET_KEY }}" >> .env
+
+      - name: Refresh depth charts (current season)
+        run: python scripts/backfill_depth_charts.py --current
+
+      - name: Refresh Vegas lines (current season)
+        run: python scripts/backfill_vegas_lines.py --current
+
+      - name: Re-project active model and promote to player_projections
+        run: python scripts/update_projections.py

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -124,8 +124,8 @@ just accuracy-report [--run-backtest] ...           # Generate accuracy report
 # Backfills / seeds
 just backfill-nfl-stats [--seasons ...] [--dry-run]    # Backfill nfl_stats from nflverse
 just backfill-draft-capital [--since YYYY] [--dry-run] # Backfill draft_capital from nflverse draft_picks
-just backfill-vegas [--since YYYY] [--dry-run]         # Backfill team_vegas_lines from nflverse games.csv
-just backfill-depth-charts [--since YYYY] [--until YYYY] [--dry-run]  # Backfill depth_charts (opening-day depth tier) from nflverse
+just backfill-vegas [--since YYYY | --current] [--dry-run]  # Backfill team_vegas_lines from nflverse games.csv (--current = projection season only)
+just backfill-depth-charts [--since YYYY] [--until YYYY] [--current] [--dry-run]  # Backfill depth_charts (opening-day depth tier) from nflverse (--current = projection season only)
 just seed-win-totals --season YYYY                     # Upsert preseason sportsbook win totals (implied_total left NULL until schedule drops)
 just scrape-draft-sharks [--season YYYY] [--positions qb rb wr te] [--dry-run]  # Scrape Draft Sharks Half-PPR Superflex auction values (stored ×2 for the $400 cap)
 just scrape-calendar [--dry-run]                      # Scrape the Ottoneu finances Calendar into league_calendar (drives the season-cycle resolver)
@@ -149,6 +149,7 @@ equivalent self-hosted setup would look like.
 | `scrape-draft-sharks.yml` | Mondays 08:00 UTC + `workflow_dispatch` | `scripts/scrape_draft_sharks.py` — Draft Sharks Half-PPR Superflex auction values (no in-season gate; ×2 for the $400 cap) |
 | `scrape-league-calendar.yml` | Mondays 12:00 UTC + `workflow_dispatch` | `scripts/scrape_league_calendar.py` — refreshes `league_calendar`, the source of truth for the season-cycle resolver. Requires FanGraphs login. |
 | `update-projections.yml` | Push to `main` touching `scripts/projection_methods.py`, `scripts/update_projections.py`, or `scripts/config.py` + `workflow_dispatch` | `scripts/update_projections.py` — re-runs the active model and promotes its outputs into `player_projections` |
+| `offseason-data-refresh.yml` | Daily 09:00 UTC (Apr–Sep) + `workflow_dispatch` | Refreshes the upcoming season's evolving inputs — `backfill_depth_charts.py --current` (depth charts) + `backfill_vegas_lines.py --current` (Vegas lines) — then `update_projections.py` to re-project. Idempotent; no-ops until the season's nflverse data appears. GH #555 |
 | `backfill-nfl-stats.yml` | `workflow_dispatch` only (seasons + dry-run inputs) | `scripts/backfill_nfl_stats.py` — historical NFL stats backfill from nflverse |
 | `backfill-player-stats.yml` | `workflow_dispatch` only (seasons input) | Historical Ottoneu `player_stats` backfill |
 | `run-tests.yml` | Push & PR against `main`/`master` | Full CI — Python (`pytest`) + web (Jest) + doc freshness check |

--- a/scripts/backfill_depth_charts.py
+++ b/scripts/backfill_depth_charts.py
@@ -214,23 +214,37 @@ def main() -> None:
         help="Latest season to ingest (default: latest available)",
     )
     parser.add_argument(
+        "--current",
+        action="store_true",
+        help=(
+            "Refresh only the current projection season (since = until = "
+            "projection_season). Use for the scheduled offseason refresh so "
+            "we re-pull just the upcoming season's evolving depth charts "
+            "without re-touching every historical row."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Map and aggregate without writing to the database",
     )
     args = parser.parse_args()
 
-    from scripts.season import stats_season
+    from scripts.season import projection_season, stats_season
 
-    until = args.until if args.until is not None else stats_season()
-    print(f"Depth Charts Backfill (since={args.since}, until={until}, dry_run={args.dry_run})")
+    if args.current:
+        since = until = projection_season()
+    else:
+        since = args.since
+        until = args.until if args.until is not None else stats_season()
+    print(f"Depth Charts Backfill (since={since}, until={until}, dry_run={args.dry_run})")
 
     supabase = get_supabase_client()
     player_lookup = build_player_lookup(supabase)
     print(f"  {len(player_lookup)} players in lookup")
 
     print("\nLoading nflverse depth charts (Week 1 REG, offense)...")
-    df = load_depth_charts(args.since, until)
+    df = load_depth_charts(since, until)
     seasons = sorted(df["season"].unique().tolist())
     print(f"  {len(df)} skill-position depth rows across seasons {seasons}")
 

--- a/scripts/backfill_vegas_lines.py
+++ b/scripts/backfill_vegas_lines.py
@@ -123,16 +123,32 @@ def main() -> None:
         help=f"Earliest season to ingest (default: {DEFAULT_SINCE_SEASON})",
     )
     parser.add_argument(
+        "--current",
+        action="store_true",
+        help=(
+            "Refresh only the current projection season (since = "
+            "projection_season). Use for the scheduled offseason refresh once "
+            "the NFL schedule drops and per-game lines start moving."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Aggregate without writing to the database",
     )
     args = parser.parse_args()
 
-    print(f"Vegas Lines Backfill (since={args.since}, dry_run={args.dry_run})")
+    if args.current:
+        from scripts.season import projection_season
+
+        since = projection_season()
+    else:
+        since = args.since
+
+    print(f"Vegas Lines Backfill (since={since}, dry_run={args.dry_run})")
 
     print("\nLoading nflverse games.csv...")
-    games = load_games(args.since)
+    games = load_games(since)
     seasons = sorted(games["season"].unique().tolist())
     print(f"  {len(games)} regular-season games across seasons {seasons}")
 


### PR DESCRIPTION
Closes #555.

Keeps the upcoming season's projections improving through the offseason by re-pulling the inputs that evolve before Week 1 and re-running the active model. Per the note on #555, this is **generalized beyond depth charts to also cover Vegas lines** — they refresh the same way once the NFL schedule drops.

## How it works

The flow is simply: refresh the data sources → re-project. `scripts/update_projections.py` already does the full re-projection (runs the `is_active` model for the target seasons and promotes to `player_projections`), so no new projection plumbing was needed.

- **`backfill_depth_charts.py` / `backfill_vegas_lines.py`** — new `--current` flag that resolves `projection_season()` and refreshes only the upcoming season (`since = until = projection_season`), so the scheduled job re-pulls just the evolving data without re-touching every historical row. Both upsert, so they're idempotent.
- **`.github/workflows/offseason-data-refresh.yml`** — daily at 09:00 UTC, **gated to April–September** (post-draft/FA → schedule release → camp/preseason → opening week) plus `workflow_dispatch`. Steps: refresh depth charts (`--current`) → refresh Vegas lines (`--current`) → `update_projections.py`.

## Why it's safe to run repeatedly

- **Idempotent**: both backfills upsert; same data → same rows.
- **No-ops until data appears**: nflverse has no current-season depth/Vegas data until ~Aug / schedule-release, and the loaders just write nothing until then.
- **Self-freezes after Week 1**: `_normalize_modern`'s opening-week cutoff (~Sept 7) means in-season runs keep picking the opening-day snapshot rather than drifting to mid-season depth — correct for a season-long projection.

## Verification

Dry-ran both `--current` paths against live nflverse data (resolves to season 2026, which already has early data): depth charts → 879 player rows, Vegas → 32 team rows. `just test-python` (913 passed), workflow YAML validated structurally. The scheduled/dispatch workflow runs from `main`, so it's triggerable after merge.

> Note: I did **not** run a live production refresh — the first run is a `workflow_dispatch` (or the next daily tick) away once merged. Happy to trigger it then; it would immediately populate 2026 depth/Vegas data and refresh the live projections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)