### PR TITLE
Availability-inclusive backtest (#574, Finding 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ docs/
 │   ├── [player-diagnostics.md](docs/generated/player-diagnostics.md)          # Per-player backtest diagnostics
 │   ├── [projection-accuracy.md](docs/generated/projection-accuracy.md)         # Projection model accuracy report (in-sample; see audit caveat)
 │   ├── [projection-holdout-eval.md](docs/generated/projection-holdout-eval.md)     # Held-out (leakage-free) model re-ranking — `just holdout-eval` (#572)
+│   ├── [projection-availability-eval.md](docs/generated/projection-availability-eval.md) # Availability-inclusive backtest — rate vs availability budget — `just availability-backtest` (#574)
 │   ├── [rookie-backtest.md](docs/generated/rookie-backtest.md)             # Rookie (0-history) projection backtest — draft_capital vs baselines
 │   └── [segment-analysis.md](docs/generated/segment-analysis.md)            # Segmented projection accuracy analysis
 ├── references/

--- a/Justfile
+++ b/Justfile
@@ -131,6 +131,10 @@ holdout-eval *args:
 significance model_a model_b *args:
     {{python}} scripts/feature_projections/significance.py {{model_a}} {{model_b}} {{args}}
 
+# Availability-inclusive backtest: keep injured/partial seasons, measure the availability budget (GH #574)
+availability-backtest *args:
+    {{python}} scripts/feature_projections/availability_backtest.py {{args}}
+
 # Promote a model to production  (e.g. just promote v24_learned_elite)
 promote model:
     {{python}} scripts/feature_projections/cli.py promote --model {{model}}

--- a/docs/exec-plans/projection-methodology-audit.md
+++ b/docs/exec-plans/projection-methodology-audit.md
@@ -157,9 +157,55 @@ the roadmap: issue #384 (injury/availability, "24% of error budget") targets
 exactly the population the evaluation filters out. You cannot measure progress
 on availability while deleting unavailable players from the test set.
 
-**Remediation:** add an availability-inclusive evaluation track (e.g. score
-total season points, or PPG×games, with DNP/low-games seasons retained as
-low-scoring outcomes) as a parallel metric.
+**Remediation (shipped):** `scripts/feature_projections/availability_backtest.py`
+(`just availability-backtest`) keeps every non-rookie with ≥1 game and scores
+each projection against two targets: **Rate** (actual PPG) and **Avail**
+(production per scheduled game, `ppg × min(games,17)/17`, missed games = 0). The
+gap is the **availability error budget**. Report:
+[projection-availability-eval.md](../generated/projection-availability-eval.md).
+
+### Finding 3 result — the availability budget is large, and the discarded feature was right
+
+Combined 2022–2025, inclusive population (N=1069 internal, mean games **12.6** —
+the average rostered player missed ~4 of 17 games):
+
+| Model | Rate MAE | Avail MAE | Avail budget | Avail bias |
+|---|---|---|---|---|
+| `v7_regression_to_mean` (has `games_played`) | 2.652 | **3.096** | **+0.444** | −1.53 |
+| `v4_availability_adjusted` (has `games_played`) | 2.673 | **3.106** | **+0.434** | −1.53 |
+| `v14_qb_starter` (**production**) | 2.555 | 3.188 | +0.633 | −1.75 |
+| `v1_baseline_weighted_ppg` | 2.693 | 3.510 | +0.817 | −2.24 |
+
+Two findings:
+
+1. **The availability budget is real and unmodeled.** Every internal model pays
+   +0.43 to +0.82 MAE purely for ignoring playing-time loss — for production
+   `v14`, +0.633, ≈20% of its availability-inclusive error (the audit's #384
+   cited ~24%). It shows up as a large negative bias (systematic
+   over-projection): a PPG rate projection assumes the player suits up.
+
+2. **The feature the rate-only backtest discarded was measuring the right
+   thing.** The `v3`–`v7` family carries a `games_played`/availability
+   adjustment and was dropped because it *raised* rate MAE (see the v3–v6
+   regression table above). On the availability target the ordering flips:
+   `v4`/`v5`/`v7` have the **lowest** budget *and* the **lowest avail MAE**,
+   beating both production `v14` and the naive `v1`. The feature traded a little
+   rate accuracy for a lot of availability accuracy — value the rate-only metric
+   was structurally blind to.
+
+Caveats: this population (games ≥ 1) is harder than the standard report's
+(games ≥ 4), so the MAE numbers are **not** comparable to
+[projection-accuracy.md](../generated/projection-accuracy.md). QB avail figures
+are extreme (the inclusive pool is dominated by 1–3 game backups). FantasyPros'
+row (N=703, mean games 13.1) is scored on its own smaller, more-available
+projected set, so its low budget is partly sample selection — don't read it as
+"FP models availability." Players with literally 0 games (no stats row) are
+still missing, so the true budget is a lower bound.
+
+**Recommended follow-up:** revisit a `games_played`/availability feature
+evaluated against the availability objective (ties directly to #384), and report
+both rate and availability MAE for any future availability work via
+`just availability-backtest`.
 
 ---
 
@@ -227,7 +273,7 @@ averaged) alongside the pooled number.
 | 1b — held-out evaluation window | 🔴 | [#572](https://github.com/alex-monroe/ottoneu-db/issues/572) | shipped (`just holdout-eval`); ranking inverts — see above |
 | 2 — bootstrap significance on MAE deltas | 🟠 | [#573](https://github.com/alex-monroe/ottoneu-db/issues/573) | shipped (`just significance`); see Finding 2 result |
 | (rec) recalibrate learned models before re-promotion | 🔴 | [#579](https://github.com/alex-monroe/ottoneu-db/issues/579) | open |
-| 3 — availability-inclusive evaluation | 🟠 | [#574](https://github.com/alex-monroe/ottoneu-db/issues/574) | open |
+| 3 — availability-inclusive evaluation | 🟠 | [#574](https://github.com/alex-monroe/ottoneu-db/issues/574) | shipped (`just availability-backtest`); see Finding 3 result |
 | 4 — naïve baselines + matched-sample FP | 🟠 | [#575](https://github.com/alex-monroe/ottoneu-db/issues/575) | open |
 | 5 — R² aggregation discipline | 🟡 | [#576](https://github.com/alex-monroe/ottoneu-db/issues/576) | open |
 | 6 — position-balanced headline MAE | 🟡 | [#577](https://github.com/alex-monroe/ottoneu-db/issues/577) | open |

--- a/docs/generated/projection-availability-eval.md
+++ b/docs/generated/projection-availability-eval.md
@@ -1,0 +1,188 @@
+# Projection Availability-Inclusive Evaluation (GH #574)
+
+_Generated: 2026-06-10 08:23_
+
+Standard backtests score only players with ≥4 games, hiding injured/benched/bust seasons. This evaluation keeps everyone with ≥1 game (non-rookie) and scores each PPG projection against two targets: **Rate** = actual PPG, and **Avail** = availability-inclusive production per scheduled game (`ppg × min(games,17) / 17`, missed games = 0). The gap **avail-MAE − rate-MAE** is the *availability error budget* — error from playing-time loss that no current rate feature addresses. Default models are parameter-free (additive + external), whose stored projections are leakage-free; learned models (if included) use in-sample projections (see #571). Seasons: 2022,2023,2024,2025. See [docs/exec-plans/projection-methodology-audit.md](../exec-plans/projection-methodology-audit.md) (Finding 3).
+
+## Rate vs availability decomposition (combined ALL)
+
+| Model | N | Mean games | Rate MAE | Avail MAE | Availability budget | Avail bias |
+| --- | --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 703 | 13.1 | 2.598 | 2.489 | -0.109 | -0.455 |
+| `v7_regression_to_mean` | 1069 | 12.6 | 2.652 | 3.096 | +0.444 | -1.530 |
+| `v4_availability_adjusted` | 1069 | 12.6 | 2.673 | 3.106 | +0.434 | -1.527 |
+| `v5_team_context` | 1069 | 12.6 | 2.679 | 3.117 | +0.437 | -1.550 |
+| `v21_tiered_regression` | 1069 | 12.6 | 2.599 | 3.120 | +0.521 | -1.536 |
+| `v6_usage_share` | 1069 | 12.6 | 2.703 | 3.179 | +0.475 | -1.697 |
+| `v14_qb_starter` | 1069 | 12.6 | 2.555 | 3.188 | +0.633 | -1.747 |
+| `v16_snap_trend_full` | 1069 | 12.6 | 2.570 | 3.216 | +0.646 | -1.781 |
+| `v19_usage_level_full` | 1069 | 12.6 | 2.560 | 3.247 | +0.687 | -1.894 |
+| `v12_no_qb_trajectory` | 1069 | 12.6 | 2.568 | 3.252 | +0.684 | -1.815 |
+| `v17_rookie_growth` | 1069 | 12.6 | 2.610 | 3.252 | +0.642 | -1.817 |
+| `v10_stat_efficiency_v2` | 1069 | 12.6 | 2.577 | 3.257 | +0.681 | -1.835 |
+| `v8_age_regression` | 1069 | 12.6 | 2.579 | 3.265 | +0.686 | -1.843 |
+| `v9_pos_specific` | 1069 | 12.6 | 2.579 | 3.265 | +0.686 | -1.843 |
+| `v13_qb_starter` | 1069 | 12.6 | 2.577 | 3.268 | +0.691 | -1.842 |
+| `v11_team_context_v2` | 1069 | 12.6 | 2.585 | 3.270 | +0.685 | -1.869 |
+| `v3_stat_weighted` | 1069 | 12.6 | 2.614 | 3.334 | +0.720 | -1.996 |
+| `v2_age_adjusted` | 1069 | 12.6 | 2.617 | 3.343 | +0.726 | -2.010 |
+| `v15_snap_trend` | 1069 | 12.6 | 2.649 | 3.375 | +0.725 | -2.044 |
+| `v18_usage_level` | 1069 | 12.6 | 2.658 | 3.414 | +0.756 | -2.157 |
+| `v1_baseline_weighted_ppg` | 1069 | 12.6 | 2.693 | 3.510 | +0.817 | -2.242 |
+
+## Availability-inclusive metrics by position
+
+### ALL
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 2.489 | -0.455 | 0.582 | 3.539 | 703 |
+| `v7_regression_to_mean` | 3.096 | -1.530 | 0.304 | 4.234 | 1069 |
+| `v4_availability_adjusted` | 3.106 | -1.527 | 0.274 | 4.323 | 1069 |
+| `v5_team_context` | 3.117 | -1.550 | 0.267 | 4.344 | 1069 |
+| `v21_tiered_regression` | 3.120 | -1.536 | 0.260 | 4.363 | 1069 |
+| `v6_usage_share` | 3.179 | -1.697 | 0.243 | 4.417 | 1069 |
+| `v14_qb_starter` | 3.188 | -1.747 | 0.263 | 4.355 | 1069 |
+| `v16_snap_trend_full` | 3.216 | -1.781 | 0.247 | 4.404 | 1069 |
+| `v19_usage_level_full` | 3.247 | -1.894 | 0.244 | 4.412 | 1069 |
+| `v12_no_qb_trajectory` | 3.252 | -1.815 | 0.222 | 4.475 | 1069 |
+| `v17_rookie_growth` | 3.252 | -1.817 | 0.250 | 4.392 | 1069 |
+| `v10_stat_efficiency_v2` | 3.257 | -1.835 | 0.207 | 4.518 | 1069 |
+| `v8_age_regression` | 3.265 | -1.843 | 0.204 | 4.527 | 1069 |
+| `v9_pos_specific` | 3.265 | -1.843 | 0.204 | 4.527 | 1069 |
+| `v13_qb_starter` | 3.268 | -1.842 | 0.202 | 4.531 | 1069 |
+| `v11_team_context_v2` | 3.270 | -1.869 | 0.200 | 4.540 | 1069 |
+| `v3_stat_weighted` | 3.334 | -1.996 | 0.155 | 4.665 | 1069 |
+| `v2_age_adjusted` | 3.343 | -2.010 | 0.149 | 4.681 | 1069 |
+| `v15_snap_trend` | 3.375 | -2.044 | 0.129 | 4.735 | 1069 |
+| `v18_usage_level` | 3.414 | -2.157 | 0.120 | 4.759 | 1069 |
+| `v1_baseline_weighted_ppg` | 3.510 | -2.242 | 0.073 | 4.885 | 1069 |
+
+### QB
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 3.299 | -0.964 | 0.566 | 4.768 | 174 |
+| `v4_availability_adjusted` | 5.054 | -3.282 | 0.132 | 6.563 | 211 |
+| `v7_regression_to_mean` | 5.078 | -3.265 | 0.167 | 6.429 | 211 |
+| `v5_team_context` | 5.115 | -3.330 | 0.119 | 6.613 | 211 |
+| `v6_usage_share` | 5.115 | -3.330 | 0.119 | 6.613 | 211 |
+| `v21_tiered_regression` | 5.411 | -3.736 | 0.057 | 6.842 | 211 |
+| `v14_qb_starter` | 5.707 | -4.258 | 0.024 | 6.958 | 211 |
+| `v17_rookie_growth` | 5.707 | -4.258 | 0.024 | 6.958 | 211 |
+| `v19_usage_level_full` | 5.707 | -4.258 | 0.024 | 6.958 | 211 |
+| `v16_snap_trend_full` | 5.787 | -4.329 | -0.002 | 7.052 | 211 |
+| `v12_no_qb_trajectory` | 6.031 | -4.602 | -0.084 | 7.335 | 211 |
+| `v3_stat_weighted` | 6.047 | -4.759 | -0.153 | 7.566 | 211 |
+| `v10_stat_efficiency_v2` | 6.047 | -4.704 | -0.119 | 7.453 | 211 |
+| `v8_age_regression` | 6.058 | -4.727 | -0.124 | 7.471 | 211 |
+| `v9_pos_specific` | 6.058 | -4.727 | -0.124 | 7.471 | 211 |
+| `v11_team_context_v2` | 6.064 | -4.779 | -0.129 | 7.488 | 211 |
+| `v2_age_adjusted` | 6.069 | -4.791 | -0.164 | 7.602 | 211 |
+| `v18_usage_level` | 6.069 | -4.791 | -0.164 | 7.602 | 211 |
+| `v13_qb_starter` | 6.074 | -4.721 | -0.128 | 7.484 | 211 |
+| `v15_snap_trend` | 6.162 | -4.862 | -0.195 | 7.703 | 211 |
+| `v1_baseline_weighted_ppg` | 6.355 | -5.165 | -0.251 | 7.882 | 211 |
+
+### RB
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 2.825 | -0.112 | 0.474 | 3.765 | 153 |
+| `v10_stat_efficiency_v2` | 3.378 | -1.221 | 0.305 | 4.295 | 217 |
+| `v11_team_context_v2` | 3.394 | -1.272 | 0.298 | 4.320 | 217 |
+| `v21_tiered_regression` | 3.399 | -1.033 | 0.265 | 4.417 | 217 |
+| `v8_age_regression` | 3.404 | -1.230 | 0.300 | 4.313 | 217 |
+| `v9_pos_specific` | 3.404 | -1.230 | 0.300 | 4.313 | 217 |
+| `v12_no_qb_trajectory` | 3.404 | -1.230 | 0.300 | 4.313 | 217 |
+| `v13_qb_starter` | 3.404 | -1.230 | 0.300 | 4.313 | 217 |
+| `v14_qb_starter` | 3.404 | -1.230 | 0.300 | 4.313 | 217 |
+| `v5_team_context` | 3.451 | -1.148 | 0.237 | 4.459 | 217 |
+| `v7_regression_to_mean` | 3.458 | -1.138 | 0.266 | 4.387 | 217 |
+| `v16_snap_trend_full` | 3.461 | -1.305 | 0.278 | 4.382 | 217 |
+| `v4_availability_adjusted` | 3.481 | -1.127 | 0.237 | 4.458 | 217 |
+| `v19_usage_level_full` | 3.529 | -1.500 | 0.259 | 4.433 | 217 |
+| `v3_stat_weighted` | 3.530 | -1.485 | 0.228 | 4.508 | 217 |
+| `v17_rookie_growth` | 3.540 | -1.385 | 0.266 | 4.437 | 217 |
+| `v2_age_adjusted` | 3.541 | -1.510 | 0.224 | 4.522 | 217 |
+| `v6_usage_share` | 3.548 | -1.417 | 0.190 | 4.588 | 217 |
+| `v15_snap_trend` | 3.585 | -1.584 | 0.197 | 4.602 | 217 |
+| `v1_baseline_weighted_ppg` | 3.667 | -1.810 | 0.148 | 4.766 | 217 |
+| `v18_usage_level` | 3.671 | -1.779 | 0.164 | 4.689 | 217 |
+
+### WR
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 2.434 | -0.695 | 0.384 | 3.175 | 196 |
+| `v21_tiered_regression` | 2.784 | -1.279 | 0.190 | 3.763 | 291 |
+| `v8_age_regression` | 2.815 | -1.296 | 0.235 | 3.656 | 291 |
+| `v9_pos_specific` | 2.815 | -1.296 | 0.235 | 3.656 | 291 |
+| `v12_no_qb_trajectory` | 2.815 | -1.296 | 0.235 | 3.656 | 291 |
+| `v13_qb_starter` | 2.815 | -1.296 | 0.235 | 3.656 | 291 |
+| `v14_qb_starter` | 2.815 | -1.296 | 0.235 | 3.656 | 291 |
+| `v11_team_context_v2` | 2.815 | -1.313 | 0.230 | 3.672 | 291 |
+| `v10_stat_efficiency_v2` | 2.818 | -1.293 | 0.234 | 3.658 | 291 |
+| `v16_snap_trend_full` | 2.827 | -1.345 | 0.222 | 3.686 | 291 |
+| `v7_regression_to_mean` | 2.876 | -1.427 | 0.183 | 3.777 | 291 |
+| `v4_availability_adjusted` | 2.881 | -1.422 | 0.140 | 3.878 | 291 |
+| `v5_team_context` | 2.889 | -1.445 | 0.132 | 3.898 | 291 |
+| `v19_usage_level_full` | 2.894 | -1.548 | 0.187 | 3.767 | 291 |
+| `v3_stat_weighted` | 2.903 | -1.556 | 0.136 | 3.887 | 291 |
+| `v17_rookie_growth` | 2.906 | -1.396 | 0.221 | 3.686 | 291 |
+| `v2_age_adjusted` | 2.908 | -1.564 | 0.134 | 3.892 | 291 |
+| `v15_snap_trend` | 2.934 | -1.612 | 0.118 | 3.926 | 291 |
+| `v6_usage_share` | 2.998 | -1.696 | 0.066 | 4.040 | 291 |
+| `v18_usage_level` | 3.019 | -1.816 | 0.064 | 4.043 | 291 |
+| `v1_baseline_weighted_ppg` | 3.106 | -1.754 | 0.040 | 4.101 | 291 |
+
+### TE
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 1.482 | +0.007 | 0.568 | 1.978 | 180 |
+| `v10_stat_efficiency_v2` | 1.794 | -0.756 | 0.398 | 2.298 | 235 |
+| `v16_snap_trend_full` | 1.799 | -0.767 | 0.397 | 2.300 | 235 |
+| `v8_age_regression` | 1.799 | -0.760 | 0.395 | 2.304 | 235 |
+| `v9_pos_specific` | 1.799 | -0.760 | 0.395 | 2.304 | 235 |
+| `v12_no_qb_trajectory` | 1.799 | -0.760 | 0.395 | 2.304 | 235 |
+| `v13_qb_starter` | 1.799 | -0.760 | 0.395 | 2.304 | 235 |
+| `v14_qb_starter` | 1.799 | -0.760 | 0.395 | 2.304 | 235 |
+| `v21_tiered_regression` | 1.799 | -0.532 | 0.388 | 2.318 | 235 |
+| `v11_team_context_v2` | 1.824 | -0.770 | 0.386 | 2.322 | 235 |
+| `v7_regression_to_mean` | 1.833 | -0.673 | 0.364 | 2.363 | 235 |
+| `v19_usage_level_full` | 1.851 | -0.870 | 0.358 | 2.372 | 235 |
+| `v17_rookie_growth` | 1.852 | -0.815 | 0.373 | 2.348 | 235 |
+| `v4_availability_adjusted` | 1.853 | -0.648 | 0.335 | 2.416 | 235 |
+| `v5_team_context` | 1.864 | -0.663 | 0.331 | 2.425 | 235 |
+| `v3_stat_weighted` | 1.879 | -0.857 | 0.324 | 2.435 | 235 |
+| `v2_age_adjusted` | 1.884 | -0.859 | 0.325 | 2.434 | 235 |
+| `v15_snap_trend` | 1.887 | -0.866 | 0.327 | 2.430 | 235 |
+| `v6_usage_share` | 1.923 | -0.773 | 0.280 | 2.514 | 235 |
+| `v18_usage_level` | 1.948 | -0.969 | 0.271 | 2.529 | 235 |
+| `v1_baseline_weighted_ppg` | 2.025 | -1.115 | 0.222 | 2.612 | 235 |
+
+### K
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v7_regression_to_mean` | 1.912 | -1.097 | -0.067 | 2.638 | 115 |
+| `v16_snap_trend_full` | 1.916 | -1.181 | -0.176 | 2.755 | 115 |
+| `v21_tiered_regression` | 1.938 | -1.154 | -0.165 | 2.731 | 115 |
+| `v12_no_qb_trajectory` | 1.945 | -1.269 | -0.192 | 2.768 | 115 |
+| `v14_qb_starter` | 1.945 | -1.269 | -0.192 | 2.768 | 115 |
+| `v17_rookie_growth` | 1.945 | -1.269 | -0.192 | 2.768 | 115 |
+| `v19_usage_level_full` | 1.945 | -1.269 | -0.192 | 2.768 | 115 |
+| `v4_availability_adjusted` | 1.954 | -1.119 | -0.109 | 2.688 | 115 |
+| `v5_team_context` | 1.954 | -1.119 | -0.109 | 2.688 | 115 |
+| `v6_usage_share` | 1.954 | -1.119 | -0.109 | 2.688 | 115 |
+| `v8_age_regression` | 2.013 | -1.307 | -0.282 | 2.889 | 115 |
+| `v9_pos_specific` | 2.013 | -1.307 | -0.282 | 2.889 | 115 |
+| `v10_stat_efficiency_v2` | 2.013 | -1.307 | -0.282 | 2.889 | 115 |
+| `v11_team_context_v2` | 2.013 | -1.307 | -0.282 | 2.889 | 115 |
+| `v13_qb_starter` | 2.013 | -1.307 | -0.282 | 2.889 | 115 |
+| `v15_snap_trend` | 2.020 | -1.242 | -0.304 | 2.921 | 115 |
+| `v1_baseline_weighted_ppg` | 2.047 | -1.234 | -0.290 | 2.902 | 115 |
+| `v2_age_adjusted` | 2.051 | -1.330 | -0.320 | 2.933 | 115 |
+| `v3_stat_weighted` | 2.051 | -1.330 | -0.320 | 2.933 | 115 |
+| `v18_usage_level` | 2.051 | -1.330 | -0.320 | 2.933 | 115 |

--- a/scripts/feature_projections/availability_backtest.py
+++ b/scripts/feature_projections/availability_backtest.py
@@ -1,0 +1,305 @@
+"""Availability-inclusive backtest (GH #574, Finding 3).
+
+The standard backtest (`backtest.py`) only scores players who cleared
+`MIN_GAMES` (=4) in the target season. That silently deletes the injured,
+benched, and bust seasons from the actuals — inflating every model's apparent
+accuracy and making the availability error budget (the motivation for the
+injury-model work, #384) impossible to measure.
+
+This parallel evaluation keeps those players. For each qualifying player-season
+it scores a model's PPG projection against two targets:
+
+- **Rate** — actual PPG (the standard target), but on the *inclusive*
+  population (games ≥ 1). Measures pure per-game accuracy.
+- **Availability-inclusive** — production per *scheduled* game,
+  `ppg × min(games, 17) / 17`. A player who played 4 games at 15 PPG scores
+  ~3.5 here, not 15: missed games count as zero production. A pure-rate PPG
+  projection is penalised for players who miss time — which is exactly the
+  availability error no current feature models.
+
+The gap between the two (avail-MAE − rate-MAE) is the **availability error
+budget**: error attributable purely to playing-time loss that better
+rate-projection cannot fix.
+
+Leakage note: this reads stored `model_projections`, so by default it only
+includes **parameter-free** models (additive + external FantasyPros), whose
+stored projections are leakage-free. Learned/residual models' stored
+projections are in-sample (see #571); pass `--include-learned` to add them, but
+treat their rows as a rough diagnostic, not a clean ranking. The availability
+budget itself is model-agnostic.
+
+Usage:
+    venv/bin/python scripts/feature_projections/availability_backtest.py \
+        --seasons 2022,2023,2024,2025 \
+        --output docs/generated/projection-availability-eval.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import datetime
+from typing import Optional
+
+from scripts.config import get_supabase_client, fetch_all_rows, POSITIONS
+from scripts.feature_projections.backtest import _compute_metrics, _fetch_season_rows
+from scripts.feature_projections.model_config import MODELS, get_model
+
+repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# NFL regular-season length (17 games since 2021). The eval seasons here are all
+# 2021+, so a single constant is correct; revisit if older seasons are added.
+GAMES_FULL_SEASON = 17
+
+# Minimum games to be *included* (vs the standard backtest's MIN_GAMES=4). 1 keeps
+# anyone who took the field at all; the point is to stop hiding partial seasons.
+MIN_INCLUDE_GAMES = 1
+
+
+def _build_availability_actuals(
+    supabase, season: int, all_stats: list[dict]
+) -> dict[str, dict]:
+    """Per-player rate + availability-inclusive actuals for non-rookies.
+
+    Returns {player_id: {"ppg": float, "avail": float, "games": int}}.
+    Mirrors backtest_model's rookie exclusion (≥1 prior-season game) but uses
+    MIN_INCLUDE_GAMES instead of MIN_GAMES so partial seasons are retained.
+    """
+    rows = _fetch_season_rows(
+        supabase, "player_stats", "player_id, ppg, games_played", season
+    )
+    had_prior: set = {
+        r["player_id"]
+        for r in all_stats
+        if r.get("season") is not None
+        and int(r["season"]) < int(season)
+        and (r.get("games_played") or 0) > 0
+    }
+    out: dict[str, dict] = {}
+    for r in rows:
+        games = int(r.get("games_played", 0) or 0)
+        if games < MIN_INCLUDE_GAMES:
+            continue
+        if r["player_id"] not in had_prior:
+            continue
+        if r.get("ppg") is None:
+            continue
+        ppg = float(r["ppg"])
+        avail = ppg * min(games, GAMES_FULL_SEASON) / GAMES_FULL_SEASON
+        out[r["player_id"]] = {"ppg": ppg, "avail": avail, "games": games}
+    return out
+
+
+def _model_metrics(
+    preds: dict[str, float],
+    actuals: dict[str, dict],
+    pos_map: dict[str, str],
+) -> dict:
+    """Rate + availability metrics (ALL + per position) plus mean games."""
+    targets = {"rate": "ppg", "avail": "avail"}
+    # accumulate paired lists
+    buckets: dict[str, dict[str, tuple[list, list]]] = {
+        t: {p: ([], []) for p in ["ALL"] + list(POSITIONS)} for t in targets
+    }
+    games_list: list[int] = []
+
+    for pid, actual in actuals.items():
+        if pid not in preds:
+            continue
+        pred = preds[pid]
+        pos = pos_map.get(pid)
+        games_list.append(actual["games"])
+        for t, key in targets.items():
+            buckets[t]["ALL"][0].append(pred)
+            buckets[t]["ALL"][1].append(actual[key])
+            if pos in buckets[t]:
+                buckets[t][pos][0].append(pred)
+                buckets[t][pos][1].append(actual[key])
+
+    out: dict = {"mean_games": (sum(games_list) / len(games_list)) if games_list else None}
+    for t in targets:
+        out[t] = {}
+        for pos in ["ALL"] + list(POSITIONS):
+            proj, act = buckets[t][pos]
+            if proj:
+                out[t][pos] = _compute_metrics(proj, act)
+    return out
+
+
+def _aggregate_metric(
+    season_results: dict[int, dict], target: str, pos: str
+) -> Optional[dict]:
+    """Weighted-average one (target, position) across seasons for a model."""
+    rows = [season_results[s][target].get(pos) for s in season_results if season_results[s].get(target)]
+    rows = [r for r in rows if r is not None]
+    if not rows:
+        return None
+    total_n = sum(r.get("player_count") or 0 for r in rows)
+    if total_n == 0:
+        return None
+
+    def _wavg(key: str) -> Optional[float]:
+        pairs = [(r.get(key), r.get("player_count") or 0) for r in rows
+                 if r.get(key) is not None and (r.get("player_count") or 0) > 0]
+        return sum(v * w for v, w in pairs) / sum(w for _, w in pairs) if pairs else None
+
+    rmse_pairs = [(r.get("rmse"), r.get("player_count") or 0) for r in rows
+                  if r.get("rmse") is not None and (r.get("player_count") or 0) > 0]
+    rmse = ((sum(v**2 * w for v, w in rmse_pairs) / sum(w for _, w in rmse_pairs)) ** 0.5
+            if rmse_pairs else None)
+    return {"mae": _wavg("mae"), "bias": _wavg("bias"), "r_squared": _wavg("r_squared"),
+            "rmse": rmse, "player_count": total_n}
+
+
+def _fmt(val, fmt: str) -> str:
+    if val is None:
+        return "—"
+    try:
+        return format(val, fmt)
+    except (ValueError, TypeError):
+        return str(val)
+
+
+def run(seasons: list[int], model_names: list[str]) -> str:
+    supabase = get_supabase_client()
+    players_data = fetch_all_rows(supabase, "players", "id, position")
+    pos_map = {row["id"]: row["position"] for row in players_data}
+    all_stats = fetch_all_rows(supabase, "player_stats", "player_id, games_played, season")
+
+    actuals_by_season = {s: _build_availability_actuals(supabase, s, all_stats) for s in seasons}
+    for s in seasons:
+        print(f"Season {s}: {len(actuals_by_season[s])} players (games ≥ {MIN_INCLUDE_GAMES}, non-rookie)")
+
+    # {model: {season: metrics}}
+    results: dict[str, dict[int, dict]] = {}
+    for name in model_names:
+        res = supabase.table("projection_models").select("id").eq("name", name).execute()
+        if not res.data:
+            continue
+        model_id = res.data[0]["id"]
+        season_results: dict[int, dict] = {}
+        for s in seasons:
+            preds_rows = _fetch_season_rows(
+                supabase, "model_projections", "player_id, projected_ppg",
+                s, extra_eq=("model_id", model_id),
+            )
+            preds = {r["player_id"]: float(r["projected_ppg"]) for r in preds_rows
+                     if r.get("projected_ppg") is not None}
+            if preds:
+                season_results[s] = _model_metrics(preds, actuals_by_season[s], pos_map)
+        if season_results:
+            results[name] = season_results
+
+    return _render(results, seasons)
+
+
+def _render(results: dict[str, dict[int, dict]], seasons: list[int]) -> str:
+    report_positions = ["ALL"] + list(POSITIONS)
+    # Combined per model: rate ALL, avail ALL+positions, mean games.
+    combined: dict[str, dict] = {}
+    for name, sr in results.items():
+        combined[name] = {
+            "rate": {p: _aggregate_metric(sr, "rate", p) for p in report_positions},
+            "avail": {p: _aggregate_metric(sr, "avail", p) for p in report_positions},
+        }
+        gpairs = [(sr[s]["mean_games"], sr[s]["avail"]["ALL"]["player_count"])
+                  for s in sr
+                  if sr[s].get("mean_games") is not None and sr[s].get("avail", {}).get("ALL")]
+        combined[name]["mean_games"] = (
+            sum(g * n for g, n in gpairs) / sum(n for _, n in gpairs) if gpairs else None
+        )
+
+    lines: list[str] = []
+    lines.append("# Projection Availability-Inclusive Evaluation (GH #574)\n")
+    lines.append(f"_Generated: {datetime.now().strftime('%Y-%m-%d %H:%M')}_\n")
+    lines.append(
+        f"Standard backtests score only players with ≥4 games, hiding injured/benched/bust "
+        f"seasons. This evaluation keeps everyone with ≥{MIN_INCLUDE_GAMES} game (non-rookie) and "
+        f"scores each PPG projection against two targets: **Rate** = actual PPG, and "
+        f"**Avail** = availability-inclusive production per scheduled game "
+        f"(`ppg × min(games,{GAMES_FULL_SEASON}) / {GAMES_FULL_SEASON}`, missed games = 0). "
+        f"The gap **avail-MAE − rate-MAE** is the *availability error budget* — error from "
+        f"playing-time loss that no current rate feature addresses. Default models are "
+        f"parameter-free (additive + external), whose stored projections are leakage-free; "
+        f"learned models (if included) use in-sample projections (see #571). "
+        f"Seasons: {','.join(map(str, seasons))}. See "
+        f"[docs/exec-plans/projection-methodology-audit.md](../exec-plans/projection-methodology-audit.md) "
+        f"(Finding 3).\n"
+    )
+
+    # Decomposition: rate vs availability, sorted by avail MAE.
+    lines.append("## Rate vs availability decomposition (combined ALL)\n")
+    lines.append("| Model | N | Mean games | Rate MAE | Avail MAE | Availability budget | Avail bias |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- |")
+    ranked = sorted(
+        (m for m in combined if combined[m]["avail"]["ALL"]),
+        key=lambda m: combined[m]["avail"]["ALL"]["mae"],
+    )
+    for name in ranked:
+        rate = combined[name]["rate"]["ALL"]
+        avail = combined[name]["avail"]["ALL"]
+        budget = (avail["mae"] - rate["mae"]) if (rate and avail) else None
+        lines.append(
+            f"| `{name}` | {_fmt(avail['player_count'], 'd')} | {_fmt(combined[name]['mean_games'], '.1f')} "
+            f"| {_fmt(rate['mae'], '.3f')} | {_fmt(avail['mae'], '.3f')} | {_fmt(budget, '+.3f')} "
+            f"| {_fmt(avail['bias'], '+.3f')} |"
+        )
+    lines.append("")
+
+    # Per-position availability MAE.
+    lines.append("## Availability-inclusive metrics by position\n")
+    for pos in report_positions:
+        lines.append(f"### {pos}\n")
+        lines.append("| Model | MAE | Bias | R² | RMSE | N |")
+        lines.append("| --- | --- | --- | --- | --- | --- |")
+        pos_models = sorted(
+            (m for m in combined if combined[m]["avail"].get(pos)),
+            key=lambda m: combined[m]["avail"][pos]["mae"],
+        )
+        for name in pos_models:
+            r = combined[name]["avail"][pos]
+            lines.append(
+                f"| `{name}` | {_fmt(r['mae'], '.3f')} | {_fmt(r['bias'], '+.3f')} "
+                f"| {_fmt(r['r_squared'], '.3f')} | {_fmt(r['rmse'], '.3f')} | {_fmt(r['player_count'], 'd')} |"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _default_models() -> list[str]:
+    """Parameter-free models only (additive + external) — leakage-free stored projections."""
+    return [name for name, m in MODELS.items() if m.combiner_type == "additive"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Availability-inclusive backtest (#574)")
+    parser.add_argument("--seasons", default="2022,2023,2024,2025")
+    parser.add_argument("--models", default=None,
+                        help="Comma-separated subset (default: all parameter-free models)")
+    parser.add_argument("--include-learned", action="store_true",
+                        help="Also include learned/residual models (in-sample projections — diagnostic only)")
+    parser.add_argument("--output",
+                        default=os.path.join(repo_root, "docs", "generated", "projection-availability-eval.md"))
+    args = parser.parse_args()
+
+    seasons = [int(s) for s in args.seasons.split(",")]
+    if args.models:
+        model_names = [m.strip() for m in args.models.split(",")]
+    else:
+        model_names = _default_models()
+        if args.include_learned:
+            model_names += [n for n, m in MODELS.items() if m.combiner_type in ("learned", "residual")]
+
+    table = run(seasons, model_names)
+
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    with open(args.output, "w") as f:
+        f.write(table)
+    print(f"\nReport written to: {args.output}")
+    print("\n" + "=" * 80)
+    print(table)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements Finding 3 of the methodology audit: the standard backtest only scores players with ≥4 games, deleting injured/benched/bust seasons from the actuals — inflating accuracy and making the availability error budget unmeasurable.

## What
New `scripts/feature_projections/availability_backtest.py` (`just availability-backtest`) keeps every non-rookie with ≥1 game and scores each PPG projection against two targets:
- **Rate** — actual PPG (per-game accuracy on the inclusive population)
- **Avail** — production per scheduled game, `ppg × min(games,17)/17` (missed games = 0)

The gap **avail-MAE − rate-MAE** is the availability error budget. Reads stored `model_projections`, so it defaults to parameter-free (additive + external) models whose projections are leakage-free; `--include-learned` adds the rest as a diagnostic.

## Results (2022–2025, N=1069 internal, mean games 12.6)

| Model | Rate MAE | Avail MAE | Avail budget | Avail bias |
|---|---|---|---|---|
| `v7_regression_to_mean` (has `games_played`) | 2.652 | **3.096** | **+0.444** | −1.53 |
| `v4_availability_adjusted` (has `games_played`) | 2.673 | **3.106** | **+0.434** | −1.53 |
| `v14_qb_starter` (**production**) | 2.555 | 3.188 | +0.633 | −1.75 |
| `v1_baseline_weighted_ppg` | 2.693 | 3.510 | +0.817 | −2.24 |

1. **Availability is a large, unmodeled error source.** Every internal model pays +0.43–0.82 MAE for ignoring playing-time loss; production v14 pays +0.633 (~20% of its availability-inclusive error; the audit cited ~24% from #384), showing up as −1.75 over-projection bias.
2. **The feature the rate-only backtest discarded was right.** The `v3`–`v7` `games_played`/availability family — dropped because it *raised* rate MAE — has the **lowest** budget and **wins** on the availability target, beating production v14 and the naive v1. The rate-only metric was structurally blind to its value.

## Caveats (documented)
Inclusive population (games ≥ 1) is harder than the standard report (≥ 4), so MAE is **not** comparable to `projection-accuracy.md`. QB avail figures are backup-dominated. FantasyPros (N=703, mean games 13.1) is scored on its own smaller, more-available set — its low budget is partly sample selection. 0-game players (no stats row) are still excluded, so the budget is a lower bound.

## Validation
- Report generated to `docs/generated/projection-availability-eval.md`; script runs clean.
- `test_architecture.py` passes (20). Reads only — no production data touched.

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)