### PR TITLE
docs: daily harness audit 2026-06-10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,10 @@ Comprehensive database and analytics platform for Ottoneu Fantasy Football Leagu
 - **Season cycle:** See [docs/exec-plans/season-cycle.md](docs/exec-plans/season-cycle.md) — the site rolls between Ottoneu seasons from the `league_calendar` table; the current season is resolved at runtime via `scripts/season.py` and `web/lib/season.ts`, not from static config
 - **Projection Accuracy Plan:** See [docs/exec-plans/projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md) for the 4-phase accuracy improvement roadmap (Issues #271-#285)
 - **Projection Accuracy:** Run `just accuracy-report` (or `python scripts/feature_projections/accuracy_report.py`) to generate a model comparison table. **Required when updating any projection code** — see Projection Model Update Requirements below.
+- **Projection Iteration:** Use `/experiment` to run a full experiment loop (train → project → backtest → verdict). Use `/ablation` for feature ablation studies, `/feature-importance` for learned model inspection, `/compare-models` for side-by-side comparisons, `/diagnose-segment` for segment deep-dives.
 - **Market Projections:** See [docs/exec-plans/market-projections.md](docs/exec-plans/market-projections.md) for the market-based projection system (DEFERRED)
 - **Experiment Log:** See [docs/generated/experiment-log.md](docs/generated/experiment-log.md) for history of all model iteration attempts.
+- **Retrospective:** Use `/retro` skill after completing a task to surface friction points and open a PR with doc/skill improvements.
 - **Build System Spec:** See [docs/superpowers/specs/2026-04-19-build-system-design.md](docs/superpowers/specs/2026-04-19-build-system-design.md) for the transition specification to `just` build runner
 - **Build System Plan:** See [docs/superpowers/plans/2026-04-19-build-system-just.md](docs/superpowers/plans/2026-04-19-build-system-just.md) for the build system migration step-by-step plan
 
@@ -48,13 +50,16 @@ docs/
 │   ├── [feature-projections.md](docs/exec-plans/feature-projections.md)         # Feature-based player projection system
 │   ├── [market-projections.md](docs/exec-plans/market-projections.md)          # Market-based projection system (DEFERRED)
 │   ├── [projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md)  # 4-phase accuracy improvement roadmap
+│   ├── [projection-methodology-audit.md](docs/exec-plans/projection-methodology-audit.md)  # ML-quality audit: train/test leakage + eval findings (#571–#577)
 │   ├── [qb-usage-share.md](docs/exec-plans/qb-usage-share.md)              # QB Usage Share findings and next steps
 │   └── [season-cycle.md](docs/exec-plans/season-cycle.md)                # Cross-season data & UI scheme (date-driven season-cycle resolver)
 ├── generated/
 │   ├── [db-schema.md](docs/generated/db-schema.md)                   # Database tables, keys, relationships
 │   ├── [experiment-log.md](docs/generated/experiment-log.md)              # History of all model iteration attempts
 │   ├── [player-diagnostics.md](docs/generated/player-diagnostics.md)          # Per-player backtest diagnostics
-│   ├── [projection-accuracy.md](docs/generated/projection-accuracy.md)         # Projection model accuracy report
+│   ├── [projection-accuracy.md](docs/generated/projection-accuracy.md)         # Projection model accuracy report (in-sample; see audit caveat)
+│   ├── [projection-holdout-eval.md](docs/generated/projection-holdout-eval.md)     # Held-out (leakage-free) model re-ranking — `just holdout-eval` (#572)
+│   ├── [rookie-backtest.md](docs/generated/rookie-backtest.md)             # Rookie (0-history) projection backtest — draft_capital vs baselines
 │   └── [segment-analysis.md](docs/generated/segment-analysis.md)            # Segmented projection accuracy analysis
 ├── references/
 │   ├── environment-variables.md       # .env and .env.local variable reference
@@ -104,7 +109,7 @@ Run `just check-arch` to validate these rules locally.
 
 ## Critical Rules
 
-- **Always use `just <recipe>`** instead of invoking Python, pytest, or npm scripts directly. This ensures the correct venv and flags are used, and keeps the agent allowlist minimal. Run `just --list` to see available recipes. Common ones: `just typecheck`, `just lint`, `just test-web`, `just test-python`, `just train MODEL`, `just project MODEL`, `just backtest MODEL`, `just promote MODEL`, `just accuracy-report`, `just diagnostics`, `just segment-analysis`, `just backfill-nfl-stats`, `just backfill-draft-capital`, `just backfill-vegas`, `just seed-win-totals`, `just scrape-draft-sharks`. For ad-hoc DB inspection use `just py "<snippet>"`.
+- **Always use `just <recipe>`** instead of invoking Python, pytest, or npm scripts directly. This ensures the correct venv and flags are used, and keeps the agent allowlist minimal. Run `just --list` to see available recipes. Common ones: `just typecheck`, `just lint`, `just test-web`, `just test-python`, `just train MODEL`, `just project MODEL`, `just backtest MODEL`, `just promote MODEL`, `just accuracy-report`, `just diagnostics`, `just segment-analysis`, `just analyze` (runs `update_projections.py` — re-projects the active model + promotes to `player_projections` + rookie fallback), `just backfill-nfl-stats`, `just backfill-draft-capital`, `just backfill-vegas`, `just backfill-depth-charts`, `just seed-win-totals`, `just scrape-draft-sharks`, `just dev` / `just dev-stop` (start/stop the Next.js dev server — use `dev-stop` instead of raw `pkill`). For ad-hoc DB inspection use `just py "<snippet>"`.
 - **Editable install can run stale `scripts/` code.** If a `scripts/*.py` edit doesn't take effect via `venv/bin/python scripts/foo.py` (but works via `python -c`), the editable install is likely pinned to a stale `.claude/worktrees/` path — run `venv/bin/pip install -e .` from the project root. See [docs/TESTING.md](docs/TESTING.md#gotcha-editable-install-can-pin-scripts-to-a-stale-worktree).
 - **New DB tables need a TS type + the config contract is enforced.** After adding a table (e.g. via `mcp__supabase__apply_migration` or Supabase dashboard), hand-add its `Row`/`Insert`/`Update` block to `web/types/supabase.ts` or `npx tsc` fails — hand-add rather than fully regenerating to avoid churning the `fp_*` tables. Separately, every key in `config.json` must be consumed by **both** `scripts/config.py` and `web/lib/config.ts` (and vice versa); this bidirectional contract is enforced by `scripts/tests/test_architecture.py`, so add/remove keys in all three places.
 - **Do not touch `fp_*` tables.** The Supabase project is shared with the `fantasy-pulse` app. Tables whose names start with `fp_` (currently `fp_notes`, `fp_user_integrations`, `fp_leagues`, `fp_teams`, but the prefix is the rule, not the list) are owned by that other codebase. Do not read from, write to, alter, drop, or migrate them from this repo. They will appear in `list_tables` output and in regenerated Supabase TS types — ignore them. See [docs/generated/db-schema.md](docs/generated/db-schema.md#shared-database--hands-off-fp_).
@@ -163,4 +168,6 @@ Skipping step 2 will cause TypeScript errors like `Argument of type '"new_table"
 
 ### Supabase pagination
 
-Supabase's Python client defaults to a **1000-row limit** on `.execute()` calls. Any query that may return more than 1000 rows must use paginated `.range(offset, offset + page_size - 1)` fetching in a loop. This has already caused a silent bug in `promote.py` (now fixed). Apply the same pattern in any new bulk-fetch code.
+Supabase's Python client defaults to a **1000-row limit** on `.execute()` calls. Any query that may return more than 1000 rows must use paginated `.range(offset, offset + page_size - 1)` fetching in a loop. This has caused silent bugs in `promote.py`, `analysis_utils.fetch_multi_season_stats` (a 3-season history fetch is ~2k rows — truncation silently dropped player-season rows, corrupting weighted-PPG bases and projections), and `feature_projections/backtest.py` (a single recent season of `player_stats` now exceeds 1000 rows) — all now fixed. A single recent NFL season of `player_stats` is already >1000 rows, so even single-season fetches need pagination now. Apply the same pattern in any new bulk-fetch code.
+
+**The web JS/TS client (`web/lib/`) has the same 1000-row default cap.** This silently broke the `/depth-charts` season selector — `depth_charts` has thousands of rows, so a plain `.select("season")` returned only the most recent ~1000 and dropped older seasons (fixed in `web/lib/depth-charts.ts` by looping `.range()`). Watch for it on any web query against a large table (`depth_charts`, `nfl_stats`, `player_stats`, `model_projections`) — distinct-value or full-table reads must paginate, and a query meant for one model/season should filter (`.eq("model_id", …)`/`.eq("season", …)`) rather than fetch-all-then-filter, or it will both truncate and mix in other rows.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -121,6 +121,8 @@ just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
 just accuracy-report [--run-backtest] ...           # Generate accuracy report
+just holdout-eval [--train-seasons ...] [--eval-seasons ...] [--output ...]  # Held-out (leakage-free) re-rank: retrain learned models on the train window, score every model OOS on eval (GH #572)
+just significance <model_a> <model_b> [--seasons ...]  # Paired bootstrap on the held-out MAE gap between two models (GH #573)
 
 # Backfills / seeds
 just backfill-nfl-stats [--seasons ...] [--dry-run]    # Backfill nfl_stats from nflverse


### PR DESCRIPTION
## Summary

Daily harness audit covering the 16 commits merged since the last audit (`70b4388`, 2026-06-06). The big drift was in **AGENTS.md** — several rounds of CLAUDE.md updates over the past few days never made it across — plus two new `just` recipes that weren't in `docs/COMMANDS.md`.

## Commits reviewed (16, since `70b4388`)

- `daabbff` Projection eval: held-out re-ranking (#572) + MAE significance test (#573) (#580)
- `e52bac6` docs+report: projection methodology audit + train/test leakage disclosure (#578)
- `a93a5b0` feat: expand training data — backfill player_stats 2018-2020, add 2021+2025 training seasons (#569)
- `36db45f` feat: overhaul projections page (rookie-inclusive board, admin-only methodology) (#568)
- `29930ce` experiment: test Week-1 depth charts as a rookie projection signal (#567)
- `8095c48` fix: paginate nfl_stats + web large-table reads (1000-row truncation audit) (#566)
- `d76be99` fix: dedupe drafted-prospect player records stranding rookie projections (#565)
- `38393b4` feat: rookie projection backtest harness (#564)
- `6f523f6` fix: pool history + draft-tier prior for rookie projections (#563)
- `b0f5af1` fix: paginate multi-season + backtest Supabase fetches (#562)
- `0b191e5` retro: surface just analyze/dev-stop + web-side Supabase pagination cap (#561)
- `4172f9c` feat: admin workflow status history page (#560)
- `7e4f401` feat: scheduled offseason refresh of depth charts + Vegas lines (#558)
- `e7ad98f` feat: add /depth-charts web page (#557)
- `bb1ec32` feat: onboard depth-chart role data + v31_depth_chart model (#554)
- `2a72a3e` feat: down-weight low-games seasons via reliability exponent (v28) (#553)

## Changes made

**`AGENTS.md`** — bring back into parity with `CLAUDE.md`:
- Quick Reference: add the **Projection Iteration** entry (`/experiment`, `/ablation`, `/feature-importance`, `/compare-models`, `/diagnose-segment`) and the **Retrospective** entry (`/retro`).
- Documentation Map: add three docs landed since the last audit — `projection-methodology-audit.md` (exec-plans) and `projection-holdout-eval.md` + `rookie-backtest.md` (generated). Annotate `projection-accuracy.md` as in-sample per the audit caveat.
- Critical Rules `just <recipe>` list: add `just analyze`, `just backfill-depth-charts`, and the `just dev` / `just dev-stop` pair (use `dev-stop` instead of raw `pkill`).
- Supabase-pagination section: expanded to call out the **web JS/TS client's identical 1000-row cap** and the `fetch_multi_season_stats` + `backtest.py` truncation bugs (previously only mentioned `promote.py`).

**`docs/COMMANDS.md`** — document the two new recipes added in PR #580:
- `just holdout-eval` — held-out (leakage-free) model re-rank (GH #572).
- `just significance` — paired bootstrap on the held-out MAE gap between two models (GH #573).

## Schema check

No drift. Migrations `028_create_depth_charts.sql` and `029_depth_charts_anon_read.sql` (the only new ones since the last audit) are already reflected in `docs/generated/db-schema.md` — the `depth_charts` row and the anon-policy table entry both went in via #554/#557. Table count (22) matches the actual table list.

## Items flagged for human follow-up

None. The doc set is otherwise in good shape — `check_docs_freshness` passes clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_014Y7xWoAUxp5ocSrBo21Hgo)_