### PR TITLE
Projection eval: held-out re-ranking (#572) + MAE significance test (#573)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,8 @@ docs/
 │   ├── [db-schema.md](docs/generated/db-schema.md)                   # Database tables, keys, relationships
 │   ├── [experiment-log.md](docs/generated/experiment-log.md)              # History of all model iteration attempts
 │   ├── [player-diagnostics.md](docs/generated/player-diagnostics.md)          # Per-player backtest diagnostics
-│   ├── [projection-accuracy.md](docs/generated/projection-accuracy.md)         # Projection model accuracy report
+│   ├── [projection-accuracy.md](docs/generated/projection-accuracy.md)         # Projection model accuracy report (in-sample; see audit caveat)
+│   ├── [projection-holdout-eval.md](docs/generated/projection-holdout-eval.md)     # Held-out (leakage-free) model re-ranking — `just holdout-eval` (#572)
 │   ├── [rookie-backtest.md](docs/generated/rookie-backtest.md)             # Rookie (0-history) projection backtest — draft_capital vs baselines
 │   └── [segment-analysis.md](docs/generated/segment-analysis.md)            # Segmented projection accuracy analysis
 ├── references/

--- a/Justfile
+++ b/Justfile
@@ -122,6 +122,10 @@ rookie-backtest *args:
 train model seasons="2021,2022,2023,2024,2025":
     {{python}} scripts/feature_projections/train_model.py --model {{model}} --seasons {{seasons}}
 
+# Held-out re-rank: retrain learned models on a clean window, score all models OOS (GH #572)
+holdout-eval *args:
+    {{python}} scripts/feature_projections/holdout_eval.py {{args}}
+
 # Promote a model to production  (e.g. just promote v24_learned_elite)
 promote model:
     {{python}} scripts/feature_projections/cli.py promote --model {{model}}

--- a/Justfile
+++ b/Justfile
@@ -126,6 +126,11 @@ train model seasons="2021,2022,2023,2024,2025":
 holdout-eval *args:
     {{python}} scripts/feature_projections/holdout_eval.py {{args}}
 
+# Paired bootstrap: is the held-out MAE gap between two models significant? (GH #573)
+#   e.g. just significance v14_qb_starter v31_depth_chart
+significance model_a model_b *args:
+    {{python}} scripts/feature_projections/significance.py {{model_a}} {{model_b}} {{args}}
+
 # Promote a model to production  (e.g. just promote v24_learned_elite)
 promote model:
     {{python}} scripts/feature_projections/cli.py promote --model {{model}}

--- a/docs/exec-plans/projection-accuracy-improvement.md
+++ b/docs/exec-plans/projection-accuracy-improvement.md
@@ -5,10 +5,14 @@
 > ⚠️ **Read first:** [projection-methodology-audit.md](projection-methodology-audit.md)
 > (2026-06-08) found that the headline `ALL MAE` for learned models (`v20`–`v31`)
 > in the tables below is **in-sample** (trained on the seasons it is scored on),
-> so the cross-model ranking is not trustworthy as stated — the promoted `v31`'s
-> out-of-sample LOSO (2.440) is actually worse than `v27`'s (2.428). The accuracy
-> report now flags leaked models (⚠️) and shows a LOSO out-of-sample reference.
-> Tracking issues: #571–#577.
+> so the cross-model ranking is not trustworthy as stated. A clean held-out
+> re-ranking (`just holdout-eval`, train ≤2023 / eval 2024–2025) **inverts the
+> order**: the promoted `v31` falls to rank 22/30 and the entire learned family
+> (`v20`–`v31`) lands at the bottom, beaten by every additive model, by the naive
+> `v1` baseline, and by FantasyPros — see
+> [projection-holdout-eval.md](../generated/projection-holdout-eval.md). Treat the
+> in-sample tables below as **not** a valid model ranking. Tracking issues:
+> #571–#577.
 
 ---
 

--- a/docs/exec-plans/projection-methodology-audit.md
+++ b/docs/exec-plans/projection-methodology-audit.md
@@ -104,11 +104,12 @@ next refinement. But the central conclusion is robust: **the promoted `v31` is
 not the best model out-of-sample, and the learned-model ranking that justified
 v20→v31 was driven by leakage.**
 
-**Recommended actions (new follow-ups):** (a) reconsider the active model — an
-additive `v12`/`v14`-class model is the honest leader and is far better
-calibrated; (b) before any learned model is trusted/promoted, fix its
-out-of-sample over-projection bias (recalibration) and re-evaluate via
-`just holdout-eval`, not the leaked backtest.
+**Recommended actions (new follow-ups):** (a) **done** — prod reverted to the
+additive `v14_qb_starter` (the honest OOS leader, far better calibrated);
+(b) [#579](https://github.com/alex-monroe/ottoneu-db/issues/579) — before any
+learned model is trusted/re-promoted, fix its out-of-sample over-projection bias
+(recalibration) and re-evaluate via `just holdout-eval`, not the leaked
+backtest.
 
 ---
 
@@ -120,9 +121,29 @@ MAE (the `/experiment` `NEUTRAL` band is literally ±0.01). With that many looks
 at one small dataset, some "winners" are sampling noise. No promotion decision
 has been tested for significance.
 
-**Remediation:** add a paired bootstrap over players for the MAE *difference*
-between two models, and require a model to clear a significance/effect-size bar
-(not just a point-estimate delta) before it is promoted.
+**Remediation (shipped):** `scripts/feature_projections/significance.py`
+(`just significance MODEL_A MODEL_B`) computes a paired bootstrap over players of
+the held-out MAE difference, returning a 95% CI and a bootstrap p-value. A
+difference counts as real only if the CI excludes zero. It reuses
+`holdout_eval.gather_predictions`, so it tests the leakage-free out-of-sample
+numbers by default.
+
+### Finding 2 result — most historical "improvements" are within noise
+
+Paired bootstrap on the held-out window (train 2021–2023, eval 2024–2025, ALL,
+10k resamples):
+
+| Comparison | ΔMAE (A−B) | 95% CI | Verdict |
+|---|---|---|---|
+| `v14_qb_starter` vs `v31_depth_chart` (new prod vs old) | −0.263 | [−0.40, −0.13] | **significant** — v14 better |
+| `v14_qb_starter` vs `v19_usage_level_full` (held-out #1 vs #2) | −0.006 | [−0.028, +0.017] | not significant |
+| `v22_advanced_receiving` vs `v27_vegas_full_refit` | −0.029 | [−0.079, +0.022] | not significant |
+
+The promotion back to `v14` clears the bar (CI excludes 0, p≈0). But the
+in-sample "improvements" the experiment log celebrated — e.g. advanced-receiving
+→ draft-capital → Vegas, each worth ~0.01–0.03 MAE — are **not statistically
+distinguishable** out-of-sample. Going forward, no model should be promoted on a
+point-estimate delta that fails `just significance`.
 
 ---
 
@@ -204,7 +225,8 @@ averaged) alongside the pooled number.
 |---|---|---|---|
 | 1 — train/test leakage (report honesty) | 🔴 | [#571](https://github.com/alex-monroe/ottoneu-db/issues/571) | shipped in this PR |
 | 1b — held-out evaluation window | 🔴 | [#572](https://github.com/alex-monroe/ottoneu-db/issues/572) | shipped (`just holdout-eval`); ranking inverts — see above |
-| 2 — bootstrap significance on MAE deltas | 🟠 | [#573](https://github.com/alex-monroe/ottoneu-db/issues/573) | open |
+| 2 — bootstrap significance on MAE deltas | 🟠 | [#573](https://github.com/alex-monroe/ottoneu-db/issues/573) | shipped (`just significance`); see Finding 2 result |
+| (rec) recalibrate learned models before re-promotion | 🔴 | [#579](https://github.com/alex-monroe/ottoneu-db/issues/579) | open |
 | 3 — availability-inclusive evaluation | 🟠 | [#574](https://github.com/alex-monroe/ottoneu-db/issues/574) | open |
 | 4 — naïve baselines + matched-sample FP | 🟠 | [#575](https://github.com/alex-monroe/ottoneu-db/issues/575) | open |
 | 5 — R² aggregation discipline | 🟡 | [#576](https://github.com/alex-monroe/ottoneu-db/issues/576) | open |

--- a/docs/exec-plans/projection-methodology-audit.md
+++ b/docs/exec-plans/projection-methodology-audit.md
@@ -60,10 +60,55 @@ different experiment-log rows had different amounts of contamination.
    surface the out-of-sample **LOSO CV MAE** next to the in-sample backtest MAE
    so the optimism gap is visible. See `accuracy_report.py`
    `generate_leakage_section` / `--no-leakage-section`.
-2. **(follow-up, Finding 1b)** Adopt a fixed held-out window — train on ≤2023,
+2. **(shipped, Finding 1b)** Adopt a fixed held-out window — train on ≤2023,
    evaluate 2024–2025 for *all* models (additive, learned, external) — so every
-   model is judged on the same untouched data. Re-rank everything; expect the
-   ranking to compress.
+   model is judged on the same untouched data. See results below.
+
+### Finding 1b result — held-out re-ranking (`just holdout-eval`, #572)
+
+`scripts/feature_projections/holdout_eval.py` retrains every learned/residual
+model on **2021–2023** (into a temp dir, so production JSONs and
+`model_projections` are untouched) and scores **2024–2025** out-of-sample, with
+additive/external models read from their already-held-out projections — all
+through the identical `backtest_model` filter. Full table:
+[projection-holdout-eval.md](../generated/projection-holdout-eval.md).
+
+**The leaked ranking does not just compress — it inverts.** Combined held-out
+ALL MAE (N≈635–647):
+
+| | Leaked (in-sample) | Held-out (honest) |
+|---|---|---|
+| #1 model | `v31_depth_chart` 2.358 | `v14_qb_starter` (additive) **2.450** |
+| `v31_depth_chart` rank | 1 / 30 | **22 / 30** (2.660) |
+| Learned family (`v20`–`v31`) | top of table | **ranks 22–30 — the entire bottom** |
+| `v1_baseline` | last | rank 21 (2.633) — beats every learned model |
+| FantasyPros | mid-pack | rank 3 (2.462) |
+
+Every additive model and FantasyPros beat every learned model out-of-sample.
+The learned stack's apparent superiority was an artifact of train/test leakage.
+Out of sample the learned models also carry a large **over-projection bias**
+(−1.0 to −1.3 PPG vs additive ≈ −0.2), i.e. they systematically project too
+high — they only "win" on R²/RMSE because they fit the variance shape while
+being biased.
+
+Nuance (don't over-read): the learned models *do* win **QB** MAE
+(e.g. `v22` 3.589 vs `v14` 3.783), so the learned approach captures real
+QB-specific signal; it is the aggregate, dominated by over-projection on
+RB/WR/TE/K, that sinks them.
+
+Caveats: under the clean protocol the learned models train on 3 seasons
+(2021–2023) vs the 5 they used (with leakage) in production, and they score a
+slightly smaller player set (N≈635 vs 647) due to advanced-feature
+availability. A rolling-origin (expanding-window) protocol would be a fairer
+next refinement. But the central conclusion is robust: **the promoted `v31` is
+not the best model out-of-sample, and the learned-model ranking that justified
+v20→v31 was driven by leakage.**
+
+**Recommended actions (new follow-ups):** (a) reconsider the active model — an
+additive `v12`/`v14`-class model is the honest leader and is far better
+calibrated; (b) before any learned model is trusted/promoted, fix its
+out-of-sample over-projection bias (recalibration) and re-evaluate via
+`just holdout-eval`, not the leaked backtest.
 
 ---
 
@@ -158,7 +203,7 @@ averaged) alongside the pooled number.
 | Finding | Severity | Issue | Status |
 |---|---|---|---|
 | 1 — train/test leakage (report honesty) | 🔴 | [#571](https://github.com/alex-monroe/ottoneu-db/issues/571) | shipped in this PR |
-| 1b — held-out evaluation window | 🔴 | [#572](https://github.com/alex-monroe/ottoneu-db/issues/572) | open |
+| 1b — held-out evaluation window | 🔴 | [#572](https://github.com/alex-monroe/ottoneu-db/issues/572) | shipped (`just holdout-eval`); ranking inverts — see above |
 | 2 — bootstrap significance on MAE deltas | 🟠 | [#573](https://github.com/alex-monroe/ottoneu-db/issues/573) | open |
 | 3 — availability-inclusive evaluation | 🟠 | [#574](https://github.com/alex-monroe/ottoneu-db/issues/574) | open |
 | 4 — naïve baselines + matched-sample FP | 🟠 | [#575](https://github.com/alex-monroe/ottoneu-db/issues/575) | open |

--- a/docs/generated/projection-holdout-eval.md
+++ b/docs/generated/projection-holdout-eval.md
@@ -1,0 +1,330 @@
+# Projection Held-Out Evaluation (GH #572)
+
+_Generated: 2026-06-08 22:04_
+
+**Every model is evaluated out-of-sample on a shared held-out window.** Learned/residual models were retrained on **2021,2022,2023** and never saw the eval seasons **2024,2025**; additive and external models are parameter-free w.r.t. training seasons, so their existing projections are already held-out. All models are scored through the identical `backtest_model` filter (target-season games ≥ 4, true rookies excluded). Unlike [projection-accuracy.md](projection-accuracy.md), **no model here is scored on data it trained on** — this is the honest ranking. See [docs/exec-plans/projection-methodology-audit.md](../exec-plans/projection-methodology-audit.md) (Finding 1b).
+
+## Ranking — combined held-out ALL (lower MAE = better)
+
+| Rank | Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | `v14_qb_starter` | **2.450** | -0.149 | 0.611 | 3.251 | 647 |
+| 2 | `v19_usage_level_full` | 2.456 | -0.280 | 0.611 | 3.249 | 647 |
+| 3 | `external_fantasypros_v1` | 2.462 | +0.990 | 0.634 | 3.360 | 430 |
+| 4 | `v16_snap_trend_full` | 2.467 | -0.183 | 0.605 | 3.278 | 647 |
+| 5 | `v12_no_qb_trajectory` | 2.471 | -0.207 | 0.590 | 3.339 | 647 |
+| 6 | `v10_stat_efficiency_v2` | 2.484 | -0.230 | 0.584 | 3.364 | 647 |
+| 7 | `v13_qb_starter` | 2.484 | -0.233 | 0.581 | 3.374 | 647 |
+| 8 | `v8_age_regression` | 2.485 | -0.235 | 0.582 | 3.370 | 647 |
+| 9 | `v9_pos_specific` | 2.485 | -0.235 | 0.582 | 3.370 | 647 |
+| 10 | `v11_team_context_v2` | 2.490 | -0.258 | 0.578 | 3.386 | 647 |
+| 11 | `v17_rookie_growth` | 2.495 | -0.208 | 0.604 | 3.283 | 647 |
+| 12 | `v21_tiered_regression` | 2.498 | +0.021 | 0.584 | 3.361 | 647 |
+| 13 | `v3_stat_weighted` | 2.528 | -0.375 | 0.563 | 3.448 | 647 |
+| 14 | `v7_regression_to_mean` | 2.529 | +0.018 | 0.578 | 3.385 | 647 |
+| 15 | `v2_age_adjusted` | 2.531 | -0.389 | 0.561 | 3.454 | 647 |
+| 16 | `v15_snap_trend` | 2.560 | -0.423 | 0.553 | 3.488 | 647 |
+| 17 | `v18_usage_level` | 2.563 | -0.520 | 0.554 | 3.484 | 647 |
+| 18 | `v4_availability_adjusted` | 2.565 | +0.015 | 0.558 | 3.466 | 647 |
+| 19 | `v5_team_context` | 2.566 | -0.006 | 0.554 | 3.479 | 647 |
+| 20 | `v6_usage_share` | 2.583 | -0.137 | 0.550 | 3.495 | 647 |
+| 21 | `v1_baseline_weighted_ppg` | 2.633 | -0.652 | 0.527 | 3.588 | 647 |
+| 22 | `v31_depth_chart` | 2.660 | -1.051 | 0.564 | 3.413 | 635 |
+| 23 | `v30_reliability_full_refit` | 2.679 | -1.152 | 0.563 | 3.414 | 635 |
+| 24 | `v20_learned_usage` | 2.683 | -1.060 | 0.572 | 3.377 | 635 |
+| 25 | `v22_advanced_receiving` | 2.707 | -1.095 | 0.566 | 3.401 | 635 |
+| 26 | `v26_vegas_residual` | 2.723 | -1.267 | 0.557 | 3.435 | 635 |
+| 27 | `v25_draft_capital_residual` | 2.723 | -1.242 | 0.562 | 3.416 | 635 |
+| 28 | `v27_vegas_full_refit` | 2.724 | -1.201 | 0.553 | 3.455 | 635 |
+| 29 | `v28_reliability_weighting` | 2.728 | -1.161 | 0.562 | 3.418 | 635 |
+| 30 | `v29_reliability_residual` | 2.752 | -1.296 | 0.556 | 3.440 | 635 |
+| 31 | `v23_draft_capital` | 2.764 | -1.105 | 0.545 | 3.486 | 635 |
+
+## Combined across eval seasons — by position
+
+### ALL
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v14_qb_starter` | 2.450 | -0.149 | 0.611 | 3.251 | 647 |
+| `v19_usage_level_full` | 2.456 | -0.280 | 0.611 | 3.249 | 647 |
+| `external_fantasypros_v1` | 2.462 | +0.990 | 0.634 | 3.360 | 430 |
+| `v16_snap_trend_full` | 2.467 | -0.183 | 0.605 | 3.278 | 647 |
+| `v12_no_qb_trajectory` | 2.471 | -0.207 | 0.590 | 3.339 | 647 |
+| `v10_stat_efficiency_v2` | 2.484 | -0.230 | 0.584 | 3.364 | 647 |
+| `v13_qb_starter` | 2.484 | -0.233 | 0.581 | 3.374 | 647 |
+| `v8_age_regression` | 2.485 | -0.235 | 0.582 | 3.370 | 647 |
+| `v9_pos_specific` | 2.485 | -0.235 | 0.582 | 3.370 | 647 |
+| `v11_team_context_v2` | 2.490 | -0.258 | 0.578 | 3.386 | 647 |
+| `v17_rookie_growth` | 2.495 | -0.208 | 0.604 | 3.283 | 647 |
+| `v21_tiered_regression` | 2.498 | +0.021 | 0.584 | 3.361 | 647 |
+| `v3_stat_weighted` | 2.528 | -0.375 | 0.563 | 3.448 | 647 |
+| `v7_regression_to_mean` | 2.529 | +0.018 | 0.578 | 3.385 | 647 |
+| `v2_age_adjusted` | 2.531 | -0.389 | 0.561 | 3.454 | 647 |
+| `v15_snap_trend` | 2.560 | -0.423 | 0.553 | 3.488 | 647 |
+| `v18_usage_level` | 2.563 | -0.520 | 0.554 | 3.484 | 647 |
+| `v4_availability_adjusted` | 2.565 | +0.015 | 0.558 | 3.466 | 647 |
+| `v5_team_context` | 2.566 | -0.006 | 0.554 | 3.479 | 647 |
+| `v6_usage_share` | 2.583 | -0.137 | 0.550 | 3.495 | 647 |
+| `v1_baseline_weighted_ppg` | 2.633 | -0.652 | 0.527 | 3.588 | 647 |
+| `v31_depth_chart` | 2.660 | -1.051 | 0.564 | 3.413 | 635 |
+| `v30_reliability_full_refit` | 2.679 | -1.152 | 0.563 | 3.414 | 635 |
+| `v20_learned_usage` | 2.683 | -1.060 | 0.572 | 3.377 | 635 |
+| `v22_advanced_receiving` | 2.707 | -1.095 | 0.566 | 3.401 | 635 |
+| `v26_vegas_residual` | 2.723 | -1.267 | 0.557 | 3.435 | 635 |
+| `v25_draft_capital_residual` | 2.723 | -1.242 | 0.562 | 3.416 | 635 |
+| `v27_vegas_full_refit` | 2.724 | -1.201 | 0.553 | 3.455 | 635 |
+| `v28_reliability_weighting` | 2.728 | -1.161 | 0.562 | 3.418 | 635 |
+| `v29_reliability_residual` | 2.752 | -1.296 | 0.556 | 3.440 | 635 |
+| `v23_draft_capital` | 2.764 | -1.105 | 0.545 | 3.486 | 635 |
+
+### QB
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v22_advanced_receiving` | 3.589 | -1.406 | 0.433 | 4.599 | 98 |
+| `v28_reliability_weighting` | 3.596 | -1.465 | 0.428 | 4.618 | 98 |
+| `v20_learned_usage` | 3.626 | -1.493 | 0.425 | 4.629 | 98 |
+| `v31_depth_chart` | 3.631 | -1.590 | 0.426 | 4.628 | 98 |
+| `v26_vegas_residual` | 3.657 | -1.645 | 0.407 | 4.703 | 98 |
+| `v27_vegas_full_refit` | 3.672 | -1.461 | 0.390 | 4.773 | 98 |
+| `v30_reliability_full_refit` | 3.681 | -1.510 | 0.388 | 4.779 | 98 |
+| `v25_draft_capital_residual` | 3.681 | -1.635 | 0.406 | 4.708 | 98 |
+| `v29_reliability_residual` | 3.686 | -1.694 | 0.401 | 4.728 | 98 |
+| `external_fantasypros_v1` | 3.690 | +2.129 | 0.410 | 5.072 | 88 |
+| `v23_draft_capital` | 3.744 | -1.077 | 0.388 | 4.777 | 98 |
+| `v14_qb_starter` | 3.783 | -0.742 | 0.441 | 4.826 | 102 |
+| `v17_rookie_growth` | 3.783 | -0.742 | 0.441 | 4.826 | 102 |
+| `v19_usage_level_full` | 3.783 | -0.742 | 0.441 | 4.826 | 102 |
+| `v21_tiered_regression` | 3.852 | -0.322 | 0.413 | 4.947 | 102 |
+| `v16_snap_trend_full` | 3.857 | -0.755 | 0.427 | 4.886 | 102 |
+| `v12_no_qb_trajectory` | 3.919 | -1.111 | 0.352 | 5.195 | 102 |
+| `v13_qb_starter` | 3.957 | -1.234 | 0.325 | 5.304 | 102 |
+| `v8_age_regression` | 3.959 | -1.245 | 0.329 | 5.286 | 102 |
+| `v9_pos_specific` | 3.959 | -1.245 | 0.329 | 5.286 | 102 |
+| `v10_stat_efficiency_v2` | 3.976 | -1.232 | 0.330 | 5.282 | 102 |
+| `v11_team_context_v2` | 3.986 | -1.283 | 0.319 | 5.324 | 102 |
+| `v7_regression_to_mean` | 4.017 | +0.185 | 0.362 | 5.155 | 102 |
+| `v2_age_adjusted` | 4.064 | -1.387 | 0.297 | 5.412 | 102 |
+| `v18_usage_level` | 4.064 | -1.387 | 0.297 | 5.412 | 102 |
+| `v3_stat_weighted` | 4.068 | -1.367 | 0.300 | 5.401 | 102 |
+| `v4_availability_adjusted` | 4.085 | +0.078 | 0.327 | 5.297 | 102 |
+| `v5_team_context` | 4.134 | +0.044 | 0.318 | 5.329 | 102 |
+| `v6_usage_share` | 4.134 | +0.044 | 0.318 | 5.329 | 102 |
+| `v15_snap_trend` | 4.158 | -1.400 | 0.279 | 5.481 | 102 |
+| `v1_baseline_weighted_ppg` | 4.218 | -1.808 | 0.261 | 5.548 | 102 |
+
+### RB
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v11_team_context_v2` | 2.686 | -0.005 | 0.575 | 3.479 | 137 |
+| `v10_stat_efficiency_v2` | 2.702 | +0.057 | 0.575 | 3.480 | 137 |
+| `v6_usage_share` | 2.712 | -0.088 | 0.555 | 3.556 | 137 |
+| `v3_stat_weighted` | 2.713 | -0.132 | 0.565 | 3.520 | 137 |
+| `v5_team_context` | 2.715 | +0.150 | 0.553 | 3.561 | 137 |
+| `v8_age_regression` | 2.717 | +0.039 | 0.572 | 3.495 | 137 |
+| `v9_pos_specific` | 2.717 | +0.039 | 0.572 | 3.495 | 137 |
+| `v12_no_qb_trajectory` | 2.717 | +0.039 | 0.572 | 3.495 | 137 |
+| `v13_qb_starter` | 2.717 | +0.039 | 0.572 | 3.495 | 137 |
+| `v14_qb_starter` | 2.717 | +0.039 | 0.572 | 3.495 | 137 |
+| `external_fantasypros_v1` | 2.718 | +1.056 | 0.548 | 3.345 | 100 |
+| `v2_age_adjusted` | 2.719 | -0.175 | 0.563 | 3.527 | 137 |
+| `v19_usage_level_full` | 2.721 | -0.200 | 0.576 | 3.479 | 137 |
+| `v7_regression_to_mean` | 2.725 | +0.126 | 0.563 | 3.523 | 137 |
+| `v4_availability_adjusted` | 2.758 | +0.176 | 0.550 | 3.574 | 137 |
+| `v18_usage_level` | 2.762 | -0.413 | 0.553 | 3.569 | 137 |
+| `v16_snap_trend_full` | 2.769 | -0.068 | 0.560 | 3.543 | 137 |
+| `v15_snap_trend` | 2.778 | -0.281 | 0.546 | 3.596 | 137 |
+| `v21_tiered_regression` | 2.782 | +0.220 | 0.534 | 3.647 | 137 |
+| `v17_rookie_growth` | 2.785 | -0.067 | 0.559 | 3.547 | 137 |
+| `v1_baseline_weighted_ppg` | 2.806 | -0.518 | 0.517 | 3.716 | 137 |
+| `v31_depth_chart` | 3.006 | -0.854 | 0.512 | 3.742 | 135 |
+| `v20_learned_usage` | 3.101 | -1.005 | 0.494 | 3.802 | 135 |
+| `v26_vegas_residual` | 3.127 | -1.172 | 0.496 | 3.798 | 135 |
+| `v25_draft_capital_residual` | 3.146 | -1.174 | 0.494 | 3.807 | 135 |
+| `v22_advanced_receiving` | 3.162 | -0.998 | 0.486 | 3.835 | 135 |
+| `v28_reliability_weighting` | 3.167 | -1.109 | 0.483 | 3.851 | 135 |
+| `v29_reliability_residual` | 3.170 | -1.246 | 0.485 | 3.843 | 135 |
+| `v30_reliability_full_refit` | 3.200 | -1.227 | 0.474 | 3.887 | 135 |
+| `v27_vegas_full_refit` | 3.201 | -1.257 | 0.469 | 3.909 | 135 |
+| `v23_draft_capital` | 3.234 | -1.135 | 0.457 | 3.953 | 135 |
+
+### WR
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 2.199 | +0.436 | 0.571 | 2.767 | 131 |
+| `v16_snap_trend_full` | 2.348 | -0.215 | 0.511 | 2.997 | 200 |
+| `v8_age_regression` | 2.373 | -0.175 | 0.511 | 2.993 | 200 |
+| `v9_pos_specific` | 2.373 | -0.175 | 0.511 | 2.993 | 200 |
+| `v12_no_qb_trajectory` | 2.373 | -0.175 | 0.511 | 2.993 | 200 |
+| `v13_qb_starter` | 2.373 | -0.175 | 0.511 | 2.993 | 200 |
+| `v14_qb_starter` | 2.373 | -0.175 | 0.511 | 2.993 | 200 |
+| `v10_stat_efficiency_v2` | 2.376 | -0.175 | 0.511 | 2.992 | 200 |
+| `v19_usage_level_full` | 2.380 | -0.379 | 0.511 | 2.996 | 200 |
+| `v11_team_context_v2` | 2.390 | -0.193 | 0.500 | 3.028 | 200 |
+| `v21_tiered_regression` | 2.408 | -0.166 | 0.473 | 3.108 | 200 |
+| `v7_regression_to_mean` | 2.421 | -0.279 | 0.489 | 3.056 | 200 |
+| `v15_snap_trend` | 2.425 | -0.431 | 0.467 | 3.132 | 200 |
+| `v3_stat_weighted` | 2.430 | -0.382 | 0.470 | 3.119 | 200 |
+| `v2_age_adjusted` | 2.435 | -0.391 | 0.467 | 3.127 | 200 |
+| `v4_availability_adjusted` | 2.444 | -0.270 | 0.456 | 3.155 | 200 |
+| `v17_rookie_growth` | 2.450 | -0.267 | 0.493 | 3.050 | 200 |
+| `v5_team_context` | 2.459 | -0.293 | 0.447 | 3.181 | 200 |
+| `v18_usage_level` | 2.488 | -0.596 | 0.450 | 3.180 | 200 |
+| `v6_usage_share` | 2.488 | -0.498 | 0.434 | 3.222 | 200 |
+| `v1_baseline_weighted_ppg` | 2.614 | -0.624 | 0.408 | 3.301 | 200 |
+| `v30_reliability_full_refit` | 2.636 | -1.409 | 0.434 | 3.212 | 196 |
+| `v20_learned_usage` | 2.637 | -0.923 | 0.443 | 3.186 | 196 |
+| `v22_advanced_receiving` | 2.750 | -1.289 | 0.399 | 3.309 | 196 |
+| `v27_vegas_full_refit` | 2.757 | -1.534 | 0.397 | 3.320 | 196 |
+| `v23_draft_capital` | 2.783 | -1.395 | 0.392 | 3.338 | 196 |
+| `v25_draft_capital_residual` | 2.785 | -1.583 | 0.397 | 3.314 | 196 |
+| `v28_reliability_weighting` | 2.787 | -1.413 | 0.390 | 3.332 | 196 |
+| `v26_vegas_residual` | 2.806 | -1.665 | 0.371 | 3.388 | 196 |
+| `v29_reliability_residual` | 2.812 | -1.595 | 0.390 | 3.334 | 196 |
+| `v31_depth_chart` | 2.836 | -1.528 | 0.340 | 3.490 | 196 |
+
+### TE
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 1.568 | +0.683 | 0.596 | 2.057 | 111 |
+| `v10_stat_efficiency_v2` | 1.737 | +0.017 | 0.564 | 2.216 | 144 |
+| `v8_age_regression` | 1.740 | +0.024 | 0.562 | 2.221 | 144 |
+| `v9_pos_specific` | 1.740 | +0.024 | 0.562 | 2.221 | 144 |
+| `v12_no_qb_trajectory` | 1.740 | +0.024 | 0.562 | 2.221 | 144 |
+| `v13_qb_starter` | 1.740 | +0.024 | 0.562 | 2.221 | 144 |
+| `v14_qb_starter` | 1.740 | +0.024 | 0.562 | 2.221 | 144 |
+| `v16_snap_trend_full` | 1.749 | +0.031 | 0.561 | 2.225 | 144 |
+| `v11_team_context_v2` | 1.750 | +0.016 | 0.559 | 2.229 | 144 |
+| `v3_stat_weighted` | 1.753 | -0.063 | 0.552 | 2.245 | 144 |
+| `v19_usage_level_full` | 1.754 | -0.055 | 0.558 | 2.231 | 144 |
+| `v2_age_adjusted` | 1.756 | -0.058 | 0.552 | 2.246 | 144 |
+| `v21_tiered_regression` | 1.765 | +0.242 | 0.543 | 2.269 | 144 |
+| `v15_snap_trend` | 1.770 | -0.050 | 0.552 | 2.246 | 144 |
+| `v1_baseline_weighted_ppg` | 1.773 | -0.326 | 0.533 | 2.304 | 144 |
+| `v17_rookie_growth` | 1.774 | -0.014 | 0.553 | 2.246 | 144 |
+| `v18_usage_level` | 1.784 | -0.136 | 0.537 | 2.283 | 144 |
+| `v7_regression_to_mean` | 1.784 | +0.109 | 0.531 | 2.295 | 144 |
+| `v5_team_context` | 1.793 | +0.104 | 0.525 | 2.312 | 144 |
+| `v4_availability_adjusted` | 1.800 | +0.117 | 0.526 | 2.309 | 144 |
+| `v6_usage_share` | 1.828 | +0.025 | 0.509 | 2.346 | 144 |
+| `v31_depth_chart` | 1.941 | -0.689 | 0.510 | 2.327 | 142 |
+| `v25_draft_capital_residual` | 1.986 | -0.811 | 0.496 | 2.385 | 142 |
+| `v26_vegas_residual` | 1.989 | -0.806 | 0.496 | 2.382 | 142 |
+| `v22_advanced_receiving` | 2.018 | -0.807 | 0.483 | 2.414 | 142 |
+| `v30_reliability_full_refit` | 2.019 | -0.771 | 0.488 | 2.400 | 142 |
+| `v27_vegas_full_refit` | 2.054 | -0.816 | 0.476 | 2.431 | 142 |
+| `v28_reliability_weighting` | 2.055 | -0.791 | 0.476 | 2.433 | 142 |
+| `v29_reliability_residual` | 2.062 | -0.846 | 0.475 | 2.434 | 142 |
+| `v20_learned_usage` | 2.099 | -1.108 | 0.444 | 2.504 | 142 |
+| `v23_draft_capital` | 2.117 | -0.982 | 0.436 | 2.527 | 142 |
+
+### K
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v31_depth_chart` | 1.501 | +0.018 | -0.128 | 1.978 | 64 |
+| `v12_no_qb_trajectory` | 1.589 | +0.090 | -0.278 | 2.115 | 64 |
+| `v14_qb_starter` | 1.589 | +0.090 | -0.278 | 2.115 | 64 |
+| `v17_rookie_growth` | 1.589 | +0.090 | -0.278 | 2.115 | 64 |
+| `v19_usage_level_full` | 1.589 | +0.090 | -0.278 | 2.115 | 64 |
+| `v16_snap_trend_full` | 1.598 | +0.101 | -0.280 | 2.117 | 64 |
+| `v23_draft_capital` | 1.644 | -0.467 | -0.255 | 2.097 | 64 |
+| `v30_reliability_full_refit` | 1.647 | -0.506 | -0.251 | 2.097 | 64 |
+| `v27_vegas_full_refit` | 1.653 | -0.516 | -0.259 | 2.102 | 64 |
+| `v21_tiered_regression` | 1.658 | +0.230 | -0.432 | 2.235 | 64 |
+| `v8_age_regression` | 1.662 | +0.020 | -0.403 | 2.233 | 64 |
+| `v9_pos_specific` | 1.662 | +0.020 | -0.403 | 2.233 | 64 |
+| `v10_stat_efficiency_v2` | 1.662 | +0.020 | -0.403 | 2.233 | 64 |
+| `v11_team_context_v2` | 1.662 | +0.020 | -0.403 | 2.233 | 64 |
+| `v13_qb_starter` | 1.662 | +0.020 | -0.403 | 2.233 | 64 |
+| `v1_baseline_weighted_ppg` | 1.727 | +0.079 | -0.563 | 2.348 | 64 |
+| `v2_age_adjusted` | 1.731 | +0.006 | -0.523 | 2.329 | 64 |
+| `v3_stat_weighted` | 1.731 | +0.006 | -0.523 | 2.329 | 64 |
+| `v18_usage_level` | 1.731 | +0.006 | -0.523 | 2.329 | 64 |
+| `v15_snap_trend` | 1.742 | +0.017 | -0.525 | 2.331 | 64 |
+| `v7_regression_to_mean` | 1.753 | +0.243 | -0.722 | 2.419 | 64 |
+| `v28_reliability_weighting` | 1.781 | -0.858 | -0.356 | 2.195 | 64 |
+| `v29_reliability_residual` | 1.788 | -0.873 | -0.359 | 2.198 | 64 |
+| `v20_learned_usage` | 1.789 | -0.824 | -0.377 | 2.208 | 64 |
+| `v22_advanced_receiving` | 1.794 | -0.868 | -0.373 | 2.206 | 64 |
+| `v25_draft_capital_residual` | 1.810 | -0.693 | -0.435 | 2.243 | 64 |
+| `v26_vegas_residual` | 1.810 | -0.693 | -0.435 | 2.243 | 64 |
+| `v4_availability_adjusted` | 1.826 | +0.229 | -0.845 | 2.509 | 64 |
+| `v5_team_context` | 1.826 | +0.229 | -0.845 | 2.509 | 64 |
+| `v6_usage_share` | 1.826 | +0.229 | -0.845 | 2.509 | 64 |
+
+## Season 2024 — ALL (held-out)
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v19_usage_level_full` | 2.660 | +0.011 | 0.552 | 3.440 | 274 |
+| `v14_qb_starter` | 2.660 | +0.168 | 0.549 | 3.449 | 274 |
+| `v12_no_qb_trajectory` | 2.663 | +0.106 | 0.537 | 3.495 | 274 |
+| `v16_snap_trend_full` | 2.669 | +0.152 | 0.543 | 3.471 | 274 |
+| `external_fantasypros_v1` | 2.671 | +1.449 | 0.579 | 3.509 | 187 |
+| `v31_depth_chart` | 2.675 | -0.939 | 0.547 | 3.420 | 271 |
+| `v13_qb_starter` | 2.675 | +0.082 | 0.525 | 3.540 | 274 |
+| `v11_team_context_v2` | 2.676 | +0.063 | 0.523 | 3.546 | 274 |
+| `v17_rookie_growth` | 2.676 | +0.135 | 0.544 | 3.468 | 274 |
+| `v8_age_regression` | 2.682 | +0.089 | 0.524 | 3.544 | 274 |
+| `v9_pos_specific` | 2.682 | +0.089 | 0.524 | 3.544 | 274 |
+| `v10_stat_efficiency_v2` | 2.690 | +0.090 | 0.524 | 3.542 | 274 |
+| `v20_learned_usage` | 2.712 | -0.796 | 0.531 | 3.477 | 271 |
+| `v22_advanced_receiving` | 2.724 | -0.840 | 0.525 | 3.500 | 271 |
+| `v23_draft_capital` | 2.725 | -0.697 | 0.516 | 3.533 | 271 |
+| `v2_age_adjusted` | 2.731 | -0.043 | 0.505 | 3.612 | 274 |
+| `v3_stat_weighted` | 2.732 | -0.026 | 0.507 | 3.606 | 274 |
+| `v27_vegas_full_refit` | 2.732 | -0.914 | 0.516 | 3.532 | 271 |
+| `v21_tiered_regression` | 2.739 | +0.406 | 0.510 | 3.597 | 274 |
+| `v28_reliability_weighting` | 2.740 | -0.909 | 0.523 | 3.507 | 271 |
+| `v30_reliability_full_refit` | 2.740 | -0.915 | 0.513 | 3.544 | 271 |
+| `v25_draft_capital_residual` | 2.748 | -1.008 | 0.518 | 3.526 | 271 |
+| `v1_baseline_weighted_ppg` | 2.755 | -0.289 | 0.482 | 3.698 | 274 |
+| `v18_usage_level` | 2.757 | -0.199 | 0.500 | 3.631 | 274 |
+| `v26_vegas_residual` | 2.759 | -1.045 | 0.513 | 3.545 | 271 |
+| `v15_snap_trend` | 2.764 | -0.059 | 0.497 | 3.642 | 274 |
+| `v29_reliability_residual` | 2.779 | -1.054 | 0.512 | 3.547 | 271 |
+| `v7_regression_to_mean` | 2.796 | +0.362 | 0.497 | 3.643 | 274 |
+| `v4_availability_adjusted` | 2.838 | +0.413 | 0.475 | 3.722 | 274 |
+| `v5_team_context` | 2.843 | +0.387 | 0.471 | 3.735 | 274 |
+| `v6_usage_share` | 2.850 | +0.231 | 0.471 | 3.737 | 274 |
+
+## Season 2025 — ALL (held-out)
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v14_qb_starter` | 2.296 | -0.381 | 0.656 | 3.097 | 373 |
+| `external_fantasypros_v1` | 2.301 | +0.637 | 0.675 | 3.241 | 243 |
+| `v19_usage_level_full` | 2.306 | -0.493 | 0.655 | 3.102 | 373 |
+| `v16_snap_trend_full` | 2.320 | -0.428 | 0.650 | 3.128 | 373 |
+| `v21_tiered_regression` | 2.320 | -0.262 | 0.638 | 3.178 | 373 |
+| `v12_no_qb_trajectory` | 2.330 | -0.437 | 0.629 | 3.220 | 373 |
+| `v10_stat_efficiency_v2` | 2.333 | -0.466 | 0.627 | 3.227 | 373 |
+| `v7_regression_to_mean` | 2.333 | -0.235 | 0.637 | 3.182 | 373 |
+| `v8_age_regression` | 2.340 | -0.473 | 0.625 | 3.236 | 373 |
+| `v9_pos_specific` | 2.340 | -0.473 | 0.625 | 3.236 | 373 |
+| `v13_qb_starter` | 2.344 | -0.465 | 0.623 | 3.247 | 373 |
+| `v11_team_context_v2` | 2.353 | -0.493 | 0.619 | 3.263 | 373 |
+| `v17_rookie_growth` | 2.362 | -0.460 | 0.647 | 3.139 | 373 |
+| `v5_team_context` | 2.363 | -0.295 | 0.615 | 3.279 | 373 |
+| `v4_availability_adjusted` | 2.364 | -0.278 | 0.618 | 3.266 | 373 |
+| `v3_stat_weighted` | 2.379 | -0.631 | 0.604 | 3.328 | 373 |
+| `v2_age_adjusted` | 2.385 | -0.643 | 0.602 | 3.334 | 373 |
+| `v6_usage_share` | 2.386 | -0.407 | 0.609 | 3.305 | 373 |
+| `v15_snap_trend` | 2.409 | -0.691 | 0.593 | 3.370 | 373 |
+| `v18_usage_level` | 2.421 | -0.756 | 0.593 | 3.372 | 373 |
+| `v1_baseline_weighted_ppg` | 2.543 | -0.919 | 0.560 | 3.505 | 373 |
+| `v30_reliability_full_refit` | 2.635 | -1.329 | 0.600 | 3.313 | 364 |
+| `v31_depth_chart` | 2.649 | -1.135 | 0.577 | 3.408 | 364 |
+| `v20_learned_usage` | 2.661 | -1.256 | 0.603 | 3.301 | 364 |
+| `v22_advanced_receiving` | 2.694 | -1.285 | 0.597 | 3.325 | 364 |
+| `v26_vegas_residual` | 2.696 | -1.432 | 0.591 | 3.351 | 364 |
+| `v25_draft_capital_residual` | 2.705 | -1.415 | 0.595 | 3.333 | 364 |
+| `v27_vegas_full_refit` | 2.718 | -1.414 | 0.580 | 3.396 | 364 |
+| `v28_reliability_weighting` | 2.719 | -1.349 | 0.591 | 3.350 | 364 |
+| `v29_reliability_residual` | 2.732 | -1.476 | 0.589 | 3.358 | 364 |
+| `v23_draft_capital` | 2.793 | -1.408 | 0.566 | 3.451 | 364 |

--- a/scripts/feature_projections/holdout_eval.py
+++ b/scripts/feature_projections/holdout_eval.py
@@ -1,0 +1,446 @@
+"""Held-out evaluation of every projection model on a clean window (GH #572).
+
+Finding 1 of the methodology audit
+(docs/exec-plans/projection-methodology-audit.md) showed that learned/residual
+models (v20–v31) are trained on the same seasons the standard backtest scores
+them on, so their headline MAE is in-sample. This script re-ranks the whole
+model history on a *shared held-out window* where every model — additive,
+learned, residual, external — is judged out-of-sample on the same untouched
+seasons.
+
+Design:
+- Learned/residual models are **retrained on the training window only**
+  (default 2021–2023) and then predict the eval seasons (default 2024–2025)
+  in memory. Their coefficients never see the eval seasons.
+- Retraining writes to a temporary directory and monkeypatches
+  ``learned_combiner.TRAINED_MODELS_DIR`` for the duration of the run, so the
+  production ``trained_models/*.json`` files and ``model_projections`` table are
+  never touched. Residual models load their (also-held-out) base from the temp
+  dir, so the whole stack is clean.
+- Additive and external (FantasyPros) models are parameter-free w.r.t. our
+  training seasons — a model's projection for 2024 depends only on 2021–2023
+  history — so their existing ``model_projections`` rows are already the
+  held-out values and are read straight from the DB.
+- Every model is then scored through the **identical** filter used by
+  ``backtest_model``: target-season games ≥ MIN_GAMES and true rookies excluded.
+
+Usage:
+    venv/bin/python scripts/feature_projections/holdout_eval.py \
+        --train-seasons 2021,2022,2023 --eval-seasons 2024,2025 \
+        --output docs/generated/projection-holdout-eval.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from scripts.config import get_supabase_client, fetch_all_rows, POSITIONS, MIN_GAMES
+from scripts.feature_projections import learned_combiner
+from scripts.feature_projections.learned_combiner import predict, predict_residual
+from scripts.feature_projections.model_config import MODELS, get_model
+from scripts.feature_projections.backtest import (
+    _compute_metrics,
+    _fetch_season_rows,
+)
+
+repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _dependency_order(model_names: list[str]) -> list[str]:
+    """Order learned/residual models so a residual's base is trained first."""
+    ordered: list[str] = []
+    remaining = list(model_names)
+    # Iterate until every model lands after its base (bases are also in the set).
+    guard = 0
+    while remaining and guard < 1000:
+        guard += 1
+        for name in list(remaining):
+            base = get_model(name).base_model_name
+            if base is None or base in ordered or base not in model_names:
+                ordered.append(name)
+                remaining.remove(name)
+    ordered.extend(remaining)  # any cycle/leftover — shouldn't happen
+    return ordered
+
+
+def _build_actuals_and_rookies(
+    supabase, season: int, all_stats: list[dict], min_games: int
+) -> tuple[dict[str, float], set]:
+    """Return (actual PPG by player for qualifying non-rookies, had_prior_stats set).
+
+    Mirrors backtest_model exactly: a player counts only if they cleared
+    min_games this season AND had ≥1 game in some prior season (excludes true
+    rookies, whose projection path is shared across models).
+    """
+    actuals_rows = _fetch_season_rows(
+        supabase, "player_stats", "player_id, ppg, games_played", season
+    )
+    had_prior: set = {
+        r["player_id"]
+        for r in all_stats
+        if r.get("season") is not None
+        and int(r["season"]) < int(season)
+        and (r.get("games_played") or 0) > 0
+    }
+    actuals: dict[str, float] = {}
+    for r in actuals_rows:
+        if int(r.get("games_played", 0) or 0) < min_games:
+            continue
+        if r["player_id"] not in had_prior:
+            continue
+        if r.get("ppg") is None:
+            continue
+        actuals[r["player_id"]] = float(r["ppg"])
+    return actuals, had_prior
+
+
+def _metrics_from_preds(
+    preds: dict[str, float],
+    actuals: dict[str, float],
+    pos_map: dict[str, str],
+) -> dict[str, dict]:
+    """Compute ALL + per-position metrics for one model on one season."""
+    all_proj: list[float] = []
+    all_act: list[float] = []
+    by_pos: dict[str, tuple[list[float], list[float]]] = {p: ([], []) for p in POSITIONS}
+
+    for pid, actual in actuals.items():
+        if pid not in preds:
+            continue
+        p = preds[pid]
+        all_proj.append(p)
+        all_act.append(actual)
+        pos = pos_map.get(pid)
+        if pos in by_pos:
+            by_pos[pos][0].append(p)
+            by_pos[pos][1].append(actual)
+
+    out = {"ALL": _compute_metrics(all_proj, all_act)}
+    for pos in POSITIONS:
+        proj, act = by_pos[pos]
+        if proj:
+            out[pos] = _compute_metrics(proj, act)
+    return out
+
+
+def _learned_preds_for_eval(
+    model_name: str,
+    train_seasons: list[int],
+    eval_seasons: list[int],
+    temp_dir: Path,
+) -> dict[int, dict[str, float]]:
+    """Retrain a learned/residual model on train_seasons; predict eval_seasons.
+
+    Returns {season: {player_id: predicted_ppg}}. Saves the held-out params to
+    temp_dir so dependent residual models can load this as their base.
+    """
+    # Imported here so the monkeypatched TRAINED_MODELS_DIR is in effect when
+    # train_ridge_residual calls load_model_params.
+    from scripts.feature_projections.train_model import (
+        collect_training_data,
+        train_ridge_loso,
+        train_ridge_residual,
+    )
+
+    model_def = get_model(model_name)
+    td = collect_training_data(model_name, train_seasons + eval_seasons)
+    if td.empty:
+        print(f"  {model_name}: no training data, skipping")
+        return {}
+
+    train_df = td[td["season"].isin(train_seasons)]
+    if train_df.empty:
+        print(f"  {model_name}: no rows in training window {train_seasons}, skipping")
+        return {}
+
+    is_residual = model_def.combiner_type == "residual"
+    if is_residual:
+        params = train_ridge_residual(
+            train_df,
+            base_model_name=model_def.base_model_name,
+            residual_features=model_def.features,
+            interaction_terms=model_def.interaction_terms,
+            training_filter=model_def.training_filter,
+        )
+    else:
+        params = train_ridge_loso(train_df, model_def.interaction_terms)
+
+    # Persist so a dependent residual can use this held-out model as its base.
+    (temp_dir / f"{model_name}.json").write_text(json.dumps(params))
+
+    preds_by_season: dict[int, dict[str, float]] = {}
+    for season in eval_seasons:
+        rows = td[td["season"] == season]
+        season_preds: dict[str, float] = {}
+        for _, r in rows.iterrows():
+            fv = r["feature_values"]
+            pos = r["position"]
+            pred = (
+                predict_residual(fv, pos, params)
+                if is_residual
+                else predict(fv, pos, params)
+            )
+            if pred is not None:
+                season_preds[str(r["player_id"])] = float(pred)
+        preds_by_season[season] = season_preds
+    return preds_by_season
+
+
+def _db_preds_for_eval(
+    supabase, model_id: int, eval_seasons: list[int]
+) -> dict[int, dict[str, float]]:
+    """Read existing model_projections (already held-out for parameter-free models)."""
+    out: dict[int, dict[str, float]] = {}
+    for season in eval_seasons:
+        rows = _fetch_season_rows(
+            supabase,
+            "model_projections",
+            "player_id, projected_ppg",
+            season,
+            extra_eq=("model_id", model_id),
+        )
+        out[season] = {
+            r["player_id"]: float(r["projected_ppg"])
+            for r in rows
+            if r.get("projected_ppg") is not None
+        }
+    return out
+
+
+def _aggregate(season_metrics: dict[int, dict[str, dict]], pos: str) -> Optional[dict]:
+    """Weighted-average a model's metrics for one position across eval seasons."""
+    rows = [season_metrics[s].get(pos) for s in season_metrics]
+    rows = [r for r in rows if r is not None]
+    if not rows:
+        return None
+    total_n = sum(r.get("player_count") or 0 for r in rows)
+    if total_n == 0:
+        return None
+
+    def _wavg(key: str) -> Optional[float]:
+        pairs = [
+            (r.get(key), r.get("player_count") or 0)
+            for r in rows
+            if r.get(key) is not None and (r.get("player_count") or 0) > 0
+        ]
+        if not pairs:
+            return None
+        return sum(v * w for v, w in pairs) / sum(w for _, w in pairs)
+
+    rmse_pairs = [
+        (r.get("rmse"), r.get("player_count") or 0)
+        for r in rows
+        if r.get("rmse") is not None and (r.get("player_count") or 0) > 0
+    ]
+    rmse = (
+        (sum(v**2 * w for v, w in rmse_pairs) / sum(w for _, w in rmse_pairs)) ** 0.5
+        if rmse_pairs
+        else None
+    )
+    return {
+        "mae": _wavg("mae"),
+        "bias": _wavg("bias"),
+        "r_squared": _wavg("r_squared"),
+        "rmse": rmse,
+        "player_count": total_n,
+    }
+
+
+def _fmt(val, fmt: str) -> str:
+    if val is None:
+        return "—"
+    try:
+        return format(val, fmt)
+    except (ValueError, TypeError):
+        return str(val)
+
+
+def run(
+    train_seasons: list[int],
+    eval_seasons: list[int],
+    only_models: Optional[list[str]] = None,
+) -> str:
+    supabase = get_supabase_client()
+
+    players_data = fetch_all_rows(supabase, "players", "id, position")
+    pos_map = {row["id"]: row["position"] for row in players_data}
+    all_stats = fetch_all_rows(supabase, "player_stats", "player_id, games_played, season")
+
+    # Shared actuals + rookie filter per eval season — identical for every model.
+    actuals_by_season: dict[int, dict[str, float]] = {}
+    for season in eval_seasons:
+        actuals, _ = _build_actuals_and_rookies(supabase, season, all_stats, MIN_GAMES)
+        actuals_by_season[season] = actuals
+        print(f"Eval season {season}: {len(actuals)} qualifying non-rookie players")
+
+    model_names = list(MODELS.keys()) if only_models is None else only_models
+    learned = [m for m in model_names if get_model(m).combiner_type in ("learned", "residual")]
+    others = [m for m in model_names if m not in learned]
+
+    # {model: {season: {pos: metrics}}}
+    results: dict[str, dict[int, dict[str, dict]]] = {}
+
+    # --- Parameter-free models: read held-out projections from the DB ---
+    for model_name in others:
+        res = supabase.table("projection_models").select("id").eq("name", model_name).execute()
+        if not res.data:
+            continue
+        model_id = res.data[0]["id"]
+        preds_by_season = _db_preds_for_eval(supabase, model_id, eval_seasons)
+        results[model_name] = {
+            s: _metrics_from_preds(preds_by_season.get(s, {}), actuals_by_season[s], pos_map)
+            for s in eval_seasons
+        }
+
+    # --- Learned/residual models: retrain on the held-out window in a temp dir ---
+    temp_dir = Path(tempfile.mkdtemp(prefix="holdout_models_"))
+    orig_dir = learned_combiner.TRAINED_MODELS_DIR
+    learned_combiner.TRAINED_MODELS_DIR = temp_dir
+    try:
+        for model_name in _dependency_order(learned):
+            print(f"\n=== Held-out retrain: {model_name} (train {train_seasons}) ===")
+            preds_by_season = _learned_preds_for_eval(
+                model_name, train_seasons, eval_seasons, temp_dir
+            )
+            if not preds_by_season:
+                continue
+            results[model_name] = {
+                s: _metrics_from_preds(preds_by_season.get(s, {}), actuals_by_season[s], pos_map)
+                for s in eval_seasons
+            }
+    finally:
+        learned_combiner.TRAINED_MODELS_DIR = orig_dir
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    return _render(results, train_seasons, eval_seasons)
+
+
+def _render(
+    results: dict[str, dict[int, dict[str, dict]]],
+    train_seasons: list[int],
+    eval_seasons: list[int],
+) -> str:
+    metric_cols = [("mae", "MAE", ".3f"), ("bias", "Bias", "+.3f"),
+                   ("r_squared", "R²", ".3f"), ("rmse", "RMSE", ".3f"),
+                   ("player_count", "N", "d")]
+    report_positions = ["ALL"] + list(POSITIONS)
+
+    # Combined (across eval seasons) per position.
+    combined: dict[str, dict[str, Optional[dict]]] = {}
+    for model_name, season_metrics in results.items():
+        combined[model_name] = {p: _aggregate(season_metrics, p) for p in report_positions}
+
+    lines: list[str] = []
+    lines.append("# Projection Held-Out Evaluation (GH #572)\n")
+    lines.append(f"_Generated: {datetime.now().strftime('%Y-%m-%d %H:%M')}_\n")
+    lines.append(
+        f"**Every model is evaluated out-of-sample on a shared held-out window.** "
+        f"Learned/residual models were retrained on **{','.join(map(str, train_seasons))}** "
+        f"and never saw the eval seasons **{','.join(map(str, eval_seasons))}**; additive and "
+        f"external models are parameter-free w.r.t. training seasons, so their existing "
+        f"projections are already held-out. All models are scored through the identical "
+        f"`backtest_model` filter (target-season games ≥ {MIN_GAMES}, true rookies excluded). "
+        f"Unlike [projection-accuracy.md](projection-accuracy.md), **no model here is scored "
+        f"on data it trained on** — this is the honest ranking. See "
+        f"[docs/exec-plans/projection-methodology-audit.md](../exec-plans/projection-methodology-audit.md) "
+        f"(Finding 1b).\n"
+    )
+
+    # --- Ranking by combined ALL MAE ---
+    lines.append("## Ranking — combined held-out ALL (lower MAE = better)\n")
+    lines.append("| Rank | Model | MAE | Bias | R² | RMSE | N |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- |")
+    ranked = sorted(
+        (m for m in combined if combined[m]["ALL"] and combined[m]["ALL"].get("mae") is not None),
+        key=lambda m: combined[m]["ALL"]["mae"],
+    )
+    best_mae = combined[ranked[0]]["ALL"]["mae"] if ranked else None
+    for i, model_name in enumerate(ranked, 1):
+        row = combined[model_name]["ALL"]
+        mae_str = _fmt(row["mae"], ".3f")
+        if best_mae is not None and row["mae"] == best_mae:
+            mae_str = f"**{mae_str}**"
+        lines.append(
+            f"| {i} | `{model_name}` | {mae_str} | {_fmt(row['bias'], '+.3f')} "
+            f"| {_fmt(row['r_squared'], '.3f')} | {_fmt(row['rmse'], '.3f')} "
+            f"| {_fmt(row['player_count'], 'd')} |"
+        )
+    lines.append("")
+
+    # --- Combined per-position tables ---
+    lines.append("## Combined across eval seasons — by position\n")
+    for pos in report_positions:
+        lines.append(f"### {pos}\n")
+        lines.append("| Model | " + " | ".join(n for _, n, _ in metric_cols) + " |")
+        lines.append("| " + " | ".join(["---"] * (len(metric_cols) + 1)) + " |")
+        # Sort each position table by MAE for readability.
+        pos_models = sorted(
+            (m for m in combined if combined[m].get(pos) and combined[m][pos].get("mae") is not None),
+            key=lambda m: combined[m][pos]["mae"],
+        )
+        for model_name in pos_models:
+            row = combined[model_name][pos]
+            cells = [_fmt(row.get(k), fmt) for k, _, fmt in metric_cols]
+            lines.append(f"| `{model_name}` | " + " | ".join(cells) + " |")
+        lines.append("")
+
+    # --- Per-season ALL ---
+    for season in eval_seasons:
+        lines.append(f"## Season {season} — ALL (held-out)\n")
+        lines.append("| Model | " + " | ".join(n for _, n, _ in metric_cols) + " |")
+        lines.append("| " + " | ".join(["---"] * (len(metric_cols) + 1)) + " |")
+        season_models = sorted(
+            (m for m in results if results[m].get(season, {}).get("ALL", {}).get("mae") is not None),
+            key=lambda m: results[m][season]["ALL"]["mae"],
+        )
+        for model_name in season_models:
+            row = results[model_name][season]["ALL"]
+            cells = [_fmt(row.get(k), fmt) for k, _, fmt in metric_cols]
+            lines.append(f"| `{model_name}` | " + " | ".join(cells) + " |")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Held-out evaluation of all projection models (#572)")
+    parser.add_argument("--train-seasons", default="2021,2022,2023",
+                        help="Comma-separated training seasons (must precede eval seasons)")
+    parser.add_argument("--eval-seasons", default="2024,2025",
+                        help="Comma-separated held-out evaluation seasons")
+    parser.add_argument("--models", default=None,
+                        help="Optional comma-separated subset of models (default: all)")
+    parser.add_argument("--output",
+                        default=os.path.join(repo_root, "docs", "generated", "projection-holdout-eval.md"))
+    args = parser.parse_args()
+
+    train_seasons = [int(s) for s in args.train_seasons.split(",")]
+    eval_seasons = [int(s) for s in args.eval_seasons.split(",")]
+    if set(train_seasons) & set(eval_seasons):
+        parser.error("train-seasons and eval-seasons must not overlap")
+    if max(train_seasons) >= min(eval_seasons):
+        parser.error("all train-seasons must precede all eval-seasons (no future leakage)")
+
+    only_models = [m.strip() for m in args.models.split(",")] if args.models else None
+
+    table = run(train_seasons, eval_seasons, only_models)
+
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    with open(args.output, "w") as f:
+        f.write(table)
+    print(f"\nReport written to: {args.output}")
+    print("\n" + "=" * 80)
+    print(table)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/feature_projections/holdout_eval.py
+++ b/scripts/feature_projections/holdout_eval.py
@@ -264,11 +264,19 @@ def _fmt(val, fmt: str) -> str:
         return str(val)
 
 
-def run(
+def gather_predictions(
     train_seasons: list[int],
     eval_seasons: list[int],
     only_models: Optional[list[str]] = None,
-) -> str:
+) -> tuple[dict[str, dict[int, dict[str, float]]], dict[int, dict[str, float]], dict[str, str]]:
+    """Produce held-out predictions for every model on the eval seasons.
+
+    Returns (preds, actuals_by_season, pos_map) where
+    preds = {model_name: {season: {player_id: predicted_ppg}}}. Learned/residual
+    models are retrained on train_seasons in a sandboxed temp dir; parameter-free
+    models are read from their already-held-out model_projections. This is the
+    shared machinery behind both the held-out report and the significance test.
+    """
     supabase = get_supabase_client()
 
     players_data = fetch_all_rows(supabase, "players", "id, position")
@@ -286,8 +294,7 @@ def run(
     learned = [m for m in model_names if get_model(m).combiner_type in ("learned", "residual")]
     others = [m for m in model_names if m not in learned]
 
-    # {model: {season: {pos: metrics}}}
-    results: dict[str, dict[int, dict[str, dict]]] = {}
+    preds: dict[str, dict[int, dict[str, float]]] = {}
 
     # --- Parameter-free models: read held-out projections from the DB ---
     for model_name in others:
@@ -295,11 +302,7 @@ def run(
         if not res.data:
             continue
         model_id = res.data[0]["id"]
-        preds_by_season = _db_preds_for_eval(supabase, model_id, eval_seasons)
-        results[model_name] = {
-            s: _metrics_from_preds(preds_by_season.get(s, {}), actuals_by_season[s], pos_map)
-            for s in eval_seasons
-        }
+        preds[model_name] = _db_preds_for_eval(supabase, model_id, eval_seasons)
 
     # --- Learned/residual models: retrain on the held-out window in a temp dir ---
     temp_dir = Path(tempfile.mkdtemp(prefix="holdout_models_"))
@@ -311,15 +314,32 @@ def run(
             preds_by_season = _learned_preds_for_eval(
                 model_name, train_seasons, eval_seasons, temp_dir
             )
-            if not preds_by_season:
-                continue
-            results[model_name] = {
-                s: _metrics_from_preds(preds_by_season.get(s, {}), actuals_by_season[s], pos_map)
-                for s in eval_seasons
-            }
+            if preds_by_season:
+                preds[model_name] = preds_by_season
     finally:
         learned_combiner.TRAINED_MODELS_DIR = orig_dir
         shutil.rmtree(temp_dir, ignore_errors=True)
+
+    return preds, actuals_by_season, pos_map
+
+
+def run(
+    train_seasons: list[int],
+    eval_seasons: list[int],
+    only_models: Optional[list[str]] = None,
+) -> str:
+    preds, actuals_by_season, pos_map = gather_predictions(
+        train_seasons, eval_seasons, only_models
+    )
+
+    # {model: {season: {pos: metrics}}}
+    results: dict[str, dict[int, dict[str, dict]]] = {
+        model_name: {
+            s: _metrics_from_preds(model_preds.get(s, {}), actuals_by_season[s], pos_map)
+            for s in eval_seasons
+        }
+        for model_name, model_preds in preds.items()
+    }
 
     return _render(results, train_seasons, eval_seasons)
 

--- a/scripts/feature_projections/significance.py
+++ b/scripts/feature_projections/significance.py
@@ -1,0 +1,190 @@
+"""Paired bootstrap significance test for the MAE difference between two models (GH #573).
+
+Finding 2 of the methodology audit
+(docs/exec-plans/projection-methodology-audit.md): 31 model variants have been
+ranked on the same four seasons with promote/verdict decisions made on MAE
+deltas as small as 0.01, and no decision has ever been tested for significance.
+With a small dataset and many looks, sub-0.05 deltas are routinely sampling
+noise.
+
+This tool computes, for two models, the per-player paired absolute errors on a
+held-out window and bootstraps the MAE difference to produce a confidence
+interval and a bootstrap p-value. A difference is only "real" if its 95% CI
+excludes zero.
+
+By default it runs on the same leakage-free held-out window as
+``holdout_eval.py`` (train 2021–2023, eval 2024–2025), so learned models are
+compared out-of-sample. Predictions come from ``holdout_eval.gather_predictions``
+so the two tools always agree.
+
+Usage:
+    venv/bin/python scripts/feature_projections/significance.py \
+        v14_qb_starter v31_depth_chart [--position ALL] [--iterations 10000]
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Optional
+
+import numpy as np
+
+from scripts.feature_projections.holdout_eval import gather_predictions
+from scripts.feature_projections.model_config import get_model
+
+
+def _expand_with_bases(model_names: list[str]) -> list[str]:
+    """Include each residual model's base chain so it can be retrained standalone."""
+    out: list[str] = []
+    for name in model_names:
+        chain: list[str] = []
+        cur: Optional[str] = name
+        seen = set()
+        while cur and cur not in seen:
+            seen.add(cur)
+            chain.append(cur)
+            cur = get_model(cur).base_model_name
+        # Bases must be trained before dependents; holdout_eval handles ordering.
+        for m in chain:
+            if m not in out:
+                out.append(m)
+    return out
+
+
+def _paired_errors(
+    preds: dict,
+    actuals_by_season: dict,
+    pos_map: dict,
+    model_a: str,
+    model_b: str,
+    position: str,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Per-player |error| arrays for both models over the common (paired) players."""
+    err_a: list[float] = []
+    err_b: list[float] = []
+    pa, pb = preds.get(model_a, {}), preds.get(model_b, {})
+    for season, actuals in actuals_by_season.items():
+        sa, sb = pa.get(season, {}), pb.get(season, {})
+        for pid, actual in actuals.items():
+            if pid not in sa or pid not in sb:
+                continue
+            if position != "ALL" and pos_map.get(pid) != position:
+                continue
+            err_a.append(abs(sa[pid] - actual))
+            err_b.append(abs(sb[pid] - actual))
+    return np.array(err_a, dtype=np.float64), np.array(err_b, dtype=np.float64)
+
+
+def bootstrap_mae_difference(
+    err_a: np.ndarray,
+    err_b: np.ndarray,
+    iterations: int = 10000,
+    seed: int = 0,
+) -> dict:
+    """Paired bootstrap of MAE(A) − MAE(B). Negative delta ⇒ A more accurate.
+
+    Resamples players (rows) with replacement, recomputing the paired MAE delta
+    each time. Returns observed delta, 95% CI, and a two-sided bootstrap p-value
+    (the share of resamples landing on the opposite side of zero from the
+    observed delta, doubled).
+    """
+    n = len(err_a)
+    if n == 0:
+        return {"n": 0}
+    rng = np.random.default_rng(seed)
+    observed = float(err_a.mean() - err_b.mean())
+
+    deltas = np.empty(iterations, dtype=np.float64)
+    for i in range(iterations):
+        idx = rng.integers(0, n, n)
+        deltas[i] = err_a[idx].mean() - err_b[idx].mean()
+
+    lo, hi = np.percentile(deltas, [2.5, 97.5])
+    # Two-sided bootstrap p-value: how often resamples cross to the other side of 0.
+    if observed < 0:
+        p = 2.0 * float(np.mean(deltas >= 0))
+    elif observed > 0:
+        p = 2.0 * float(np.mean(deltas <= 0))
+    else:
+        p = 1.0
+    p = min(1.0, p)
+
+    return {
+        "n": n,
+        "mae_a": float(err_a.mean()),
+        "mae_b": float(err_b.mean()),
+        "delta": observed,
+        "ci_low": float(lo),
+        "ci_high": float(hi),
+        "p_value": p,
+        "significant": (lo > 0) or (hi < 0),
+    }
+
+
+def run(
+    model_a: str,
+    model_b: str,
+    train_seasons: list[int],
+    eval_seasons: list[int],
+    position: str = "ALL",
+    iterations: int = 10000,
+    seed: int = 0,
+) -> dict:
+    models = _expand_with_bases([model_a, model_b])
+    preds, actuals_by_season, pos_map = gather_predictions(train_seasons, eval_seasons, models)
+    err_a, err_b = _paired_errors(preds, actuals_by_season, pos_map, model_a, model_b, position)
+    res = bootstrap_mae_difference(err_a, err_b, iterations=iterations, seed=seed)
+    res.update({"model_a": model_a, "model_b": model_b, "position": position})
+    return res
+
+
+def _print_result(res: dict, train_seasons: list[int], eval_seasons: list[int]) -> None:
+    a, b = res["model_a"], res["model_b"]
+    print("\n" + "=" * 72)
+    print(f"Paired bootstrap — MAE({a}) − MAE({b})")
+    print(f"Held-out window: train {train_seasons} → eval {eval_seasons} | position {res['position']}")
+    print("=" * 72)
+    if res.get("n", 0) == 0:
+        print("No paired players found — cannot test.")
+        return
+    print(f"  Paired players (N): {res['n']}")
+    print(f"  MAE {a}: {res['mae_a']:.4f}")
+    print(f"  MAE {b}: {res['mae_b']:.4f}")
+    print(f"  Observed delta (A−B): {res['delta']:+.4f}  "
+          f"({'A better' if res['delta'] < 0 else 'B better' if res['delta'] > 0 else 'tie'})")
+    print(f"  95% CI: [{res['ci_low']:+.4f}, {res['ci_high']:+.4f}]")
+    print(f"  Bootstrap p-value: {res['p_value']:.4f}")
+    if res["significant"]:
+        better = a if res["delta"] < 0 else b
+        print(f"  ⇒ SIGNIFICANT at 95%: {better} is more accurate (CI excludes 0).")
+    else:
+        print(f"  ⇒ NOT significant at 95%: the MAE gap is within sampling noise (CI spans 0).")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Paired bootstrap significance of an MAE difference (#573)")
+    parser.add_argument("model_a")
+    parser.add_argument("model_b")
+    parser.add_argument("--train-seasons", default="2021,2022,2023")
+    parser.add_argument("--eval-seasons", default="2024,2025")
+    parser.add_argument("--position", default="ALL", help="ALL | QB | RB | WR | TE | K")
+    parser.add_argument("--iterations", type=int, default=10000)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    train_seasons = [int(s) for s in args.train_seasons.split(",")]
+    eval_seasons = [int(s) for s in args.eval_seasons.split(",")]
+    if set(train_seasons) & set(eval_seasons):
+        parser.error("train-seasons and eval-seasons must not overlap")
+    if max(train_seasons) >= min(eval_seasons):
+        parser.error("all train-seasons must precede all eval-seasons (no future leakage)")
+
+    res = run(
+        args.model_a, args.model_b, train_seasons, eval_seasons,
+        position=args.position, iterations=args.iterations, seed=args.seed,
+    )
+    _print_result(res, train_seasons, eval_seasons)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to #578 (audit + Finding 1 report-honesty fix, already merged). This adds the next two remediations, which landed on the branch after #578 was squash-merged.

## Finding 1b (#572) — held-out re-ranking
New `scripts/feature_projections/holdout_eval.py` (`just holdout-eval`) retrains every learned/residual model on a clean window (default 2021–2023) into a sandboxed temp dir — production `trained_models/*.json` and `model_projections` are never touched — and scores 2024–2025 out-of-sample for all models through the identical `backtest_model` filter. Additive/external models are read from their already-held-out projections.

**The leaked ranking inverts** (`docs/generated/projection-holdout-eval.md`): the previously-promoted `v31_depth_chart` falls from in-sample rank 1 (2.358) to held-out **rank 22/30** (2.660); the entire learned family (v20–v31) occupies the bottom, beaten by every additive model, the naive `v1` baseline, and FantasyPros. Held-out leader is the additive **v14_qb_starter** (2.450). Learned models also over-project OOS (bias −1.0 to −1.3 vs additive ≈ −0.2).

> Prod was already reverted to `v14_qb_starter` via `just promote` (a DB action, independent of this code).

## Finding 2 (#573) — paired-bootstrap significance
New `scripts/feature_projections/significance.py` (`just significance A B`): paired bootstrap over players of the held-out MAE difference (95% CI + p-value), reusing `holdout_eval.gather_predictions`.
- v14 vs v31: Δ −0.263, CI [−0.40, −0.13], p≈0 — **significant** (revert justified).
- v14 vs v19: Δ −0.006 — not significant.
- v22 vs v27 (a celebrated in-sample gain): Δ −0.029 — not significant.

Going forward, no model should be promoted on a point delta that fails `just significance`.

## Follow-up
- #579 — recalibrate the learned models' OOS over-projection bias before any re-promotion.

## Validation
- Both scripts run clean; `holdout_eval` report regenerated.
- `test_architecture.py` passes (20). Held-out retraining is fully sandboxed (temp dir) — no production data touched by this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #572
Closes #573