### PR TITLE
Naïve baselines + matched-sample FantasyPros comparison (#575, Finding 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,8 @@ docs/
 │   ├── [experiment-log.md](docs/generated/experiment-log.md)              # History of all model iteration attempts
 │   ├── [player-diagnostics.md](docs/generated/player-diagnostics.md)          # Per-player backtest diagnostics
 │   ├── [projection-accuracy.md](docs/generated/projection-accuracy.md)         # Projection model accuracy report (in-sample; see audit caveat)
-│   ├── [projection-holdout-eval.md](docs/generated/projection-holdout-eval.md)     # Held-out (leakage-free) model re-ranking — `just holdout-eval` (#572)
+│   ├── [projection-holdout-eval.md](docs/generated/projection-holdout-eval.md)     # Held-out (leakage-free) model re-ranking — `just holdout-eval` (#572); naïve baselines (#575)
+│   ├── [projection-holdout-eval-matched.md](docs/generated/projection-holdout-eval-matched.md) # Held-out re-ranking on the common player set — apples-to-apples FantasyPros — `just holdout-eval --matched` (#575)
 │   ├── [projection-availability-eval.md](docs/generated/projection-availability-eval.md) # Availability-inclusive backtest — rate vs availability budget — `just availability-backtest` (#574)
 │   ├── [rookie-backtest.md](docs/generated/rookie-backtest.md)             # Rookie (0-history) projection backtest — draft_capital vs baselines
 │   └── [segment-analysis.md](docs/generated/segment-analysis.md)            # Segmented projection accuracy analysis

--- a/docs/exec-plans/projection-methodology-audit.md
+++ b/docs/exec-plans/projection-methodology-audit.md
@@ -219,9 +219,41 @@ and a per-position mean. Notably, `v1_baseline` is already within ~0.05 MAE of
 the best "improved" model on most positions — the most under-discussed result in
 the log.
 
-**Remediation:** add `naive_prior_season_ppg` and `position_mean` baseline
-models; restrict cross-model `ALL` aggregates to the common matched-player set
-when comparing against FantasyPros.
+**Remediation (shipped):** two baseline models — `naive_prior_season_ppg`
+(next season = last season's PPG) and `position_mean_baseline` (everyone at the
+positional mean) — are registered and now appear in every report. And
+`just holdout-eval --matched` scores all models on the common player set for an
+apples-to-apples FantasyPros comparison.
+
+### Finding 4 result — the models barely clear "use last year," and FP ties when matched
+
+Held-out 2024–2025 (`just holdout-eval`), the naïve baselines bracket the field:
+
+| Model | Held-out ALL MAE | Note |
+|---|---|---|
+| `v14_qb_starter` (production) | **2.450** | best |
+| `v1_baseline_weighted_ppg` (3-yr weighted) | 2.633 | rank 21 |
+| learned family `v20`–`v31` | 2.65–2.73 | ranks 22–31 |
+| **`naive_prior_season_ppg`** (persistence) | 2.754 | rank 32 |
+| **`position_mean_baseline`** (no-skill) | 3.710 | rank 33 (floor) |
+
+Two readings:
+
+1. **The whole learned family barely beats persistence.** `v20`–`v31` (2.65–2.73)
+   sit just above "use last year's PPG" (2.754) and *below* the 3-year weighted
+   `v1` (2.633). All that feature engineering buys almost nothing over the
+   simplest possible projection — the under-discussed result the audit flagged,
+   now quantified against an explicit floor. `position_mean` (3.710) sets the
+   no-skill floor; good models clear it by ~1.3 MAE and on R² (0.19 → 0.61),
+   confirming they *do* rank players — they just don't beat persistence by much.
+2. **FantasyPros ties the best internal models once the sample is matched.** The
+   full report shows FP at rank 3 (2.462, N=430) vs internal (N=647) — different
+   players. Restricted to the **common 416 players** (`--matched`,
+   [projection-holdout-eval-matched.md](../generated/projection-holdout-eval-matched.md)),
+   FP (2.502) is statistically tied with `v14` (2.494) and `v19` (2.501) — a gap
+   far inside the bootstrap noise (Finding 2) — while still over-projecting
+   (+1.0 bias). FP is neither clearly ahead nor behind; the earlier "mid-pack FP"
+   impression was a sample artifact.
 
 ---
 
@@ -274,7 +306,7 @@ averaged) alongside the pooled number.
 | 2 — bootstrap significance on MAE deltas | 🟠 | [#573](https://github.com/alex-monroe/ottoneu-db/issues/573) | shipped (`just significance`); see Finding 2 result |
 | (rec) recalibrate learned models before re-promotion | 🔴 | [#579](https://github.com/alex-monroe/ottoneu-db/issues/579) | open |
 | 3 — availability-inclusive evaluation | 🟠 | [#574](https://github.com/alex-monroe/ottoneu-db/issues/574) | shipped (`just availability-backtest`); see Finding 3 result |
-| 4 — naïve baselines + matched-sample FP | 🟠 | [#575](https://github.com/alex-monroe/ottoneu-db/issues/575) | open |
+| 4 — naïve baselines + matched-sample FP | 🟠 | [#575](https://github.com/alex-monroe/ottoneu-db/issues/575) | shipped (2 baseline models + `--matched`); see Finding 4 result |
 | 5 — R² aggregation discipline | 🟡 | [#576](https://github.com/alex-monroe/ottoneu-db/issues/576) | open |
 | 6 — position-balanced headline MAE | 🟡 | [#577](https://github.com/alex-monroe/ottoneu-db/issues/577) | open |
 </content>

--- a/docs/generated/projection-holdout-eval-matched.md
+++ b/docs/generated/projection-holdout-eval-matched.md
@@ -1,0 +1,318 @@
+# Projection Held-Out Evaluation (GH #572) — matched-sample (common players only)
+
+_Generated: 2026-06-10 08:44_
+
+**Matched-sample mode (Finding 4):** every model is scored on the *same* players — the intersection of players all evaluated models projected, per season. This makes the FantasyPros comparison apples-to-apples (FP projects a smaller, more-available set), at the cost of a smaller N. Run without `--matched` for the full-coverage report.
+
+**Every model is evaluated out-of-sample on a shared held-out window.** Learned/residual models were retrained on **2021,2022,2023** and never saw the eval seasons **2024,2025**; additive and external models are parameter-free w.r.t. training seasons, so their existing projections are already held-out. All models are scored through the identical `backtest_model` filter (target-season games ≥ 4, true rookies excluded). Unlike [projection-accuracy.md](projection-accuracy.md), **no model here is scored on data it trained on** — this is the honest ranking. See [docs/exec-plans/projection-methodology-audit.md](../exec-plans/projection-methodology-audit.md) (Finding 1b).
+
+## Ranking — combined held-out ALL (lower MAE = better)
+
+| Rank | Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | `v14_qb_starter` | **2.494** | +0.161 | 0.643 | 3.283 | 416 |
+| 2 | `v19_usage_level_full` | 2.501 | -0.039 | 0.645 | 3.275 | 416 |
+| 3 | `external_fantasypros_v1` | 2.502 | +1.022 | 0.616 | 3.400 | 416 |
+| 4 | `v10_stat_efficiency_v2` | 2.521 | +0.071 | 0.620 | 3.389 | 416 |
+| 5 | `v17_rookie_growth` | 2.521 | +0.119 | 0.639 | 3.299 | 416 |
+| 6 | `v16_snap_trend_full` | 2.524 | +0.098 | 0.633 | 3.326 | 416 |
+| 7 | `v12_no_qb_trajectory` | 2.524 | +0.094 | 0.620 | 3.390 | 416 |
+| 8 | `v11_team_context_v2` | 2.525 | +0.033 | 0.613 | 3.419 | 416 |
+| 9 | `v8_age_regression` | 2.525 | +0.069 | 0.618 | 3.398 | 416 |
+| 10 | `v9_pos_specific` | 2.525 | +0.069 | 0.618 | 3.398 | 416 |
+| 11 | `v13_qb_starter` | 2.527 | +0.070 | 0.617 | 3.403 | 416 |
+| 12 | `v21_tiered_regression` | 2.551 | +0.233 | 0.619 | 3.387 | 416 |
+| 13 | `v7_regression_to_mean` | 2.570 | +0.304 | 0.615 | 3.406 | 416 |
+| 14 | `v3_stat_weighted` | 2.585 | -0.183 | 0.601 | 3.475 | 416 |
+| 15 | `v2_age_adjusted` | 2.587 | -0.197 | 0.600 | 3.480 | 416 |
+| 16 | `v5_team_context` | 2.623 | +0.238 | 0.591 | 3.511 | 416 |
+| 17 | `v15_snap_trend` | 2.624 | -0.259 | 0.587 | 3.532 | 416 |
+| 18 | `v4_availability_adjusted` | 2.628 | +0.272 | 0.595 | 3.494 | 416 |
+| 19 | `v18_usage_level` | 2.633 | -0.397 | 0.591 | 3.519 | 416 |
+| 20 | `v26_vegas_residual` | 2.642 | -0.905 | 0.627 | 3.354 | 416 |
+| 21 | `v6_usage_share` | 2.646 | +0.038 | 0.587 | 3.531 | 416 |
+| 22 | `v20_learned_usage` | 2.647 | -0.627 | 0.629 | 3.347 | 416 |
+| 23 | `v22_advanced_receiving` | 2.650 | -0.661 | 0.627 | 3.357 | 416 |
+| 24 | `v31_depth_chart` | 2.656 | -0.908 | 0.618 | 3.399 | 416 |
+| 25 | `v25_draft_capital_residual` | 2.663 | -0.857 | 0.624 | 3.368 | 416 |
+| 26 | `v28_reliability_weighting` | 2.663 | -0.786 | 0.625 | 3.362 | 416 |
+| 27 | `v27_vegas_full_refit` | 2.674 | -0.872 | 0.616 | 3.403 | 416 |
+| 28 | `v30_reliability_full_refit` | 2.675 | -0.877 | 0.615 | 3.409 | 416 |
+| 29 | `v29_reliability_residual` | 2.693 | -0.964 | 0.618 | 3.395 | 416 |
+| 30 | `v1_baseline_weighted_ppg` | 2.700 | -0.429 | 0.571 | 3.605 | 416 |
+| 31 | `v23_draft_capital` | 2.720 | -0.845 | 0.607 | 3.444 | 416 |
+| 32 | `naive_prior_season_ppg` | 2.890 | -0.281 | 0.484 | 3.949 | 416 |
+| 33 | `position_mean_baseline` | 4.080 | +1.757 | 0.117 | 5.173 | 416 |
+
+## Combined across eval seasons — by position
+
+### ALL
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v14_qb_starter` | 2.494 | +0.161 | 0.643 | 3.283 | 416 |
+| `v19_usage_level_full` | 2.501 | -0.039 | 0.645 | 3.275 | 416 |
+| `external_fantasypros_v1` | 2.502 | +1.022 | 0.616 | 3.400 | 416 |
+| `v10_stat_efficiency_v2` | 2.521 | +0.071 | 0.620 | 3.389 | 416 |
+| `v17_rookie_growth` | 2.521 | +0.119 | 0.639 | 3.299 | 416 |
+| `v16_snap_trend_full` | 2.524 | +0.098 | 0.633 | 3.326 | 416 |
+| `v12_no_qb_trajectory` | 2.524 | +0.094 | 0.620 | 3.390 | 416 |
+| `v11_team_context_v2` | 2.525 | +0.033 | 0.613 | 3.419 | 416 |
+| `v8_age_regression` | 2.525 | +0.069 | 0.618 | 3.398 | 416 |
+| `v9_pos_specific` | 2.525 | +0.069 | 0.618 | 3.398 | 416 |
+| `v13_qb_starter` | 2.527 | +0.070 | 0.617 | 3.403 | 416 |
+| `v21_tiered_regression` | 2.551 | +0.233 | 0.619 | 3.387 | 416 |
+| `v7_regression_to_mean` | 2.570 | +0.304 | 0.615 | 3.406 | 416 |
+| `v3_stat_weighted` | 2.585 | -0.183 | 0.601 | 3.475 | 416 |
+| `v2_age_adjusted` | 2.587 | -0.197 | 0.600 | 3.480 | 416 |
+| `v5_team_context` | 2.623 | +0.238 | 0.591 | 3.511 | 416 |
+| `v15_snap_trend` | 2.624 | -0.259 | 0.587 | 3.532 | 416 |
+| `v4_availability_adjusted` | 2.628 | +0.272 | 0.595 | 3.494 | 416 |
+| `v18_usage_level` | 2.633 | -0.397 | 0.591 | 3.519 | 416 |
+| `v26_vegas_residual` | 2.642 | -0.905 | 0.627 | 3.354 | 416 |
+| `v6_usage_share` | 2.646 | +0.038 | 0.587 | 3.531 | 416 |
+| `v20_learned_usage` | 2.647 | -0.627 | 0.629 | 3.347 | 416 |
+| `v22_advanced_receiving` | 2.650 | -0.661 | 0.627 | 3.357 | 416 |
+| `v31_depth_chart` | 2.656 | -0.908 | 0.618 | 3.399 | 416 |
+| `v25_draft_capital_residual` | 2.663 | -0.857 | 0.624 | 3.368 | 416 |
+| `v28_reliability_weighting` | 2.663 | -0.786 | 0.625 | 3.362 | 416 |
+| `v27_vegas_full_refit` | 2.674 | -0.872 | 0.616 | 3.403 | 416 |
+| `v30_reliability_full_refit` | 2.675 | -0.877 | 0.615 | 3.409 | 416 |
+| `v29_reliability_residual` | 2.693 | -0.964 | 0.618 | 3.395 | 416 |
+| `v1_baseline_weighted_ppg` | 2.700 | -0.429 | 0.571 | 3.605 | 416 |
+| `v23_draft_capital` | 2.720 | -0.845 | 0.607 | 3.444 | 416 |
+| `naive_prior_season_ppg` | 2.890 | -0.281 | 0.484 | 3.949 | 416 |
+| `position_mean_baseline` | 4.080 | +1.757 | 0.117 | 5.173 | 416 |
+
+### QB
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v31_depth_chart` | 3.455 | -1.347 | 0.484 | 4.460 | 84 |
+| `v22_advanced_receiving` | 3.462 | -1.114 | 0.481 | 4.471 | 84 |
+| `v20_learned_usage` | 3.486 | -1.200 | 0.476 | 4.491 | 84 |
+| `v28_reliability_weighting` | 3.492 | -1.252 | 0.471 | 4.511 | 84 |
+| `v26_vegas_residual` | 3.520 | -1.402 | 0.460 | 4.558 | 84 |
+| `v27_vegas_full_refit` | 3.539 | -1.240 | 0.443 | 4.631 | 84 |
+| `v30_reliability_full_refit` | 3.549 | -1.274 | 0.436 | 4.658 | 84 |
+| `v14_qb_starter` | 3.558 | -0.397 | 0.446 | 4.622 | 84 |
+| `v17_rookie_growth` | 3.558 | -0.397 | 0.446 | 4.622 | 84 |
+| `v19_usage_level_full` | 3.558 | -0.397 | 0.446 | 4.622 | 84 |
+| `v25_draft_capital_residual` | 3.566 | -1.377 | 0.452 | 4.594 | 84 |
+| `v29_reliability_residual` | 3.592 | -1.513 | 0.441 | 4.639 | 84 |
+| `v23_draft_capital` | 3.623 | -1.195 | 0.433 | 4.674 | 84 |
+| `v16_snap_trend_full` | 3.637 | -0.420 | 0.433 | 4.676 | 84 |
+| `v21_tiered_regression` | 3.670 | -0.023 | 0.412 | 4.759 | 84 |
+| `v7_regression_to_mean` | 3.703 | +0.480 | 0.388 | 4.857 | 84 |
+| `v12_no_qb_trajectory` | 3.706 | -0.726 | 0.354 | 4.991 | 84 |
+| `v8_age_regression` | 3.715 | -0.849 | 0.347 | 5.018 | 84 |
+| `v9_pos_specific` | 3.715 | -0.849 | 0.347 | 5.018 | 84 |
+| `v13_qb_starter` | 3.721 | -0.845 | 0.343 | 5.035 | 84 |
+| `v10_stat_efficiency_v2` | 3.724 | -0.853 | 0.349 | 5.012 | 84 |
+| `v11_team_context_v2` | 3.739 | -0.917 | 0.332 | 5.075 | 84 |
+| `v4_availability_adjusted` | 3.810 | +0.352 | 0.347 | 5.018 | 84 |
+| `external_fantasypros_v1` | 3.835 | +2.254 | 0.301 | 5.189 | 84 |
+| `v3_stat_weighted` | 3.848 | -1.038 | 0.309 | 5.164 | 84 |
+| `v2_age_adjusted` | 3.851 | -1.038 | 0.307 | 5.168 | 84 |
+| `v18_usage_level` | 3.851 | -1.038 | 0.307 | 5.168 | 84 |
+| `v5_team_context` | 3.862 | +0.292 | 0.333 | 5.070 | 84 |
+| `v6_usage_share` | 3.862 | +0.292 | 0.333 | 5.070 | 84 |
+| `v15_snap_trend` | 3.928 | -1.060 | 0.291 | 5.229 | 84 |
+| `v1_baseline_weighted_ppg` | 3.949 | -1.288 | 0.287 | 5.243 | 84 |
+| `naive_prior_season_ppg` | 4.478 | -0.552 | 0.102 | 5.886 | 84 |
+| `position_mean_baseline` | 5.022 | +0.132 | -0.000 | 6.208 | 84 |
+
+### RB
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v11_team_context_v2` | 2.615 | +0.725 | 0.531 | 3.368 | 97 |
+| `v10_stat_efficiency_v2` | 2.637 | +0.790 | 0.535 | 3.365 | 97 |
+| `v19_usage_level_full` | 2.656 | +0.438 | 0.540 | 3.349 | 97 |
+| `v8_age_regression` | 2.664 | +0.770 | 0.527 | 3.392 | 97 |
+| `v9_pos_specific` | 2.664 | +0.770 | 0.527 | 3.392 | 97 |
+| `v12_no_qb_trajectory` | 2.664 | +0.770 | 0.527 | 3.392 | 97 |
+| `v13_qb_starter` | 2.664 | +0.770 | 0.527 | 3.392 | 97 |
+| `v14_qb_starter` | 2.664 | +0.770 | 0.527 | 3.392 | 97 |
+| `v3_stat_weighted` | 2.683 | +0.483 | 0.531 | 3.378 | 97 |
+| `v2_age_adjusted` | 2.685 | +0.429 | 0.526 | 3.387 | 97 |
+| `v17_rookie_growth` | 2.727 | +0.659 | 0.519 | 3.429 | 97 |
+| `v18_usage_level` | 2.732 | +0.098 | 0.517 | 3.430 | 97 |
+| `v7_regression_to_mean` | 2.746 | +0.786 | 0.492 | 3.494 | 97 |
+| `v16_snap_trend_full` | 2.753 | +0.579 | 0.494 | 3.493 | 97 |
+| `external_fantasypros_v1` | 2.760 | +1.107 | 0.530 | 3.382 | 97 |
+| `v6_usage_share` | 2.762 | +0.445 | 0.486 | 3.510 | 97 |
+| `v1_baseline_weighted_ppg` | 2.774 | +0.086 | 0.473 | 3.601 | 97 |
+| `v5_team_context` | 2.780 | +0.777 | 0.476 | 3.535 | 97 |
+| `v15_snap_trend` | 2.788 | +0.238 | 0.484 | 3.521 | 97 |
+| `v21_tiered_regression` | 2.797 | +0.862 | 0.474 | 3.559 | 97 |
+| `v26_vegas_residual` | 2.816 | -0.316 | 0.525 | 3.479 | 97 |
+| `v4_availability_adjusted` | 2.839 | +0.807 | 0.473 | 3.553 | 97 |
+| `v20_learned_usage` | 2.848 | -0.133 | 0.507 | 3.537 | 97 |
+| `v29_reliability_residual` | 2.873 | -0.485 | 0.523 | 3.496 | 97 |
+| `v25_draft_capital_residual` | 2.874 | -0.289 | 0.518 | 3.509 | 97 |
+| `v28_reliability_weighting` | 2.881 | -0.330 | 0.517 | 3.519 | 97 |
+| `v22_advanced_receiving` | 2.903 | -0.058 | 0.501 | 3.565 | 97 |
+| `v30_reliability_full_refit` | 2.907 | -0.543 | 0.496 | 3.602 | 97 |
+| `v27_vegas_full_refit` | 2.909 | -0.543 | 0.496 | 3.603 | 97 |
+| `v31_depth_chart` | 2.915 | -0.609 | 0.477 | 3.649 | 97 |
+| `v23_draft_capital` | 2.963 | -0.481 | 0.483 | 3.651 | 97 |
+| `naive_prior_season_ppg` | 2.999 | -0.058 | 0.326 | 4.080 | 97 |
+| `position_mean_baseline` | 4.790 | +2.922 | -0.329 | 5.967 | 97 |
+
+### WR
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 2.217 | +0.448 | 0.549 | 2.791 | 127 |
+| `v16_snap_trend_full` | 2.315 | +0.114 | 0.495 | 2.934 | 127 |
+| `v8_age_regression` | 2.345 | +0.160 | 0.498 | 2.923 | 127 |
+| `v9_pos_specific` | 2.345 | +0.160 | 0.498 | 2.923 | 127 |
+| `v12_no_qb_trajectory` | 2.345 | +0.160 | 0.498 | 2.923 | 127 |
+| `v13_qb_starter` | 2.345 | +0.160 | 0.498 | 2.923 | 127 |
+| `v14_qb_starter` | 2.345 | +0.160 | 0.498 | 2.923 | 127 |
+| `v10_stat_efficiency_v2` | 2.350 | +0.159 | 0.497 | 2.922 | 127 |
+| `v19_usage_level_full` | 2.359 | -0.160 | 0.498 | 2.927 | 127 |
+| `v11_team_context_v2` | 2.359 | +0.138 | 0.489 | 2.952 | 127 |
+| `v21_tiered_regression` | 2.362 | -0.048 | 0.477 | 2.993 | 127 |
+| `v17_rookie_growth` | 2.387 | +0.109 | 0.489 | 2.949 | 127 |
+| `v15_snap_trend` | 2.409 | -0.263 | 0.452 | 3.068 | 127 |
+| `v7_regression_to_mean` | 2.416 | -0.001 | 0.468 | 3.007 | 127 |
+| `v2_age_adjusted` | 2.427 | -0.216 | 0.456 | 3.053 | 127 |
+| `v3_stat_weighted` | 2.428 | -0.204 | 0.456 | 3.052 | 127 |
+| `v4_availability_adjusted` | 2.446 | -0.031 | 0.435 | 3.101 | 127 |
+| `v5_team_context` | 2.453 | -0.057 | 0.428 | 3.122 | 127 |
+| `v20_learned_usage` | 2.462 | -0.316 | 0.483 | 2.978 | 127 |
+| `v6_usage_share` | 2.503 | -0.377 | 0.405 | 3.187 | 127 |
+| `v18_usage_level` | 2.514 | -0.536 | 0.428 | 3.137 | 127 |
+| `v30_reliability_full_refit` | 2.532 | -1.042 | 0.464 | 3.044 | 127 |
+| `v27_vegas_full_refit` | 2.536 | -1.048 | 0.463 | 3.048 | 127 |
+| `v22_advanced_receiving` | 2.543 | -0.831 | 0.451 | 3.074 | 127 |
+| `v26_vegas_residual` | 2.547 | -1.230 | 0.454 | 3.076 | 127 |
+| `v25_draft_capital_residual` | 2.559 | -1.134 | 0.456 | 3.067 | 127 |
+| `v28_reliability_weighting` | 2.567 | -0.950 | 0.441 | 3.100 | 127 |
+| `v31_depth_chart` | 2.578 | -1.106 | 0.424 | 3.189 | 127 |
+| `v23_draft_capital` | 2.584 | -1.032 | 0.444 | 3.100 | 127 |
+| `v29_reliability_residual` | 2.602 | -1.193 | 0.437 | 3.114 | 127 |
+| `v1_baseline_weighted_ppg` | 2.615 | -0.355 | 0.400 | 3.211 | 127 |
+| `naive_prior_season_ppg` | 2.647 | -0.357 | 0.346 | 3.329 | 127 |
+| `position_mean_baseline` | 4.085 | +2.780 | -0.455 | 5.009 | 127 |
+
+### TE
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 1.569 | +0.661 | 0.598 | 2.040 | 108 |
+| `v21_tiered_regression` | 1.681 | +0.195 | 0.558 | 2.162 | 108 |
+| `v10_stat_efficiency_v2` | 1.683 | +0.041 | 0.580 | 2.117 | 108 |
+| `v8_age_regression` | 1.688 | +0.048 | 0.577 | 2.125 | 108 |
+| `v9_pos_specific` | 1.688 | +0.048 | 0.577 | 2.125 | 108 |
+| `v12_no_qb_trajectory` | 1.688 | +0.048 | 0.577 | 2.125 | 108 |
+| `v13_qb_starter` | 1.688 | +0.048 | 0.577 | 2.125 | 108 |
+| `v14_qb_starter` | 1.688 | +0.048 | 0.577 | 2.125 | 108 |
+| `v17_rookie_growth` | 1.689 | +0.047 | 0.577 | 2.125 | 108 |
+| `v11_team_context_v2` | 1.694 | +0.028 | 0.573 | 2.134 | 108 |
+| `v16_snap_trend_full` | 1.697 | +0.050 | 0.575 | 2.129 | 108 |
+| `v3_stat_weighted` | 1.700 | -0.091 | 0.565 | 2.141 | 108 |
+| `v2_age_adjusted` | 1.703 | -0.082 | 0.564 | 2.145 | 108 |
+| `v19_usage_level_full` | 1.705 | -0.049 | 0.571 | 2.134 | 108 |
+| `v7_regression_to_mean` | 1.713 | +0.094 | 0.554 | 2.175 | 108 |
+| `v15_snap_trend` | 1.718 | -0.080 | 0.565 | 2.141 | 108 |
+| `v5_team_context` | 1.719 | +0.061 | 0.544 | 2.194 | 108 |
+| `v4_availability_adjusted` | 1.733 | +0.085 | 0.546 | 2.191 | 108 |
+| `v18_usage_level` | 1.738 | -0.178 | 0.542 | 2.190 | 108 |
+| `v1_baseline_weighted_ppg` | 1.761 | -0.310 | 0.539 | 2.213 | 108 |
+| `v6_usage_share` | 1.763 | -0.036 | 0.521 | 2.239 | 108 |
+| `naive_prior_season_ppg` | 1.843 | -0.181 | 0.512 | 2.269 | 108 |
+| `v25_draft_capital_residual` | 1.892 | -0.637 | 0.523 | 2.273 | 108 |
+| `v31_depth_chart` | 1.895 | -0.601 | 0.509 | 2.262 | 108 |
+| `v26_vegas_residual` | 1.914 | -0.666 | 0.518 | 2.278 | 108 |
+| `v22_advanced_receiving` | 1.918 | -0.651 | 0.507 | 2.306 | 108 |
+| `v28_reliability_weighting` | 1.935 | -0.641 | 0.511 | 2.300 | 108 |
+| `v29_reliability_residual` | 1.940 | -0.698 | 0.509 | 2.301 | 108 |
+| `v27_vegas_full_refit` | 1.951 | -0.674 | 0.505 | 2.310 | 108 |
+| `v30_reliability_full_refit` | 1.955 | -0.675 | 0.505 | 2.312 | 108 |
+| `v23_draft_capital` | 1.958 | -0.680 | 0.500 | 2.332 | 108 |
+| `v20_learned_usage` | 2.033 | -0.992 | 0.463 | 2.411 | 108 |
+| `position_mean_baseline` | 2.704 | +0.770 | -0.057 | 3.412 | 108 |
+
+### K
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+
+## Season 2024 — ALL (held-out)
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v19_usage_level_full` | 2.594 | +0.282 | 0.621 | 3.311 | 185 |
+| `v12_no_qb_trajectory` | 2.598 | +0.453 | 0.612 | 3.352 | 185 |
+| `v14_qb_starter` | 2.599 | +0.507 | 0.616 | 3.334 | 185 |
+| `v13_qb_starter` | 2.601 | +0.445 | 0.610 | 3.361 | 185 |
+| `v17_rookie_growth` | 2.603 | +0.480 | 0.615 | 3.339 | 185 |
+| `v11_team_context_v2` | 2.604 | +0.425 | 0.606 | 3.379 | 185 |
+| `v31_depth_chart` | 2.608 | -0.808 | 0.616 | 3.333 | 185 |
+| `v8_age_regression` | 2.614 | +0.458 | 0.609 | 3.366 | 185 |
+| `v9_pos_specific` | 2.614 | +0.458 | 0.609 | 3.366 | 185 |
+| `v10_stat_efficiency_v2` | 2.616 | +0.453 | 0.611 | 3.357 | 185 |
+| `v22_advanced_receiving` | 2.643 | -0.407 | 0.608 | 3.370 | 185 |
+| `v16_snap_trend_full` | 2.647 | +0.444 | 0.595 | 3.422 | 185 |
+| `v20_learned_usage` | 2.648 | -0.350 | 0.607 | 3.372 | 185 |
+| `v26_vegas_residual` | 2.650 | -0.667 | 0.606 | 3.376 | 185 |
+| `v25_draft_capital_residual` | 2.654 | -0.621 | 0.603 | 3.390 | 185 |
+| `v3_stat_weighted` | 2.660 | +0.282 | 0.601 | 3.398 | 185 |
+| `v28_reliability_weighting` | 2.661 | -0.635 | 0.602 | 3.393 | 185 |
+| `v2_age_adjusted` | 2.663 | +0.272 | 0.599 | 3.405 | 185 |
+| `v27_vegas_full_refit` | 2.675 | -0.678 | 0.591 | 3.443 | 185 |
+| `external_fantasypros_v1` | 2.679 | +1.456 | 0.572 | 3.520 | 185 |
+| `v21_tiered_regression` | 2.681 | +0.711 | 0.584 | 3.471 | 185 |
+| `v30_reliability_full_refit` | 2.687 | -0.682 | 0.586 | 3.463 | 185 |
+| `v1_baseline_weighted_ppg` | 2.695 | +0.091 | 0.577 | 3.499 | 185 |
+| `v23_draft_capital` | 2.696 | -0.633 | 0.582 | 3.477 | 185 |
+| `v18_usage_level` | 2.696 | +0.047 | 0.595 | 3.425 | 185 |
+| `v29_reliability_residual` | 2.712 | -0.826 | 0.588 | 3.455 | 185 |
+| `v7_regression_to_mean` | 2.722 | +0.721 | 0.585 | 3.467 | 185 |
+| `v15_snap_trend` | 2.738 | +0.209 | 0.576 | 3.502 | 185 |
+| `v4_availability_adjusted` | 2.769 | +0.792 | 0.569 | 3.533 | 185 |
+| `v5_team_context` | 2.777 | +0.759 | 0.562 | 3.560 | 185 |
+| `v6_usage_share` | 2.784 | +0.534 | 0.563 | 3.555 | 185 |
+| `naive_prior_season_ppg` | 2.881 | +0.310 | 0.468 | 3.924 | 185 |
+| `position_mean_baseline` | 3.868 | +1.645 | 0.168 | 4.909 | 185 |
+
+## Season 2025 — ALL (held-out)
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 2.361 | +0.673 | 0.652 | 3.301 | 231 |
+| `v14_qb_starter` | 2.410 | -0.117 | 0.664 | 3.241 | 231 |
+| `v16_snap_trend_full` | 2.425 | -0.179 | 0.663 | 3.248 | 231 |
+| `v19_usage_level_full` | 2.426 | -0.297 | 0.663 | 3.246 | 231 |
+| `v10_stat_efficiency_v2` | 2.445 | -0.234 | 0.627 | 3.414 | 231 |
+| `v21_tiered_regression` | 2.447 | -0.151 | 0.648 | 3.319 | 231 |
+| `v7_regression_to_mean` | 2.449 | -0.029 | 0.640 | 3.356 | 231 |
+| `v8_age_regression` | 2.455 | -0.242 | 0.625 | 3.423 | 231 |
+| `v9_pos_specific` | 2.455 | -0.242 | 0.625 | 3.423 | 231 |
+| `v17_rookie_growth` | 2.456 | -0.170 | 0.659 | 3.267 | 231 |
+| `v11_team_context_v2` | 2.461 | -0.281 | 0.619 | 3.450 | 231 |
+| `v12_no_qb_trajectory` | 2.464 | -0.193 | 0.626 | 3.420 | 231 |
+| `v13_qb_starter` | 2.467 | -0.230 | 0.622 | 3.437 | 231 |
+| `v5_team_context` | 2.500 | -0.178 | 0.615 | 3.472 | 231 |
+| `v4_availability_adjusted` | 2.515 | -0.144 | 0.617 | 3.463 | 231 |
+| `v3_stat_weighted` | 2.525 | -0.555 | 0.600 | 3.537 | 231 |
+| `v2_age_adjusted` | 2.526 | -0.572 | 0.600 | 3.538 | 231 |
+| `v15_snap_trend` | 2.534 | -0.634 | 0.596 | 3.555 | 231 |
+| `v6_usage_share` | 2.535 | -0.359 | 0.606 | 3.511 | 231 |
+| `v18_usage_level` | 2.583 | -0.752 | 0.587 | 3.593 | 231 |
+| `v26_vegas_residual` | 2.636 | -1.096 | 0.644 | 3.337 | 231 |
+| `v20_learned_usage` | 2.647 | -0.850 | 0.646 | 3.328 | 231 |
+| `v22_advanced_receiving` | 2.656 | -0.865 | 0.642 | 3.346 | 231 |
+| `v28_reliability_weighting` | 2.664 | -0.907 | 0.644 | 3.338 | 231 |
+| `v30_reliability_full_refit` | 2.665 | -1.034 | 0.638 | 3.365 | 231 |
+| `v25_draft_capital_residual` | 2.670 | -1.046 | 0.641 | 3.351 | 231 |
+| `v27_vegas_full_refit` | 2.673 | -1.027 | 0.637 | 3.370 | 231 |
+| `v29_reliability_residual` | 2.679 | -1.075 | 0.642 | 3.347 | 231 |
+| `v31_depth_chart` | 2.695 | -0.987 | 0.619 | 3.451 | 231 |
+| `v1_baseline_weighted_ppg` | 2.703 | -0.845 | 0.565 | 3.687 | 231 |
+| `v23_draft_capital` | 2.739 | -1.015 | 0.626 | 3.418 | 231 |
+| `naive_prior_season_ppg` | 2.897 | -0.754 | 0.496 | 3.970 | 231 |
+| `position_mean_baseline` | 4.250 | +1.846 | 0.076 | 5.376 | 231 |

--- a/docs/generated/projection-holdout-eval.md
+++ b/docs/generated/projection-holdout-eval.md
@@ -1,6 +1,6 @@
 # Projection Held-Out Evaluation (GH #572)
 
-_Generated: 2026-06-08 22:04_
+_Generated: 2026-06-10 08:40_
 
 **Every model is evaluated out-of-sample on a shared held-out window.** Learned/residual models were retrained on **2021,2022,2023** and never saw the eval seasons **2024,2025**; additive and external models are parameter-free w.r.t. training seasons, so their existing projections are already held-out. All models are scored through the identical `backtest_model` filter (target-season games ≥ 4, true rookies excluded). Unlike [projection-accuracy.md](projection-accuracy.md), **no model here is scored on data it trained on** — this is the honest ranking. See [docs/exec-plans/projection-methodology-audit.md](../exec-plans/projection-methodology-audit.md) (Finding 1b).
 
@@ -29,16 +29,18 @@ _Generated: 2026-06-08 22:04_
 | 19 | `v5_team_context` | 2.566 | -0.006 | 0.554 | 3.479 | 647 |
 | 20 | `v6_usage_share` | 2.583 | -0.137 | 0.550 | 3.495 | 647 |
 | 21 | `v1_baseline_weighted_ppg` | 2.633 | -0.652 | 0.527 | 3.588 | 647 |
-| 22 | `v31_depth_chart` | 2.660 | -1.051 | 0.564 | 3.413 | 635 |
-| 23 | `v30_reliability_full_refit` | 2.679 | -1.152 | 0.563 | 3.414 | 635 |
-| 24 | `v20_learned_usage` | 2.683 | -1.060 | 0.572 | 3.377 | 635 |
-| 25 | `v22_advanced_receiving` | 2.707 | -1.095 | 0.566 | 3.401 | 635 |
-| 26 | `v26_vegas_residual` | 2.723 | -1.267 | 0.557 | 3.435 | 635 |
-| 27 | `v25_draft_capital_residual` | 2.723 | -1.242 | 0.562 | 3.416 | 635 |
-| 28 | `v27_vegas_full_refit` | 2.724 | -1.201 | 0.553 | 3.455 | 635 |
-| 29 | `v28_reliability_weighting` | 2.728 | -1.161 | 0.562 | 3.418 | 635 |
-| 30 | `v29_reliability_residual` | 2.752 | -1.296 | 0.556 | 3.440 | 635 |
-| 31 | `v23_draft_capital` | 2.764 | -1.105 | 0.545 | 3.486 | 635 |
+| 22 | `v31_depth_chart` | 2.646 | -1.066 | 0.571 | 3.385 | 635 |
+| 23 | `v20_learned_usage` | 2.685 | -1.071 | 0.573 | 3.376 | 635 |
+| 24 | `v27_vegas_full_refit` | 2.685 | -1.197 | 0.564 | 3.411 | 635 |
+| 25 | `v30_reliability_full_refit` | 2.687 | -1.201 | 0.562 | 3.415 | 635 |
+| 26 | `v28_reliability_weighting` | 2.706 | -1.178 | 0.566 | 3.400 | 635 |
+| 27 | `v22_advanced_receiving` | 2.706 | -1.172 | 0.567 | 3.398 | 635 |
+| 28 | `v26_vegas_residual` | 2.711 | -1.322 | 0.563 | 3.413 | 635 |
+| 29 | `v25_draft_capital_residual` | 2.731 | -1.298 | 0.560 | 3.423 | 635 |
+| 30 | `v29_reliability_residual` | 2.731 | -1.305 | 0.559 | 3.426 | 635 |
+| 31 | `v23_draft_capital` | 2.733 | -1.202 | 0.553 | 3.451 | 635 |
+| 32 | `naive_prior_season_ppg` | 2.754 | -0.428 | 0.458 | 3.861 | 667 |
+| 33 | `position_mean_baseline` | 3.710 | +0.458 | 0.185 | 4.745 | 667 |
 
 ## Combined across eval seasons — by position
 
@@ -67,32 +69,34 @@ _Generated: 2026-06-08 22:04_
 | `v5_team_context` | 2.566 | -0.006 | 0.554 | 3.479 | 647 |
 | `v6_usage_share` | 2.583 | -0.137 | 0.550 | 3.495 | 647 |
 | `v1_baseline_weighted_ppg` | 2.633 | -0.652 | 0.527 | 3.588 | 647 |
-| `v31_depth_chart` | 2.660 | -1.051 | 0.564 | 3.413 | 635 |
-| `v30_reliability_full_refit` | 2.679 | -1.152 | 0.563 | 3.414 | 635 |
-| `v20_learned_usage` | 2.683 | -1.060 | 0.572 | 3.377 | 635 |
-| `v22_advanced_receiving` | 2.707 | -1.095 | 0.566 | 3.401 | 635 |
-| `v26_vegas_residual` | 2.723 | -1.267 | 0.557 | 3.435 | 635 |
-| `v25_draft_capital_residual` | 2.723 | -1.242 | 0.562 | 3.416 | 635 |
-| `v27_vegas_full_refit` | 2.724 | -1.201 | 0.553 | 3.455 | 635 |
-| `v28_reliability_weighting` | 2.728 | -1.161 | 0.562 | 3.418 | 635 |
-| `v29_reliability_residual` | 2.752 | -1.296 | 0.556 | 3.440 | 635 |
-| `v23_draft_capital` | 2.764 | -1.105 | 0.545 | 3.486 | 635 |
+| `v31_depth_chart` | 2.646 | -1.066 | 0.571 | 3.385 | 635 |
+| `v20_learned_usage` | 2.685 | -1.071 | 0.573 | 3.376 | 635 |
+| `v27_vegas_full_refit` | 2.685 | -1.197 | 0.564 | 3.411 | 635 |
+| `v30_reliability_full_refit` | 2.687 | -1.201 | 0.562 | 3.415 | 635 |
+| `v28_reliability_weighting` | 2.706 | -1.178 | 0.566 | 3.400 | 635 |
+| `v22_advanced_receiving` | 2.706 | -1.172 | 0.567 | 3.398 | 635 |
+| `v26_vegas_residual` | 2.711 | -1.322 | 0.563 | 3.413 | 635 |
+| `v25_draft_capital_residual` | 2.731 | -1.298 | 0.560 | 3.423 | 635 |
+| `v29_reliability_residual` | 2.731 | -1.305 | 0.559 | 3.426 | 635 |
+| `v23_draft_capital` | 2.733 | -1.202 | 0.553 | 3.451 | 635 |
+| `naive_prior_season_ppg` | 2.754 | -0.428 | 0.458 | 3.861 | 667 |
+| `position_mean_baseline` | 3.710 | +0.458 | 0.185 | 4.745 | 667 |
 
 ### QB
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `v22_advanced_receiving` | 3.589 | -1.406 | 0.433 | 4.599 | 98 |
-| `v28_reliability_weighting` | 3.596 | -1.465 | 0.428 | 4.618 | 98 |
-| `v20_learned_usage` | 3.626 | -1.493 | 0.425 | 4.629 | 98 |
-| `v31_depth_chart` | 3.631 | -1.590 | 0.426 | 4.628 | 98 |
-| `v26_vegas_residual` | 3.657 | -1.645 | 0.407 | 4.703 | 98 |
-| `v27_vegas_full_refit` | 3.672 | -1.461 | 0.390 | 4.773 | 98 |
-| `v30_reliability_full_refit` | 3.681 | -1.510 | 0.388 | 4.779 | 98 |
-| `v25_draft_capital_residual` | 3.681 | -1.635 | 0.406 | 4.708 | 98 |
-| `v29_reliability_residual` | 3.686 | -1.694 | 0.401 | 4.728 | 98 |
+| `v22_advanced_receiving` | 3.604 | -1.508 | 0.428 | 4.620 | 98 |
+| `v28_reliability_weighting` | 3.613 | -1.549 | 0.423 | 4.638 | 98 |
+| `v20_learned_usage` | 3.617 | -1.453 | 0.427 | 4.623 | 98 |
+| `v31_depth_chart` | 3.624 | -1.582 | 0.429 | 4.613 | 98 |
+| `v26_vegas_residual` | 3.653 | -1.748 | 0.407 | 4.706 | 98 |
+| `v27_vegas_full_refit` | 3.667 | -1.544 | 0.392 | 4.764 | 98 |
+| `v30_reliability_full_refit` | 3.673 | -1.577 | 0.387 | 4.783 | 98 |
 | `external_fantasypros_v1` | 3.690 | +2.129 | 0.410 | 5.072 | 88 |
-| `v23_draft_capital` | 3.744 | -1.077 | 0.388 | 4.777 | 98 |
+| `v25_draft_capital_residual` | 3.691 | -1.727 | 0.401 | 4.729 | 98 |
+| `v29_reliability_residual` | 3.702 | -1.776 | 0.395 | 4.752 | 98 |
+| `v23_draft_capital` | 3.735 | -1.521 | 0.386 | 4.786 | 98 |
 | `v14_qb_starter` | 3.783 | -0.742 | 0.441 | 4.826 | 102 |
 | `v17_rookie_growth` | 3.783 | -0.742 | 0.441 | 4.826 | 102 |
 | `v19_usage_level_full` | 3.783 | -0.742 | 0.441 | 4.826 | 102 |
@@ -113,6 +117,8 @@ _Generated: 2026-06-08 22:04_
 | `v6_usage_share` | 4.134 | +0.044 | 0.318 | 5.329 | 102 |
 | `v15_snap_trend` | 4.158 | -1.400 | 0.279 | 5.481 | 102 |
 | `v1_baseline_weighted_ppg` | 4.218 | -1.808 | 0.261 | 5.548 | 102 |
+| `naive_prior_season_ppg` | 4.851 | -0.904 | 0.048 | 6.300 | 102 |
+| `position_mean_baseline` | 5.184 | -0.755 | -0.014 | 6.506 | 102 |
 
 ### RB
 
@@ -135,20 +141,22 @@ _Generated: 2026-06-08 22:04_
 | `v4_availability_adjusted` | 2.758 | +0.176 | 0.550 | 3.574 | 137 |
 | `v18_usage_level` | 2.762 | -0.413 | 0.553 | 3.569 | 137 |
 | `v16_snap_trend_full` | 2.769 | -0.068 | 0.560 | 3.543 | 137 |
+| `naive_prior_season_ppg` | 2.777 | -0.454 | 0.496 | 3.857 | 144 |
 | `v15_snap_trend` | 2.778 | -0.281 | 0.546 | 3.596 | 137 |
 | `v21_tiered_regression` | 2.782 | +0.220 | 0.534 | 3.647 | 137 |
 | `v17_rookie_growth` | 2.785 | -0.067 | 0.559 | 3.547 | 137 |
 | `v1_baseline_weighted_ppg` | 2.806 | -0.518 | 0.517 | 3.716 | 137 |
-| `v31_depth_chart` | 3.006 | -0.854 | 0.512 | 3.742 | 135 |
-| `v20_learned_usage` | 3.101 | -1.005 | 0.494 | 3.802 | 135 |
-| `v26_vegas_residual` | 3.127 | -1.172 | 0.496 | 3.798 | 135 |
-| `v25_draft_capital_residual` | 3.146 | -1.174 | 0.494 | 3.807 | 135 |
-| `v22_advanced_receiving` | 3.162 | -0.998 | 0.486 | 3.835 | 135 |
-| `v28_reliability_weighting` | 3.167 | -1.109 | 0.483 | 3.851 | 135 |
-| `v29_reliability_residual` | 3.170 | -1.246 | 0.485 | 3.843 | 135 |
-| `v30_reliability_full_refit` | 3.200 | -1.227 | 0.474 | 3.887 | 135 |
-| `v27_vegas_full_refit` | 3.201 | -1.257 | 0.469 | 3.909 | 135 |
-| `v23_draft_capital` | 3.234 | -1.135 | 0.457 | 3.953 | 135 |
+| `v31_depth_chart` | 2.963 | -0.978 | 0.536 | 3.656 | 135 |
+| `v20_learned_usage` | 3.090 | -0.962 | 0.499 | 3.783 | 135 |
+| `v26_vegas_residual` | 3.119 | -1.322 | 0.500 | 3.779 | 135 |
+| `v22_advanced_receiving` | 3.150 | -1.166 | 0.496 | 3.797 | 135 |
+| `v25_draft_capital_residual` | 3.153 | -1.290 | 0.498 | 3.793 | 135 |
+| `v28_reliability_weighting` | 3.154 | -1.172 | 0.495 | 3.802 | 135 |
+| `v29_reliability_residual` | 3.157 | -1.292 | 0.496 | 3.797 | 135 |
+| `v27_vegas_full_refit` | 3.186 | -1.345 | 0.480 | 3.860 | 135 |
+| `v30_reliability_full_refit` | 3.191 | -1.350 | 0.479 | 3.867 | 135 |
+| `v23_draft_capital` | 3.215 | -1.294 | 0.473 | 3.888 | 135 |
+| `position_mean_baseline` | 4.557 | +0.934 | -0.031 | 5.566 | 144 |
 
 ### WR
 
@@ -174,17 +182,19 @@ _Generated: 2026-06-08 22:04_
 | `v5_team_context` | 2.459 | -0.293 | 0.447 | 3.181 | 200 |
 | `v18_usage_level` | 2.488 | -0.596 | 0.450 | 3.180 | 200 |
 | `v6_usage_share` | 2.488 | -0.498 | 0.434 | 3.222 | 200 |
+| `naive_prior_season_ppg` | 2.587 | -0.551 | 0.406 | 3.375 | 207 |
 | `v1_baseline_weighted_ppg` | 2.614 | -0.624 | 0.408 | 3.301 | 200 |
-| `v30_reliability_full_refit` | 2.636 | -1.409 | 0.434 | 3.212 | 196 |
-| `v20_learned_usage` | 2.637 | -0.923 | 0.443 | 3.186 | 196 |
-| `v22_advanced_receiving` | 2.750 | -1.289 | 0.399 | 3.309 | 196 |
-| `v27_vegas_full_refit` | 2.757 | -1.534 | 0.397 | 3.320 | 196 |
-| `v23_draft_capital` | 2.783 | -1.395 | 0.392 | 3.338 | 196 |
-| `v25_draft_capital_residual` | 2.785 | -1.583 | 0.397 | 3.314 | 196 |
-| `v28_reliability_weighting` | 2.787 | -1.413 | 0.390 | 3.332 | 196 |
-| `v26_vegas_residual` | 2.806 | -1.665 | 0.371 | 3.388 | 196 |
-| `v29_reliability_residual` | 2.812 | -1.595 | 0.390 | 3.334 | 196 |
-| `v31_depth_chart` | 2.836 | -1.528 | 0.340 | 3.490 | 196 |
+| `v20_learned_usage` | 2.650 | -0.997 | 0.439 | 3.196 | 196 |
+| `v30_reliability_full_refit` | 2.689 | -1.484 | 0.420 | 3.252 | 196 |
+| `v27_vegas_full_refit` | 2.692 | -1.488 | 0.419 | 3.256 | 196 |
+| `v28_reliability_weighting` | 2.771 | -1.450 | 0.386 | 3.340 | 196 |
+| `v23_draft_capital` | 2.772 | -1.507 | 0.391 | 3.331 | 196 |
+| `v22_advanced_receiving` | 2.776 | -1.454 | 0.384 | 3.345 | 196 |
+| `v26_vegas_residual` | 2.778 | -1.677 | 0.383 | 3.351 | 196 |
+| `v29_reliability_residual` | 2.800 | -1.627 | 0.382 | 3.349 | 196 |
+| `v25_draft_capital_residual` | 2.804 | -1.630 | 0.380 | 3.355 | 196 |
+| `v31_depth_chart` | 2.815 | -1.514 | 0.346 | 3.478 | 196 |
+| `position_mean_baseline` | 3.770 | +0.975 | -0.066 | 4.549 | 207 |
 
 ### TE
 
@@ -211,30 +221,33 @@ _Generated: 2026-06-08 22:04_
 | `v5_team_context` | 1.793 | +0.104 | 0.525 | 2.312 | 144 |
 | `v4_availability_adjusted` | 1.800 | +0.117 | 0.526 | 2.309 | 144 |
 | `v6_usage_share` | 1.828 | +0.025 | 0.509 | 2.346 | 144 |
-| `v31_depth_chart` | 1.941 | -0.689 | 0.510 | 2.327 | 142 |
-| `v25_draft_capital_residual` | 1.986 | -0.811 | 0.496 | 2.385 | 142 |
-| `v26_vegas_residual` | 1.989 | -0.806 | 0.496 | 2.382 | 142 |
-| `v22_advanced_receiving` | 2.018 | -0.807 | 0.483 | 2.414 | 142 |
-| `v30_reliability_full_refit` | 2.019 | -0.771 | 0.488 | 2.400 | 142 |
-| `v27_vegas_full_refit` | 2.054 | -0.816 | 0.476 | 2.431 | 142 |
-| `v28_reliability_weighting` | 2.055 | -0.791 | 0.476 | 2.433 | 142 |
-| `v29_reliability_residual` | 2.062 | -0.846 | 0.475 | 2.434 | 142 |
-| `v20_learned_usage` | 2.099 | -1.108 | 0.444 | 2.504 | 142 |
-| `v23_draft_capital` | 2.117 | -0.982 | 0.436 | 2.527 | 142 |
+| `naive_prior_season_ppg` | 1.864 | -0.197 | 0.479 | 2.435 | 150 |
+| `v31_depth_chart` | 1.953 | -0.658 | 0.512 | 2.322 | 142 |
+| `v27_vegas_full_refit` | 1.998 | -0.746 | 0.501 | 2.367 | 142 |
+| `v30_reliability_full_refit` | 2.000 | -0.748 | 0.501 | 2.367 | 142 |
+| `v28_reliability_weighting` | 2.003 | -0.736 | 0.499 | 2.372 | 142 |
+| `v22_advanced_receiving` | 2.003 | -0.736 | 0.498 | 2.375 | 142 |
+| `v29_reliability_residual` | 2.007 | -0.782 | 0.498 | 2.373 | 142 |
+| `v25_draft_capital_residual` | 2.007 | -0.783 | 0.497 | 2.376 | 142 |
+| `v26_vegas_residual` | 2.013 | -0.780 | 0.498 | 2.370 | 142 |
+| `v23_draft_capital` | 2.020 | -0.793 | 0.488 | 2.401 | 142 |
+| `v20_learned_usage` | 2.108 | -1.130 | 0.441 | 2.513 | 142 |
+| `position_mean_baseline` | 2.769 | +0.223 | -0.005 | 3.381 | 150 |
 
 ### K
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `v31_depth_chart` | 1.501 | +0.018 | -0.128 | 1.978 | 64 |
+| `position_mean_baseline` | 1.471 | +0.195 | -0.072 | 1.934 | 64 |
+| `v31_depth_chart` | 1.502 | +0.002 | -0.127 | 1.978 | 64 |
 | `v12_no_qb_trajectory` | 1.589 | +0.090 | -0.278 | 2.115 | 64 |
 | `v14_qb_starter` | 1.589 | +0.090 | -0.278 | 2.115 | 64 |
 | `v17_rookie_growth` | 1.589 | +0.090 | -0.278 | 2.115 | 64 |
 | `v19_usage_level_full` | 1.589 | +0.090 | -0.278 | 2.115 | 64 |
 | `v16_snap_trend_full` | 1.598 | +0.101 | -0.280 | 2.117 | 64 |
-| `v23_draft_capital` | 1.644 | -0.467 | -0.255 | 2.097 | 64 |
-| `v30_reliability_full_refit` | 1.647 | -0.506 | -0.251 | 2.097 | 64 |
-| `v27_vegas_full_refit` | 1.653 | -0.516 | -0.259 | 2.102 | 64 |
+| `v30_reliability_full_refit` | 1.625 | -0.454 | -0.230 | 2.079 | 64 |
+| `v27_vegas_full_refit` | 1.631 | -0.464 | -0.236 | 2.083 | 64 |
+| `v23_draft_capital` | 1.645 | -0.486 | -0.254 | 2.098 | 64 |
 | `v21_tiered_regression` | 1.658 | +0.230 | -0.432 | 2.235 | 64 |
 | `v8_age_regression` | 1.662 | +0.020 | -0.403 | 2.233 | 64 |
 | `v9_pos_specific` | 1.662 | +0.020 | -0.403 | 2.233 | 64 |
@@ -245,53 +258,56 @@ _Generated: 2026-06-08 22:04_
 | `v2_age_adjusted` | 1.731 | +0.006 | -0.523 | 2.329 | 64 |
 | `v3_stat_weighted` | 1.731 | +0.006 | -0.523 | 2.329 | 64 |
 | `v18_usage_level` | 1.731 | +0.006 | -0.523 | 2.329 | 64 |
+| `v28_reliability_weighting` | 1.736 | -0.768 | -0.308 | 2.155 | 64 |
 | `v15_snap_trend` | 1.742 | +0.017 | -0.525 | 2.331 | 64 |
+| `v29_reliability_residual` | 1.743 | -0.781 | -0.310 | 2.157 | 64 |
+| `v22_advanced_receiving` | 1.744 | -0.775 | -0.316 | 2.160 | 64 |
+| `v25_draft_capital_residual` | 1.751 | -0.789 | -0.318 | 2.162 | 64 |
+| `v26_vegas_residual` | 1.751 | -0.789 | -0.318 | 2.162 | 64 |
 | `v7_regression_to_mean` | 1.753 | +0.243 | -0.722 | 2.419 | 64 |
-| `v28_reliability_weighting` | 1.781 | -0.858 | -0.356 | 2.195 | 64 |
-| `v29_reliability_residual` | 1.788 | -0.873 | -0.359 | 2.198 | 64 |
-| `v20_learned_usage` | 1.789 | -0.824 | -0.377 | 2.208 | 64 |
-| `v22_advanced_receiving` | 1.794 | -0.868 | -0.373 | 2.206 | 64 |
-| `v25_draft_capital_residual` | 1.810 | -0.693 | -0.435 | 2.243 | 64 |
-| `v26_vegas_residual` | 1.810 | -0.693 | -0.435 | 2.243 | 64 |
+| `v20_learned_usage` | 1.785 | -0.815 | -0.373 | 2.205 | 64 |
 | `v4_availability_adjusted` | 1.826 | +0.229 | -0.845 | 2.509 | 64 |
 | `v5_team_context` | 1.826 | +0.229 | -0.845 | 2.509 | 64 |
 | `v6_usage_share` | 1.826 | +0.229 | -0.845 | 2.509 | 64 |
+| `naive_prior_season_ppg` | 1.980 | +0.247 | -1.367 | 2.804 | 64 |
 
 ## Season 2024 — ALL (held-out)
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
+| `v31_depth_chart` | 2.636 | -0.928 | 0.566 | 3.345 | 271 |
 | `v19_usage_level_full` | 2.660 | +0.011 | 0.552 | 3.440 | 274 |
 | `v14_qb_starter` | 2.660 | +0.168 | 0.549 | 3.449 | 274 |
 | `v12_no_qb_trajectory` | 2.663 | +0.106 | 0.537 | 3.495 | 274 |
 | `v16_snap_trend_full` | 2.669 | +0.152 | 0.543 | 3.471 | 274 |
 | `external_fantasypros_v1` | 2.671 | +1.449 | 0.579 | 3.509 | 187 |
-| `v31_depth_chart` | 2.675 | -0.939 | 0.547 | 3.420 | 271 |
 | `v13_qb_starter` | 2.675 | +0.082 | 0.525 | 3.540 | 274 |
 | `v11_team_context_v2` | 2.676 | +0.063 | 0.523 | 3.546 | 274 |
 | `v17_rookie_growth` | 2.676 | +0.135 | 0.544 | 3.468 | 274 |
 | `v8_age_regression` | 2.682 | +0.089 | 0.524 | 3.544 | 274 |
 | `v9_pos_specific` | 2.682 | +0.089 | 0.524 | 3.544 | 274 |
 | `v10_stat_efficiency_v2` | 2.690 | +0.090 | 0.524 | 3.542 | 274 |
-| `v20_learned_usage` | 2.712 | -0.796 | 0.531 | 3.477 | 271 |
-| `v22_advanced_receiving` | 2.724 | -0.840 | 0.525 | 3.500 | 271 |
-| `v23_draft_capital` | 2.725 | -0.697 | 0.516 | 3.533 | 271 |
+| `v20_learned_usage` | 2.707 | -0.781 | 0.533 | 3.470 | 271 |
 | `v2_age_adjusted` | 2.731 | -0.043 | 0.505 | 3.612 | 274 |
 | `v3_stat_weighted` | 2.732 | -0.026 | 0.507 | 3.606 | 274 |
-| `v27_vegas_full_refit` | 2.732 | -0.914 | 0.516 | 3.532 | 271 |
 | `v21_tiered_regression` | 2.739 | +0.406 | 0.510 | 3.597 | 274 |
-| `v28_reliability_weighting` | 2.740 | -0.909 | 0.523 | 3.507 | 271 |
-| `v30_reliability_full_refit` | 2.740 | -0.915 | 0.513 | 3.544 | 271 |
-| `v25_draft_capital_residual` | 2.748 | -1.008 | 0.518 | 3.526 | 271 |
+| `v27_vegas_full_refit` | 2.745 | -0.993 | 0.513 | 3.544 | 271 |
+| `v30_reliability_full_refit` | 2.754 | -0.994 | 0.510 | 3.556 | 271 |
 | `v1_baseline_weighted_ppg` | 2.755 | -0.289 | 0.482 | 3.698 | 274 |
+| `v22_advanced_receiving` | 2.756 | -1.010 | 0.516 | 3.534 | 271 |
 | `v18_usage_level` | 2.757 | -0.199 | 0.500 | 3.631 | 274 |
-| `v26_vegas_residual` | 2.759 | -1.045 | 0.513 | 3.545 | 271 |
 | `v15_snap_trend` | 2.764 | -0.059 | 0.497 | 3.642 | 274 |
-| `v29_reliability_residual` | 2.779 | -1.054 | 0.512 | 3.547 | 271 |
+| `v28_reliability_weighting` | 2.765 | -1.016 | 0.513 | 3.545 | 271 |
+| `v23_draft_capital` | 2.767 | -0.976 | 0.505 | 3.573 | 271 |
+| `v26_vegas_residual` | 2.790 | -1.177 | 0.506 | 3.571 | 271 |
+| `v25_draft_capital_residual` | 2.794 | -1.146 | 0.504 | 3.578 | 271 |
 | `v7_regression_to_mean` | 2.796 | +0.362 | 0.497 | 3.643 | 274 |
+| `v29_reliability_residual` | 2.803 | -1.153 | 0.500 | 3.591 | 271 |
 | `v4_availability_adjusted` | 2.838 | +0.413 | 0.475 | 3.722 | 274 |
 | `v5_team_context` | 2.843 | +0.387 | 0.471 | 3.735 | 274 |
 | `v6_usage_share` | 2.850 | +0.231 | 0.471 | 3.737 | 274 |
+| `naive_prior_season_ppg` | 2.963 | +0.039 | 0.369 | 4.112 | 278 |
+| `position_mean_baseline` | 3.650 | +0.702 | 0.174 | 4.704 | 278 |
 
 ## Season 2025 — ALL (held-out)
 
@@ -318,13 +334,15 @@ _Generated: 2026-06-08 22:04_
 | `v15_snap_trend` | 2.409 | -0.691 | 0.593 | 3.370 | 373 |
 | `v18_usage_level` | 2.421 | -0.756 | 0.593 | 3.372 | 373 |
 | `v1_baseline_weighted_ppg` | 2.543 | -0.919 | 0.560 | 3.505 | 373 |
-| `v30_reliability_full_refit` | 2.635 | -1.329 | 0.600 | 3.313 | 364 |
-| `v31_depth_chart` | 2.649 | -1.135 | 0.577 | 3.408 | 364 |
-| `v20_learned_usage` | 2.661 | -1.256 | 0.603 | 3.301 | 364 |
-| `v22_advanced_receiving` | 2.694 | -1.285 | 0.597 | 3.325 | 364 |
-| `v26_vegas_residual` | 2.696 | -1.432 | 0.591 | 3.351 | 364 |
-| `v25_draft_capital_residual` | 2.705 | -1.415 | 0.595 | 3.333 | 364 |
-| `v27_vegas_full_refit` | 2.718 | -1.414 | 0.580 | 3.396 | 364 |
-| `v28_reliability_weighting` | 2.719 | -1.349 | 0.591 | 3.350 | 364 |
-| `v29_reliability_residual` | 2.732 | -1.476 | 0.589 | 3.358 | 364 |
-| `v23_draft_capital` | 2.793 | -1.408 | 0.566 | 3.451 | 364 |
+| `naive_prior_season_ppg` | 2.603 | -0.761 | 0.522 | 3.671 | 389 |
+| `v30_reliability_full_refit` | 2.636 | -1.356 | 0.602 | 3.305 | 364 |
+| `v27_vegas_full_refit` | 2.641 | -1.349 | 0.601 | 3.308 | 364 |
+| `v26_vegas_residual` | 2.652 | -1.431 | 0.605 | 3.290 | 364 |
+| `v31_depth_chart` | 2.654 | -1.170 | 0.575 | 3.415 | 364 |
+| `v28_reliability_weighting` | 2.663 | -1.298 | 0.606 | 3.288 | 364 |
+| `v20_learned_usage` | 2.668 | -1.287 | 0.602 | 3.304 | 364 |
+| `v22_advanced_receiving` | 2.670 | -1.293 | 0.605 | 3.293 | 364 |
+| `v29_reliability_residual` | 2.678 | -1.418 | 0.603 | 3.299 | 364 |
+| `v25_draft_capital_residual` | 2.684 | -1.412 | 0.602 | 3.303 | 364 |
+| `v23_draft_capital` | 2.708 | -1.370 | 0.589 | 3.357 | 364 |
+| `position_mean_baseline` | 3.753 | +0.283 | 0.192 | 4.774 | 389 |

--- a/scripts/feature_projections/features/__init__.py
+++ b/scripts/feature_projections/features/__init__.py
@@ -41,6 +41,8 @@ from scripts.feature_projections.features.depth_chart import (
     DepthChartPositionFeature,
     RoleChangeFeature,
 )
+from scripts.feature_projections.features.naive_prior_ppg import NaivePriorSeasonPPGFeature
+from scripts.feature_projections.features.position_mean import PositionMeanFeature
 
 FEATURE_REGISTRY: dict[str, type] = {
     "weighted_ppg": WeightedPPGFeature,
@@ -67,4 +69,6 @@ FEATURE_REGISTRY: dict[str, type] = {
     "implied_team_total_raw": ImpliedTeamTotalRawFeature,
     "depth_chart_position_raw": DepthChartPositionFeature,
     "role_change_raw": RoleChangeFeature,
+    "naive_prior_ppg": NaivePriorSeasonPPGFeature,
+    "position_mean": PositionMeanFeature,
 }

--- a/scripts/feature_projections/features/naive_prior_ppg.py
+++ b/scripts/feature_projections/features/naive_prior_ppg.py
@@ -1,0 +1,46 @@
+"""Naïve prior-season PPG baseline (GH #575, Finding 4).
+
+The simplest possible projection: next season's PPG = the player's most recent
+season's PPG, with no recency weighting, age curve, or regression. Serves as an
+honest floor — any model worth its complexity should beat "just use last year."
+Even simpler than `v1_baseline_weighted_ppg` (a 3-year weighted average).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pandas as pd
+
+from scripts.feature_projections.features.base import ProjectionFeature
+
+
+class NaivePriorSeasonPPGFeature(ProjectionFeature):
+    """Absolute PPG = the player's most recent prior season's PPG."""
+
+    @property
+    def name(self) -> str:
+        return "naive_prior_ppg"
+
+    @property
+    def is_base(self) -> bool:
+        return True
+
+    def compute(
+        self,
+        player_id: str,
+        position: str,
+        history_df: pd.DataFrame,
+        nfl_stats_df: pd.DataFrame,
+        context: dict[str, Any],
+    ) -> Optional[float]:
+        if history_df is None or history_df.empty:
+            return None
+        df = history_df.copy()
+        df["season"] = pd.to_numeric(df["season"], errors="coerce")
+        df["ppg"] = pd.to_numeric(df["ppg"], errors="coerce")
+        df = df.dropna(subset=["season", "ppg"])
+        if df.empty:
+            return None
+        latest = df.loc[df["season"].idxmax()]
+        return float(latest["ppg"])

--- a/scripts/feature_projections/features/position_mean.py
+++ b/scripts/feature_projections/features/position_mean.py
@@ -1,0 +1,39 @@
+"""Positional-mean baseline (GH #575, Finding 4).
+
+A zero-information floor: every player is projected at their position's mean PPG
+(computed from the prior-season window, so leakage-free). By construction it
+cannot discriminate between players (R² ≈ 0), which is the point — it shows how
+much of a model's apparent accuracy is just knowing the positional scale vs.
+actually ranking players. Any real model must clearly beat this.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pandas as pd
+
+from scripts.feature_projections.features.base import ProjectionFeature
+
+
+class PositionMeanFeature(ProjectionFeature):
+    """Absolute PPG = the position's mean PPG from the history window."""
+
+    @property
+    def name(self) -> str:
+        return "position_mean"
+
+    @property
+    def is_base(self) -> bool:
+        return True
+
+    def compute(
+        self,
+        player_id: str,
+        position: str,
+        history_df: pd.DataFrame,
+        nfl_stats_df: pd.DataFrame,
+        context: dict[str, Any],
+    ) -> Optional[float]:
+        val = context.get("positional_mean_ppg")
+        return float(val) if val is not None else None

--- a/scripts/feature_projections/holdout_eval.py
+++ b/scripts/feature_projections/holdout_eval.py
@@ -323,14 +323,41 @@ def gather_predictions(
     return preds, actuals_by_season, pos_map
 
 
+def _restrict_to_common_players(
+    preds: dict[str, dict[int, dict[str, float]]],
+    actuals_by_season: dict[int, dict[str, float]],
+) -> dict[int, dict[str, float]]:
+    """Intersect actuals down to players EVERY model projected, per season.
+
+    Matched-sample mode (Finding 4): the ALL ranking is only apples-to-apples if
+    all models are scored on the same players. FantasyPros projects a smaller,
+    more-fantasy-relevant set than the internal models, so the default report's
+    ALL rows aren't on a common sample. Restricting to the intersection (≈ FP's
+    set) makes the comparison fair, at the cost of a smaller N.
+    """
+    matched: dict[int, dict[str, float]] = {}
+    for season, actuals in actuals_by_season.items():
+        common = set(actuals.keys())
+        for model_preds in preds.values():
+            common &= set(model_preds.get(season, {}).keys())
+        matched[season] = {pid: actuals[pid] for pid in common}
+    return matched
+
+
 def run(
     train_seasons: list[int],
     eval_seasons: list[int],
     only_models: Optional[list[str]] = None,
+    matched: bool = False,
 ) -> str:
     preds, actuals_by_season, pos_map = gather_predictions(
         train_seasons, eval_seasons, only_models
     )
+
+    if matched:
+        actuals_by_season = _restrict_to_common_players(preds, actuals_by_season)
+        for s in eval_seasons:
+            print(f"Matched-sample season {s}: {len(actuals_by_season[s])} common players")
 
     # {model: {season: {pos: metrics}}}
     results: dict[str, dict[int, dict[str, dict]]] = {
@@ -341,13 +368,14 @@ def run(
         for model_name, model_preds in preds.items()
     }
 
-    return _render(results, train_seasons, eval_seasons)
+    return _render(results, train_seasons, eval_seasons, matched=matched)
 
 
 def _render(
     results: dict[str, dict[int, dict[str, dict]]],
     train_seasons: list[int],
     eval_seasons: list[int],
+    matched: bool = False,
 ) -> str:
     metric_cols = [("mae", "MAE", ".3f"), ("bias", "Bias", "+.3f"),
                    ("r_squared", "R²", ".3f"), ("rmse", "RMSE", ".3f"),
@@ -360,8 +388,16 @@ def _render(
         combined[model_name] = {p: _aggregate(season_metrics, p) for p in report_positions}
 
     lines: list[str] = []
-    lines.append("# Projection Held-Out Evaluation (GH #572)\n")
+    title_suffix = " — matched-sample (common players only)" if matched else ""
+    lines.append(f"# Projection Held-Out Evaluation (GH #572){title_suffix}\n")
     lines.append(f"_Generated: {datetime.now().strftime('%Y-%m-%d %H:%M')}_\n")
+    if matched:
+        lines.append(
+            "**Matched-sample mode (Finding 4):** every model is scored on the *same* players "
+            "— the intersection of players all evaluated models projected, per season. This makes "
+            "the FantasyPros comparison apples-to-apples (FP projects a smaller, more-available "
+            "set), at the cost of a smaller N. Run without `--matched` for the full-coverage report.\n"
+        )
     lines.append(
         f"**Every model is evaluated out-of-sample on a shared held-out window.** "
         f"Learned/residual models were retrained on **{','.join(map(str, train_seasons))}** "
@@ -439,8 +475,11 @@ def main() -> None:
                         help="Comma-separated held-out evaluation seasons")
     parser.add_argument("--models", default=None,
                         help="Optional comma-separated subset of models (default: all)")
-    parser.add_argument("--output",
-                        default=os.path.join(repo_root, "docs", "generated", "projection-holdout-eval.md"))
+    parser.add_argument("--matched", action="store_true",
+                        help="Matched-sample mode: score all models on the common player set "
+                             "(apples-to-apples FantasyPros comparison, #575). Writes to a "
+                             "-matched output path unless --output is given.")
+    parser.add_argument("--output", default=None)
     args = parser.parse_args()
 
     train_seasons = [int(s) for s in args.train_seasons.split(",")]
@@ -452,12 +491,17 @@ def main() -> None:
 
     only_models = [m.strip() for m in args.models.split(",")] if args.models else None
 
-    table = run(train_seasons, eval_seasons, only_models)
+    output = args.output or os.path.join(
+        repo_root, "docs", "generated",
+        "projection-holdout-eval-matched.md" if args.matched else "projection-holdout-eval.md",
+    )
 
-    os.makedirs(os.path.dirname(args.output), exist_ok=True)
-    with open(args.output, "w") as f:
+    table = run(train_seasons, eval_seasons, only_models, matched=args.matched)
+
+    os.makedirs(os.path.dirname(output), exist_ok=True)
+    with open(output, "w") as f:
         f.write(table)
-    print(f"\nReport written to: {args.output}")
+    print(f"\nReport written to: {output}")
     print("\n" + "=" * 80)
     print(table)
 

--- a/scripts/feature_projections/model_config.py
+++ b/scripts/feature_projections/model_config.py
@@ -540,6 +540,26 @@ MODELS: dict[str, ModelDefinition] = {
             "depth_chart_position_raw*position",
         ],
     ),
+    "naive_prior_season_ppg": ModelDefinition(
+        name="naive_prior_season_ppg",
+        version=1,
+        description=(
+            "Naïve floor (GH #575): next season = most recent prior season's PPG, "
+            "no weighting/age/regression. Honest lower bound — any model worth its "
+            "complexity must beat 'just use last year'."
+        ),
+        features=["naive_prior_ppg"],
+    ),
+    "position_mean_baseline": ModelDefinition(
+        name="position_mean_baseline",
+        version=1,
+        description=(
+            "Zero-information floor (GH #575): every player projected at their "
+            "position's mean PPG (from the prior-season window). Cannot rank players "
+            "(R² ≈ 0); isolates how much accuracy is just knowing positional scale."
+        ),
+        features=["position_mean"],
+    ),
     "external_fantasypros_v1": ModelDefinition(
         name="external_fantasypros_v1",
         version=1,

--- a/scripts/tests/test_feature_projections.py
+++ b/scripts/tests/test_feature_projections.py
@@ -26,6 +26,8 @@ from scripts.feature_projections.features.regression_to_mean import (
 )
 from scripts.feature_projections.features.snap_trend import SnapTrendFeature
 from scripts.feature_projections.features.qb_starter_usage import QBStarterUsageFeature, QBStarterBackupPenaltyFeature
+from scripts.feature_projections.features.naive_prior_ppg import NaivePriorSeasonPPGFeature
+from scripts.feature_projections.features.position_mean import PositionMeanFeature
 from scripts.feature_projections.combiner import combine_features
 from scripts.feature_projections.model_config import get_model, MODELS, ModelDefinition, PositionOverride
 from scripts.feature_projections.runner import _resolve_features_for_position
@@ -1846,3 +1848,54 @@ class TestRoleChangeFeature:
     def test_kicker_excluded(self):
         ctx = {"target_season": 2025, "depth_charts": {("p1", 2024): 2, ("p1", 2025): 1}}
         assert self.feature.compute("p1", "K", pd.DataFrame(), pd.DataFrame(), ctx) is None
+
+
+# ---------------------------------------------------------------------------
+# Naïve baselines (#575)
+# ---------------------------------------------------------------------------
+
+class TestNaivePriorSeasonPPGFeature:
+    def setup_method(self):
+        self.feature = NaivePriorSeasonPPGFeature()
+
+    def test_is_base(self):
+        assert self.feature.is_base is True
+        assert self.feature.name == "naive_prior_ppg"
+
+    def test_empty_history_returns_none(self):
+        assert self.feature.compute("p1", "WR", pd.DataFrame(), pd.DataFrame(), {}) is None
+
+    def test_returns_most_recent_season_ppg(self):
+        df = make_history_df([
+            {"player_id": "p1", "season": 2022, "ppg": 8.0, "games_played": 16},
+            {"player_id": "p1", "season": 2024, "ppg": 14.0, "games_played": 17},
+            {"player_id": "p1", "season": 2023, "ppg": 11.0, "games_played": 15},
+        ])
+        # Most recent prior season is 2024 regardless of row order.
+        assert self.feature.compute("p1", "WR", df, pd.DataFrame(), {}) == 14.0
+
+    def test_single_season(self):
+        df = make_history_df([{"player_id": "p1", "season": 2024, "ppg": 9.5, "games_played": 10}])
+        assert self.feature.compute("p1", "RB", df, pd.DataFrame(), {}) == 9.5
+
+
+class TestPositionMeanFeature:
+    def setup_method(self):
+        self.feature = PositionMeanFeature()
+
+    def test_is_base(self):
+        assert self.feature.is_base is True
+        assert self.feature.name == "position_mean"
+
+    def test_returns_positional_mean_from_context(self):
+        assert self.feature.compute("p1", "WR", pd.DataFrame(), pd.DataFrame(),
+                                    {"positional_mean_ppg": 7.3}) == 7.3
+
+    def test_missing_mean_returns_none(self):
+        assert self.feature.compute("p1", "WR", pd.DataFrame(), pd.DataFrame(), {}) is None
+
+    def test_ignores_history(self):
+        df = make_history_df([{"player_id": "p1", "season": 2024, "ppg": 25.0, "games_played": 17}])
+        # Projection is the positional mean, NOT the player's own production.
+        assert self.feature.compute("p1", "WR", df, pd.DataFrame(),
+                                    {"positional_mean_ppg": 7.3}) == 7.3


### PR DESCRIPTION
Implements Finding 4 of the methodology audit: there were no honest floors to judge model complexity against, and the FantasyPros comparison was confounded by FP's smaller player coverage.

## What
**Two baseline models** (parameter-free features + model defs + tests, registered so they flow through every report):
- `naive_prior_season_ppg` — next season = most recent prior season's PPG (persistence floor; simpler than the 3-yr `v1`).
- `position_mean_baseline` — everyone projected at their position's mean PPG (zero-information floor, R² ≈ 0).

**`just holdout-eval --matched`** — scores every model on the *common* player set (the intersection all models projected, per season ≈ FP's coverage), making the FP comparison apples-to-apples. Writes `projection-holdout-eval-matched.md`.

## Results (held-out 2024–2025)

The baselines bracket the field:

| Model | Held-out ALL MAE | |
|---|---|---|
| `v14_qb_starter` (production) | **2.450** | best |
| `v1_baseline_weighted_ppg` (3-yr) | 2.633 | rank 21 |
| learned family `v20`–`v31` | 2.65–2.73 | ranks 22–31 |
| `naive_prior_season_ppg` | 2.754 | rank 32 |
| `position_mean_baseline` | 3.710 | rank 33 (floor) |

1. **The learned family barely clears persistence.** v20–v31 sit just above "use last year" (2.754) and below the 3-yr v1 (2.633) — the feature engineering buys almost nothing over the simplest projection. `position_mean` (3.710) is the no-skill floor; good models clear it by ~1.3 MAE / on R² 0.19→0.61, so they *do* rank players, just don't beat persistence by much.
2. **FantasyPros ties the best internal models once matched.** Full report: FP rank 3 (2.462, N=430) vs internal N=647 — different players. On the **common 416** (`--matched`), FP (2.502) is tied with v14 (2.494) and v19 (2.501) — inside the bootstrap noise (Finding 2) — while over-projecting (+1.0 bias). The "FP mid-pack" impression was a sample artifact.

## Validation
- 192 tests pass (8 new feature tests + architecture/registry contracts).
- Baseline projections generated to `model_projections` only — production `player_projections` untouched.
- Both held-out reports regenerated.

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)