### PR TITLE
Position-balanced MAE headline (#577, Finding 6)

### DIFF
--- a/docs/exec-plans/projection-methodology-audit.md
+++ b/docs/exec-plans/projection-methodology-audit.md
@@ -286,8 +286,29 @@ each position cleared the games filter that year — a mix that drifts season to
 season (2022 n=154 vs 2024 n=274). A model that merely changes the position mix
 of qualifiers can look like an accuracy gain.
 
-**Remediation:** report a position-balanced headline (per-position MAE then
-averaged) alongside the pooled number.
+**Remediation (shipped):** every report now shows a **position-balanced MAE**
+alongside the pooled `ALL` — the unweighted mean of the per-position MAEs over a
+fixed set (QB/RB/WR/TE; K excluded as essentially random and not projected by
+every model, so it's comparable across models). `holdout_eval.py` and
+`availability_backtest.py` add a `Bal MAE` column; `accuracy_report.py` adds a
+Position-balanced ranking table.
+
+### Finding 6 result — balanced metric confirms the leader and exposed a coverage confound
+
+- On the **matched** held-out sample (same 416 players, the clean comparison),
+  `v14` leads on **both** pooled (2.494) and balanced (2.564) MAE — the
+  position-mix worry does not overturn the top of the board.
+- In the **full** (unmatched) held-out report the two disagree: `v14` wins
+  pooled (2.450) but FantasyPros wins balanced (2.544 vs `v14` 2.653). That flip
+  is **not** real skill — it's FP's smaller, per-position-favourable coverage
+  (N=430 vs 647), and it vanishes once players are matched. So the balanced
+  metric and matched mode (#575) are complementary: balanced guards against
+  position-mix gaming, matched guards against coverage gaming, and only together
+  do they show `v14` robustly ahead.
+
+Net: the balanced headline mostly **confirms** the pooled ranking here rather
+than overturning it — which is the reassuring outcome — while making any future
+mix-driven illusion visible at a glance.
 
 ---
 
@@ -317,6 +338,6 @@ averaged) alongside the pooled number.
 | 3 — availability-inclusive evaluation | 🟠 | [#574](https://github.com/alex-monroe/ottoneu-db/issues/574) | shipped (`just availability-backtest`); see Finding 3 result |
 | 4 — naïve baselines + matched-sample FP | 🟠 | [#575](https://github.com/alex-monroe/ottoneu-db/issues/575) | shipped (2 baseline models + `--matched`); see Finding 4 result |
 | 5 — R² aggregation discipline | 🟡 | [#576](https://github.com/alex-monroe/ottoneu-db/issues/576) | shipped (pooled R² where possible, omitted where not) |
-| 6 — position-balanced headline MAE | 🟡 | [#577](https://github.com/alex-monroe/ottoneu-db/issues/577) | open |
+| 6 — position-balanced headline MAE | 🟡 | [#577](https://github.com/alex-monroe/ottoneu-db/issues/577) | shipped (`Bal MAE` in all reports); see Finding 6 result |
 </content>
 </invoke>

--- a/docs/generated/projection-accuracy.md
+++ b/docs/generated/projection-accuracy.md
@@ -1,6 +1,6 @@
 # Projection Model Accuracy Report
 
-_Generated: 2026-06-10 09:06_
+_Generated: 2026-06-10 09:29_
 
 Metrics: **MAE** = Mean Absolute Error (lower is better), **Bias** = Mean signed error (positive = under-projection), **R²** = Goodness of fit (higher is better), **RMSE** = Root mean square error, **N** = player sample size.
 
@@ -1157,6 +1157,44 @@ _N-weighted across all seasons. MAE/Bias are exact (linear in the errors); RMSE 
 | `naive_prior_season_ppg` | — | — | — | — | — |
 | `position_mean_baseline` | — | — | — | — | — |
 | `external_fantasypros_v1` | — | — | — | — | — |
+
+### Position-balanced MAE
+
+_The `ALL` rows above pool positions weighted by how many cleared the games filter — a mix that drifts season to season (QB ~3.7 MAE vs K ~1.0), so a model can look better just by having more easy/plentiful players in the pool. **Balanced MAE** is the unweighted mean of the per-position combined MAEs over a fixed set (QB/RB/WR/TE; K is excluded — essentially random and not projected by every model), removing that mix effect and keeping all models comparable. Compare against the pooled `ALL` MAE above. (GH #577.)_
+
+| Model | Balanced MAE | Pooled ALL MAE |
+| --- | --- | --- |
+| `external_fantasypros_v1` | **2.525** | 2.460 |
+| `v31_depth_chart` | 2.566 | 2.358 |
+| `v14_qb_starter` | 2.658 | 2.437 |
+| `v26_vegas_residual` | 2.660 | 2.443 |
+| `v19_usage_level_full` | 2.665 | 2.441 |
+| `v13_qb_starter` | 2.666 | 2.447 |
+| `v10_stat_efficiency_v2` | 2.668 | 2.449 |
+| `v8_age_regression` | 2.669 | 2.449 |
+| `v9_pos_specific` | 2.669 | 2.449 |
+| `v12_no_qb_trajectory` | 2.670 | 2.445 |
+| `v11_team_context_v2` | 2.673 | 2.452 |
+| `v16_snap_trend_full` | 2.674 | 2.447 |
+| `v28_reliability_weighting` | 2.678 | 2.449 |
+| `v29_reliability_residual` | 2.680 | 2.451 |
+| `v27_vegas_full_refit` | 2.687 | 2.458 |
+| `v17_rookie_growth` | 2.690 | 2.467 |
+| `v30_reliability_full_refit` | 2.691 | 2.461 |
+| `v22_advanced_receiving` | 2.695 | 2.474 |
+| `v25_draft_capital_residual` | 2.696 | 2.474 |
+| `v20_learned_usage` | 2.714 | 2.494 |
+| `v3_stat_weighted` | 2.721 | 2.496 |
+| `v2_age_adjusted` | 2.722 | 2.498 |
+| `v23_draft_capital` | 2.723 | 2.493 |
+| `v21_tiered_regression` | 2.729 | 2.501 |
+| `v15_snap_trend` | 2.761 | 2.527 |
+| `v18_usage_level` | 2.768 | 2.541 |
+| `v7_regression_to_mean` | 2.769 | 2.536 |
+| `v1_baseline_weighted_ppg` _(baseline)_ | 2.799 | 2.571 |
+| `v4_availability_adjusted` | 2.800 | 2.567 |
+| `v5_team_context` | 2.806 | 2.571 |
+| `v6_usage_share` | 2.833 | 2.597 |
 
 ## Out-of-Sample Reference (LOSO CV)
 

--- a/docs/generated/projection-availability-eval.md
+++ b/docs/generated/projection-availability-eval.md
@@ -1,36 +1,38 @@
 # Projection Availability-Inclusive Evaluation (GH #574)
 
-_Generated: 2026-06-10 09:06_
+_Generated: 2026-06-10 09:30_
 
 Standard backtests score only players with ≥4 games, hiding injured/benched/bust seasons. This evaluation keeps everyone with ≥1 game (non-rookie) and scores each PPG projection against two targets: **Rate** = actual PPG, and **Avail** = availability-inclusive production per scheduled game (`ppg × min(games,17) / 17`, missed games = 0). The gap **avail-MAE − rate-MAE** is the *availability error budget* — error from playing-time loss that no current rate feature addresses. Default models are parameter-free (additive + external), whose stored projections are leakage-free; learned models (if included) use in-sample projections (see #571). Seasons: 2022,2023,2024,2025. See [docs/exec-plans/projection-methodology-audit.md](../exec-plans/projection-methodology-audit.md) (Finding 3).
 
 ## Rate vs availability decomposition (combined ALL)
 
-| Model | N | Mean games | Rate MAE | Avail MAE | Availability budget | Avail bias |
-| --- | --- | --- | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 703 | 13.1 | 2.598 | 2.489 | -0.109 | -0.455 |
-| `v7_regression_to_mean` | 1069 | 12.6 | 2.652 | 3.096 | +0.444 | -1.530 |
-| `v4_availability_adjusted` | 1069 | 12.6 | 2.673 | 3.106 | +0.433 | -1.527 |
-| `v5_team_context` | 1069 | 12.6 | 2.679 | 3.117 | +0.437 | -1.550 |
-| `v21_tiered_regression` | 1069 | 12.6 | 2.599 | 3.120 | +0.521 | -1.536 |
-| `v6_usage_share` | 1069 | 12.6 | 2.703 | 3.179 | +0.475 | -1.697 |
-| `v14_qb_starter` | 1069 | 12.6 | 2.555 | 3.188 | +0.633 | -1.747 |
-| `v16_snap_trend_full` | 1069 | 12.6 | 2.570 | 3.216 | +0.646 | -1.781 |
-| `v19_usage_level_full` | 1069 | 12.6 | 2.560 | 3.247 | +0.687 | -1.894 |
-| `v12_no_qb_trajectory` | 1069 | 12.6 | 2.568 | 3.252 | +0.684 | -1.815 |
-| `v17_rookie_growth` | 1069 | 12.6 | 2.610 | 3.252 | +0.642 | -1.817 |
-| `v10_stat_efficiency_v2` | 1069 | 12.6 | 2.577 | 3.257 | +0.681 | -1.835 |
-| `v8_age_regression` | 1069 | 12.6 | 2.579 | 3.265 | +0.686 | -1.843 |
-| `v9_pos_specific` | 1069 | 12.6 | 2.579 | 3.265 | +0.686 | -1.843 |
-| `v13_qb_starter` | 1069 | 12.6 | 2.578 | 3.268 | +0.691 | -1.842 |
-| `v11_team_context_v2` | 1069 | 12.6 | 2.585 | 3.270 | +0.685 | -1.869 |
-| `v3_stat_weighted` | 1069 | 12.6 | 2.615 | 3.334 | +0.720 | -1.996 |
-| `v2_age_adjusted` | 1069 | 12.6 | 2.617 | 3.343 | +0.726 | -2.010 |
-| `v15_snap_trend` | 1069 | 12.6 | 2.649 | 3.375 | +0.725 | -2.044 |
-| `v18_usage_level` | 1069 | 12.6 | 2.658 | 3.414 | +0.756 | -2.157 |
-| `naive_prior_season_ppg` | 1098 | 12.4 | 2.819 | 3.476 | +0.657 | -1.979 |
-| `v1_baseline_weighted_ppg` | 1069 | 12.6 | 2.693 | 3.510 | +0.817 | -2.242 |
-| `position_mean_baseline` | 1098 | 12.4 | 4.078 | 4.312 | +0.234 | -0.700 |
+_**Avail MAE** is pooled over players; **Bal Avail MAE** is the position-balanced availability MAE (unweighted mean of per-position avail MAE over QB/RB/WR/TE; K excluded), which removes the drifting position mix of the qualifier pool (GH #577)._
+
+| Model | N | Mean games | Rate MAE | Avail MAE | Bal Avail MAE | Availability budget | Avail bias |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 703 | 13.1 | 2.598 | 2.489 | 2.510 | -0.109 | -0.455 |
+| `v7_regression_to_mean` | 1069 | 12.6 | 2.652 | 3.096 | 3.312 | +0.444 | -1.530 |
+| `v4_availability_adjusted` | 1069 | 12.6 | 2.673 | 3.106 | 3.317 | +0.433 | -1.527 |
+| `v5_team_context` | 1069 | 12.6 | 2.679 | 3.117 | 3.330 | +0.437 | -1.550 |
+| `v21_tiered_regression` | 1069 | 12.6 | 2.599 | 3.120 | 3.348 | +0.521 | -1.536 |
+| `v6_usage_share` | 1069 | 12.6 | 2.703 | 3.179 | 3.396 | +0.475 | -1.697 |
+| `v14_qb_starter` | 1069 | 12.6 | 2.555 | 3.188 | 3.431 | +0.633 | -1.747 |
+| `v16_snap_trend_full` | 1069 | 12.6 | 2.570 | 3.216 | 3.468 | +0.646 | -1.781 |
+| `v19_usage_level_full` | 1069 | 12.6 | 2.560 | 3.247 | 3.495 | +0.687 | -1.894 |
+| `v12_no_qb_trajectory` | 1069 | 12.6 | 2.568 | 3.252 | 3.512 | +0.684 | -1.815 |
+| `v17_rookie_growth` | 1069 | 12.6 | 2.610 | 3.252 | 3.501 | +0.642 | -1.817 |
+| `v10_stat_efficiency_v2` | 1069 | 12.6 | 2.577 | 3.257 | 3.509 | +0.681 | -1.835 |
+| `v8_age_regression` | 1069 | 12.6 | 2.579 | 3.265 | 3.519 | +0.686 | -1.843 |
+| `v9_pos_specific` | 1069 | 12.6 | 2.579 | 3.265 | 3.519 | +0.686 | -1.843 |
+| `v13_qb_starter` | 1069 | 12.6 | 2.578 | 3.268 | 3.523 | +0.691 | -1.842 |
+| `v11_team_context_v2` | 1069 | 12.6 | 2.585 | 3.270 | 3.524 | +0.685 | -1.869 |
+| `v3_stat_weighted` | 1069 | 12.6 | 2.615 | 3.334 | 3.590 | +0.720 | -1.996 |
+| `v2_age_adjusted` | 1069 | 12.6 | 2.617 | 3.343 | 3.601 | +0.726 | -2.010 |
+| `v15_snap_trend` | 1069 | 12.6 | 2.649 | 3.375 | 3.642 | +0.725 | -2.044 |
+| `v18_usage_level` | 1069 | 12.6 | 2.658 | 3.414 | 3.677 | +0.756 | -2.157 |
+| `naive_prior_season_ppg` | 1098 | 12.4 | 2.819 | 3.476 | 3.754 | +0.657 | -1.979 |
+| `v1_baseline_weighted_ppg` | 1069 | 12.6 | 2.693 | 3.510 | 3.788 | +0.817 | -2.242 |
+| `position_mean_baseline` | 1098 | 12.4 | 4.078 | 4.312 | 4.717 | +0.234 | -0.700 |
 
 ## Availability-inclusive metrics by position
 

--- a/docs/generated/projection-holdout-eval-matched.md
+++ b/docs/generated/projection-holdout-eval-matched.md
@@ -1,6 +1,6 @@
 # Projection Held-Out Evaluation (GH #572) — matched-sample (common players only)
 
-_Generated: 2026-06-10 09:15_
+_Generated: 2026-06-10 09:35_
 
 **Matched-sample mode (Finding 4):** every model is scored on the *same* players — the intersection of players all evaluated models projected, per season. This makes the FantasyPros comparison apples-to-apples (FP projects a smaller, more-available set), at the cost of a smaller N. Run without `--matched` for the full-coverage report.
 
@@ -8,41 +8,43 @@ _Generated: 2026-06-10 09:15_
 
 ## Ranking — combined held-out ALL (lower MAE = better)
 
-| Rank | Model | MAE | Bias | R² | RMSE | N |
-| --- | --- | --- | --- | --- | --- | --- |
-| 1 | `v14_qb_starter` | **2.494** | +0.161 | 0.650 | 3.283 | 416 |
-| 2 | `v19_usage_level_full` | 2.501 | -0.040 | 0.652 | 3.275 | 416 |
-| 3 | `external_fantasypros_v1` | 2.502 | +1.022 | 0.625 | 3.400 | 416 |
-| 4 | `v10_stat_efficiency_v2` | 2.521 | +0.071 | 0.627 | 3.389 | 416 |
-| 5 | `v17_rookie_growth` | 2.522 | +0.119 | 0.647 | 3.299 | 416 |
-| 6 | `v12_no_qb_trajectory` | 2.523 | +0.094 | 0.627 | 3.390 | 416 |
-| 7 | `v16_snap_trend_full` | 2.523 | +0.098 | 0.641 | 3.326 | 416 |
-| 8 | `v11_team_context_v2` | 2.525 | +0.033 | 0.621 | 3.419 | 416 |
-| 9 | `v8_age_regression` | 2.526 | +0.069 | 0.625 | 3.398 | 416 |
-| 10 | `v9_pos_specific` | 2.526 | +0.069 | 0.625 | 3.398 | 416 |
-| 11 | `v13_qb_starter` | 2.527 | +0.070 | 0.624 | 3.403 | 416 |
-| 12 | `v21_tiered_regression` | 2.551 | +0.233 | 0.628 | 3.387 | 416 |
-| 13 | `v7_regression_to_mean` | 2.571 | +0.304 | 0.624 | 3.405 | 416 |
-| 14 | `v3_stat_weighted` | 2.585 | -0.183 | 0.608 | 3.475 | 416 |
-| 15 | `v2_age_adjusted` | 2.587 | -0.197 | 0.607 | 3.480 | 416 |
-| 16 | `v5_team_context` | 2.623 | +0.238 | 0.600 | 3.511 | 416 |
-| 17 | `v15_snap_trend` | 2.624 | -0.259 | 0.595 | 3.532 | 416 |
-| 18 | `v4_availability_adjusted` | 2.628 | +0.272 | 0.604 | 3.494 | 416 |
-| 19 | `v18_usage_level` | 2.633 | -0.397 | 0.598 | 3.519 | 416 |
-| 20 | `v26_vegas_residual` | 2.642 | -0.905 | 0.635 | 3.354 | 416 |
-| 21 | `v6_usage_share` | 2.646 | +0.038 | 0.595 | 3.531 | 416 |
-| 22 | `v20_learned_usage` | 2.647 | -0.627 | 0.636 | 3.347 | 416 |
-| 23 | `v22_advanced_receiving` | 2.650 | -0.661 | 0.634 | 3.357 | 416 |
-| 24 | `v31_depth_chart` | 2.656 | -0.908 | 0.625 | 3.399 | 416 |
-| 25 | `v25_draft_capital_residual` | 2.663 | -0.857 | 0.632 | 3.368 | 416 |
-| 26 | `v28_reliability_weighting` | 2.663 | -0.786 | 0.633 | 3.362 | 416 |
-| 27 | `v27_vegas_full_refit` | 2.674 | -0.872 | 0.624 | 3.403 | 416 |
-| 28 | `v30_reliability_full_refit` | 2.675 | -0.877 | 0.623 | 3.409 | 416 |
-| 29 | `v29_reliability_residual` | 2.693 | -0.964 | 0.626 | 3.396 | 416 |
-| 30 | `v1_baseline_weighted_ppg` | 2.700 | -0.429 | 0.578 | 3.605 | 416 |
-| 31 | `v23_draft_capital` | 2.720 | -0.845 | 0.615 | 3.444 | 416 |
-| 32 | `naive_prior_season_ppg` | 2.890 | -0.281 | 0.494 | 3.949 | 416 |
-| 33 | `position_mean_baseline` | 4.080 | +1.757 | 0.131 | 5.173 | 416 |
+_**MAE** is the pooled-over-players ALL error. **Bal MAE** is the position-balanced MAE — the unweighted mean of the per-position MAEs over a fixed set (QB/RB/WR/TE; K excluded as essentially random and not projected by every model) — which neutralises the drifting position mix of the qualifier pool (GH #577). They can disagree: a model can win the pooled MAE while losing the balanced one if it's strong only where players are easy/plentiful._
+
+| Rank | Model | MAE | Bal MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `v14_qb_starter` | **2.494** | **2.564** | +0.161 | 0.650 | 3.283 | 416 |
+| 2 | `v19_usage_level_full` | 2.501 | 2.569 | -0.040 | 0.652 | 3.275 | 416 |
+| 3 | `external_fantasypros_v1` | 2.502 | 2.595 | +1.022 | 0.625 | 3.400 | 416 |
+| 4 | `v10_stat_efficiency_v2` | 2.521 | 2.598 | +0.071 | 0.627 | 3.389 | 416 |
+| 5 | `v17_rookie_growth` | 2.522 | 2.590 | +0.119 | 0.647 | 3.299 | 416 |
+| 6 | `v12_no_qb_trajectory` | 2.523 | 2.601 | +0.094 | 0.627 | 3.390 | 416 |
+| 7 | `v16_snap_trend_full` | 2.523 | 2.600 | +0.098 | 0.641 | 3.326 | 416 |
+| 8 | `v11_team_context_v2` | 2.525 | 2.602 | +0.033 | 0.621 | 3.419 | 416 |
+| 9 | `v8_age_regression` | 2.526 | 2.603 | +0.069 | 0.625 | 3.398 | 416 |
+| 10 | `v9_pos_specific` | 2.526 | 2.603 | +0.069 | 0.625 | 3.398 | 416 |
+| 11 | `v13_qb_starter` | 2.527 | 2.604 | +0.070 | 0.624 | 3.403 | 416 |
+| 12 | `v21_tiered_regression` | 2.551 | 2.628 | +0.233 | 0.628 | 3.387 | 416 |
+| 13 | `v7_regression_to_mean` | 2.571 | 2.645 | +0.304 | 0.624 | 3.405 | 416 |
+| 14 | `v3_stat_weighted` | 2.585 | 2.665 | -0.183 | 0.608 | 3.475 | 416 |
+| 15 | `v2_age_adjusted` | 2.587 | 2.667 | -0.197 | 0.607 | 3.480 | 416 |
+| 16 | `v5_team_context` | 2.623 | 2.703 | +0.238 | 0.600 | 3.511 | 416 |
+| 17 | `v15_snap_trend` | 2.624 | 2.711 | -0.259 | 0.595 | 3.532 | 416 |
+| 18 | `v4_availability_adjusted` | 2.628 | 2.707 | +0.272 | 0.604 | 3.494 | 416 |
+| 19 | `v18_usage_level` | 2.633 | 2.709 | -0.397 | 0.598 | 3.519 | 416 |
+| 20 | `v6_usage_share` | 2.646 | 2.722 | +0.038 | 0.595 | 3.531 | 416 |
+| 21 | `v20_learned_usage` | 2.647 | 2.707 | -0.627 | 0.636 | 3.347 | 416 |
+| 22 | `v31_depth_chart` | 2.656 | 2.711 | -0.908 | 0.625 | 3.399 | 416 |
+| 23 | `v28_reliability_weighting` | 2.663 | 2.719 | -0.786 | 0.633 | 3.362 | 416 |
+| 24 | `v26_vegas_residual` | 2.663 | 2.718 | -0.827 | 0.627 | 3.388 | 416 |
+| 25 | `v22_advanced_receiving` | 2.664 | 2.717 | -0.566 | 0.630 | 3.376 | 416 |
+| 26 | `v27_vegas_full_refit` | 2.674 | 2.734 | -0.872 | 0.624 | 3.403 | 416 |
+| 27 | `v30_reliability_full_refit` | 2.675 | 2.736 | -0.877 | 0.623 | 3.409 | 416 |
+| 28 | `v25_draft_capital_residual` | 2.693 | 2.751 | -0.779 | 0.623 | 3.408 | 416 |
+| 29 | `v29_reliability_residual` | 2.693 | 2.752 | -0.964 | 0.626 | 3.396 | 416 |
+| 30 | `v1_baseline_weighted_ppg` | 2.700 | 2.775 | -0.429 | 0.578 | 3.605 | 416 |
+| 31 | `v23_draft_capital` | 2.742 | 2.805 | -0.652 | 0.606 | 3.486 | 416 |
+| 32 | `naive_prior_season_ppg` | 2.890 | 2.992 | -0.281 | 0.494 | 3.949 | 416 |
+| 33 | `position_mean_baseline` | 4.080 | 4.150 | +1.757 | 0.131 | 5.173 | 416 |
 
 ## Combined across eval seasons — by position
 
@@ -69,18 +71,18 @@ _Generated: 2026-06-10 09:15_
 | `v15_snap_trend` | 2.624 | -0.259 | 0.595 | 3.532 | 416 |
 | `v4_availability_adjusted` | 2.628 | +0.272 | 0.604 | 3.494 | 416 |
 | `v18_usage_level` | 2.633 | -0.397 | 0.598 | 3.519 | 416 |
-| `v26_vegas_residual` | 2.642 | -0.905 | 0.635 | 3.354 | 416 |
 | `v6_usage_share` | 2.646 | +0.038 | 0.595 | 3.531 | 416 |
 | `v20_learned_usage` | 2.647 | -0.627 | 0.636 | 3.347 | 416 |
-| `v22_advanced_receiving` | 2.650 | -0.661 | 0.634 | 3.357 | 416 |
 | `v31_depth_chart` | 2.656 | -0.908 | 0.625 | 3.399 | 416 |
-| `v25_draft_capital_residual` | 2.663 | -0.857 | 0.632 | 3.368 | 416 |
 | `v28_reliability_weighting` | 2.663 | -0.786 | 0.633 | 3.362 | 416 |
+| `v26_vegas_residual` | 2.663 | -0.827 | 0.627 | 3.388 | 416 |
+| `v22_advanced_receiving` | 2.664 | -0.566 | 0.630 | 3.376 | 416 |
 | `v27_vegas_full_refit` | 2.674 | -0.872 | 0.624 | 3.403 | 416 |
 | `v30_reliability_full_refit` | 2.675 | -0.877 | 0.623 | 3.409 | 416 |
+| `v25_draft_capital_residual` | 2.693 | -0.779 | 0.623 | 3.408 | 416 |
 | `v29_reliability_residual` | 2.693 | -0.964 | 0.626 | 3.396 | 416 |
 | `v1_baseline_weighted_ppg` | 2.700 | -0.429 | 0.578 | 3.605 | 416 |
-| `v23_draft_capital` | 2.720 | -0.845 | 0.615 | 3.444 | 416 |
+| `v23_draft_capital` | 2.742 | -0.652 | 0.606 | 3.486 | 416 |
 | `naive_prior_season_ppg` | 2.890 | -0.281 | 0.494 | 3.949 | 416 |
 | `position_mean_baseline` | 4.080 | +1.757 | 0.131 | 5.173 | 416 |
 
@@ -88,20 +90,20 @@ _Generated: 2026-06-10 09:15_
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
+| `v22_advanced_receiving` | 3.447 | -0.678 | 0.482 | 4.470 | 84 |
 | `v31_depth_chart` | 3.455 | -1.347 | 0.484 | 4.460 | 84 |
-| `v22_advanced_receiving` | 3.462 | -1.114 | 0.481 | 4.471 | 84 |
 | `v20_learned_usage` | 3.486 | -1.200 | 0.477 | 4.491 | 84 |
 | `v28_reliability_weighting` | 3.492 | -1.252 | 0.472 | 4.511 | 84 |
-| `v26_vegas_residual` | 3.520 | -1.402 | 0.461 | 4.558 | 84 |
+| `v26_vegas_residual` | 3.497 | -1.067 | 0.460 | 4.564 | 84 |
 | `v27_vegas_full_refit` | 3.539 | -1.240 | 0.444 | 4.631 | 84 |
 | `v30_reliability_full_refit` | 3.549 | -1.274 | 0.437 | 4.658 | 84 |
 | `v14_qb_starter` | 3.558 | -0.397 | 0.446 | 4.622 | 84 |
 | `v17_rookie_growth` | 3.558 | -0.397 | 0.446 | 4.622 | 84 |
 | `v19_usage_level_full` | 3.558 | -0.397 | 0.446 | 4.622 | 84 |
-| `v25_draft_capital_residual` | 3.566 | -1.377 | 0.452 | 4.594 | 84 |
+| `v25_draft_capital_residual` | 3.563 | -1.036 | 0.448 | 4.612 | 84 |
 | `v29_reliability_residual` | 3.592 | -1.513 | 0.442 | 4.639 | 84 |
-| `v23_draft_capital` | 3.623 | -1.195 | 0.433 | 4.674 | 84 |
 | `v16_snap_trend_full` | 3.637 | -0.420 | 0.433 | 4.676 | 84 |
+| `v23_draft_capital` | 3.666 | -0.712 | 0.425 | 4.710 | 84 |
 | `v21_tiered_regression` | 3.670 | -0.023 | 0.412 | 4.759 | 84 |
 | `v7_regression_to_mean` | 3.703 | +0.480 | 0.388 | 4.857 | 84 |
 | `v12_no_qb_trajectory` | 3.706 | -0.726 | 0.354 | 4.990 | 84 |
@@ -146,17 +148,17 @@ _Generated: 2026-06-10 09:15_
 | `v5_team_context` | 2.780 | +0.777 | 0.569 | 3.535 | 97 |
 | `v15_snap_trend` | 2.788 | +0.238 | 0.573 | 3.521 | 97 |
 | `v21_tiered_regression` | 2.797 | +0.862 | 0.563 | 3.558 | 97 |
-| `v26_vegas_residual` | 2.816 | -0.316 | 0.583 | 3.479 | 97 |
 | `v4_availability_adjusted` | 2.839 | +0.807 | 0.565 | 3.553 | 97 |
 | `v20_learned_usage` | 2.848 | -0.133 | 0.569 | 3.537 | 97 |
+| `v26_vegas_residual` | 2.853 | -0.351 | 0.567 | 3.545 | 97 |
 | `v29_reliability_residual` | 2.873 | -0.485 | 0.579 | 3.496 | 97 |
-| `v25_draft_capital_residual` | 2.874 | -0.289 | 0.575 | 3.509 | 97 |
 | `v28_reliability_weighting` | 2.881 | -0.330 | 0.573 | 3.519 | 97 |
-| `v22_advanced_receiving` | 2.903 | -0.058 | 0.562 | 3.565 | 97 |
 | `v30_reliability_full_refit` | 2.906 | -0.543 | 0.553 | 3.602 | 97 |
 | `v27_vegas_full_refit` | 2.909 | -0.543 | 0.552 | 3.603 | 97 |
+| `v25_draft_capital_residual` | 2.910 | -0.325 | 0.559 | 3.574 | 97 |
 | `v31_depth_chart` | 2.915 | -0.609 | 0.541 | 3.649 | 97 |
-| `v23_draft_capital` | 2.963 | -0.481 | 0.540 | 3.651 | 97 |
+| `v22_advanced_receiving` | 2.922 | -0.174 | 0.552 | 3.602 | 97 |
+| `v23_draft_capital` | 2.991 | -0.282 | 0.516 | 3.745 | 97 |
 | `naive_prior_season_ppg` | 2.999 | -0.058 | 0.426 | 4.080 | 97 |
 | `position_mean_baseline` | 4.790 | +2.922 | -0.228 | 5.967 | 97 |
 
@@ -187,14 +189,14 @@ _Generated: 2026-06-10 09:15_
 | `v18_usage_level` | 2.514 | -0.536 | 0.476 | 3.136 | 127 |
 | `v30_reliability_full_refit` | 2.532 | -1.042 | 0.507 | 3.044 | 127 |
 | `v27_vegas_full_refit` | 2.536 | -1.048 | 0.505 | 3.048 | 127 |
-| `v22_advanced_receiving` | 2.543 | -0.831 | 0.497 | 3.074 | 127 |
-| `v26_vegas_residual` | 2.547 | -1.230 | 0.496 | 3.076 | 127 |
-| `v25_draft_capital_residual` | 2.559 | -1.134 | 0.499 | 3.067 | 127 |
 | `v28_reliability_weighting` | 2.567 | -0.950 | 0.488 | 3.100 | 127 |
 | `v31_depth_chart` | 2.578 | -1.106 | 0.458 | 3.189 | 127 |
-| `v23_draft_capital` | 2.584 | -1.032 | 0.488 | 3.100 | 127 |
+| `v26_vegas_residual` | 2.579 | -1.201 | 0.487 | 3.104 | 127 |
+| `v22_advanced_receiving` | 2.581 | -0.808 | 0.488 | 3.102 | 127 |
 | `v29_reliability_residual` | 2.602 | -1.194 | 0.484 | 3.114 | 127 |
+| `v25_draft_capital_residual` | 2.603 | -1.110 | 0.486 | 3.106 | 127 |
 | `v1_baseline_weighted_ppg` | 2.615 | -0.355 | 0.451 | 3.211 | 127 |
+| `v23_draft_capital` | 2.618 | -0.935 | 0.481 | 3.122 | 127 |
 | `naive_prior_season_ppg` | 2.647 | -0.357 | 0.410 | 3.329 | 127 |
 | `position_mean_baseline` | 4.085 | +2.780 | -0.336 | 5.009 | 127 |
 
@@ -224,15 +226,15 @@ _Generated: 2026-06-10 09:15_
 | `v1_baseline_weighted_ppg` | 1.761 | -0.310 | 0.553 | 2.213 | 108 |
 | `v6_usage_share` | 1.763 | -0.036 | 0.542 | 2.239 | 108 |
 | `naive_prior_season_ppg` | 1.843 | -0.181 | 0.530 | 2.269 | 108 |
-| `v25_draft_capital_residual` | 1.892 | -0.637 | 0.528 | 2.273 | 108 |
 | `v31_depth_chart` | 1.895 | -0.601 | 0.533 | 2.262 | 108 |
-| `v26_vegas_residual` | 1.914 | -0.666 | 0.526 | 2.278 | 108 |
-| `v22_advanced_receiving` | 1.918 | -0.651 | 0.514 | 2.306 | 108 |
+| `v22_advanced_receiving` | 1.920 | -0.546 | 0.508 | 2.321 | 108 |
+| `v25_draft_capital_residual` | 1.926 | -0.599 | 0.509 | 2.318 | 108 |
 | `v28_reliability_weighting` | 1.935 | -0.641 | 0.517 | 2.300 | 108 |
 | `v29_reliability_residual` | 1.940 | -0.698 | 0.517 | 2.301 | 108 |
+| `v23_draft_capital` | 1.943 | -0.604 | 0.499 | 2.343 | 108 |
+| `v26_vegas_residual` | 1.944 | -0.629 | 0.508 | 2.320 | 108 |
 | `v27_vegas_full_refit` | 1.951 | -0.674 | 0.513 | 2.310 | 108 |
 | `v30_reliability_full_refit` | 1.954 | -0.675 | 0.512 | 2.312 | 108 |
-| `v23_draft_capital` | 1.958 | -0.680 | 0.503 | 2.332 | 108 |
 | `v20_learned_usage` | 2.033 | -0.992 | 0.469 | 2.411 | 108 |
 | `position_mean_baseline` | 2.704 | +0.770 | -0.063 | 3.412 | 108 |
 
@@ -248,6 +250,7 @@ _Generated: 2026-06-10 09:15_
 | `v19_usage_level_full` | 2.594 | +0.282 | 0.621 | 3.311 | 185 |
 | `v12_no_qb_trajectory` | 2.598 | +0.453 | 0.612 | 3.352 | 185 |
 | `v14_qb_starter` | 2.599 | +0.507 | 0.616 | 3.334 | 185 |
+| `v22_advanced_receiving` | 2.599 | -0.186 | 0.616 | 3.335 | 185 |
 | `v13_qb_starter` | 2.601 | +0.445 | 0.610 | 3.361 | 185 |
 | `v17_rookie_growth` | 2.603 | +0.480 | 0.615 | 3.339 | 185 |
 | `v11_team_context_v2` | 2.604 | +0.425 | 0.606 | 3.379 | 185 |
@@ -255,20 +258,19 @@ _Generated: 2026-06-10 09:15_
 | `v8_age_regression` | 2.614 | +0.458 | 0.609 | 3.366 | 185 |
 | `v9_pos_specific` | 2.614 | +0.458 | 0.609 | 3.366 | 185 |
 | `v10_stat_efficiency_v2` | 2.616 | +0.453 | 0.611 | 3.357 | 185 |
-| `v22_advanced_receiving` | 2.643 | -0.407 | 0.608 | 3.370 | 185 |
+| `v26_vegas_residual` | 2.637 | -0.460 | 0.607 | 3.373 | 185 |
 | `v16_snap_trend_full` | 2.647 | +0.444 | 0.595 | 3.422 | 185 |
 | `v20_learned_usage` | 2.648 | -0.350 | 0.607 | 3.372 | 185 |
-| `v26_vegas_residual` | 2.650 | -0.667 | 0.606 | 3.376 | 185 |
-| `v25_draft_capital_residual` | 2.654 | -0.621 | 0.603 | 3.390 | 185 |
+| `v25_draft_capital_residual` | 2.648 | -0.415 | 0.602 | 3.394 | 185 |
 | `v3_stat_weighted` | 2.660 | +0.282 | 0.601 | 3.398 | 185 |
 | `v28_reliability_weighting` | 2.661 | -0.635 | 0.602 | 3.393 | 185 |
 | `v2_age_adjusted` | 2.663 | +0.272 | 0.599 | 3.405 | 185 |
 | `v27_vegas_full_refit` | 2.675 | -0.678 | 0.591 | 3.443 | 185 |
 | `external_fantasypros_v1` | 2.679 | +1.456 | 0.572 | 3.520 | 185 |
+| `v23_draft_capital` | 2.679 | -0.231 | 0.582 | 3.477 | 185 |
 | `v21_tiered_regression` | 2.681 | +0.711 | 0.584 | 3.471 | 185 |
 | `v30_reliability_full_refit` | 2.687 | -0.682 | 0.586 | 3.463 | 185 |
 | `v1_baseline_weighted_ppg` | 2.695 | +0.091 | 0.577 | 3.499 | 185 |
-| `v23_draft_capital` | 2.696 | -0.633 | 0.582 | 3.477 | 185 |
 | `v18_usage_level` | 2.696 | +0.047 | 0.595 | 3.425 | 185 |
 | `v29_reliability_residual` | 2.712 | -0.826 | 0.588 | 3.455 | 185 |
 | `v7_regression_to_mean` | 2.722 | +0.721 | 0.585 | 3.467 | 185 |
@@ -303,16 +305,16 @@ _Generated: 2026-06-10 09:15_
 | `v15_snap_trend` | 2.534 | -0.634 | 0.596 | 3.555 | 231 |
 | `v6_usage_share` | 2.535 | -0.359 | 0.606 | 3.511 | 231 |
 | `v18_usage_level` | 2.583 | -0.752 | 0.587 | 3.593 | 231 |
-| `v26_vegas_residual` | 2.636 | -1.096 | 0.644 | 3.337 | 231 |
 | `v20_learned_usage` | 2.647 | -0.850 | 0.646 | 3.328 | 231 |
-| `v22_advanced_receiving` | 2.656 | -0.865 | 0.642 | 3.346 | 231 |
 | `v28_reliability_weighting` | 2.664 | -0.907 | 0.644 | 3.338 | 231 |
 | `v30_reliability_full_refit` | 2.665 | -1.034 | 0.638 | 3.365 | 231 |
-| `v25_draft_capital_residual` | 2.670 | -1.046 | 0.641 | 3.351 | 231 |
 | `v27_vegas_full_refit` | 2.673 | -1.027 | 0.637 | 3.370 | 231 |
 | `v29_reliability_residual` | 2.679 | -1.075 | 0.642 | 3.347 | 231 |
+| `v26_vegas_residual` | 2.684 | -1.122 | 0.631 | 3.399 | 231 |
 | `v31_depth_chart` | 2.695 | -0.987 | 0.619 | 3.451 | 231 |
 | `v1_baseline_weighted_ppg` | 2.703 | -0.845 | 0.565 | 3.687 | 231 |
-| `v23_draft_capital` | 2.739 | -1.015 | 0.626 | 3.418 | 231 |
+| `v22_advanced_receiving` | 2.716 | -0.870 | 0.629 | 3.408 | 231 |
+| `v25_draft_capital_residual` | 2.729 | -1.071 | 0.626 | 3.419 | 231 |
+| `v23_draft_capital` | 2.792 | -0.989 | 0.610 | 3.493 | 231 |
 | `naive_prior_season_ppg` | 2.897 | -0.754 | 0.496 | 3.970 | 231 |
 | `position_mean_baseline` | 4.250 | +1.846 | 0.076 | 5.376 | 231 |

--- a/docs/generated/projection-holdout-eval.md
+++ b/docs/generated/projection-holdout-eval.md
@@ -1,46 +1,48 @@
 # Projection Held-Out Evaluation (GH #572)
 
-_Generated: 2026-06-10 09:11_
+_Generated: 2026-06-10 09:32_
 
 **Every model is evaluated out-of-sample on a shared held-out window.** Learned/residual models were retrained on **2021,2022,2023** and never saw the eval seasons **2024,2025**; additive and external models are parameter-free w.r.t. training seasons, so their existing projections are already held-out. All models are scored through the identical `backtest_model` filter (target-season games ≥ 4, true rookies excluded). Unlike [projection-accuracy.md](projection-accuracy.md), **no model here is scored on data it trained on** — this is the honest ranking. See [docs/exec-plans/projection-methodology-audit.md](../exec-plans/projection-methodology-audit.md) (Finding 1b).
 
 ## Ranking — combined held-out ALL (lower MAE = better)
 
-| Rank | Model | MAE | Bias | R² | RMSE | N |
-| --- | --- | --- | --- | --- | --- | --- |
-| 1 | `v14_qb_starter` | **2.450** | -0.149 | 0.626 | 3.251 | 647 |
-| 2 | `v19_usage_level_full` | 2.456 | -0.280 | 0.627 | 3.249 | 647 |
-| 3 | `external_fantasypros_v1` | 2.462 | +0.990 | 0.645 | 3.360 | 430 |
-| 4 | `v16_snap_trend_full` | 2.467 | -0.183 | 0.620 | 3.278 | 647 |
-| 5 | `v12_no_qb_trajectory` | 2.471 | -0.207 | 0.606 | 3.339 | 647 |
-| 6 | `v10_stat_efficiency_v2` | 2.484 | -0.231 | 0.600 | 3.364 | 647 |
-| 7 | `v13_qb_starter` | 2.484 | -0.233 | 0.598 | 3.374 | 647 |
-| 8 | `v8_age_regression` | 2.485 | -0.235 | 0.599 | 3.369 | 647 |
-| 9 | `v9_pos_specific` | 2.485 | -0.235 | 0.599 | 3.369 | 647 |
-| 10 | `v11_team_context_v2` | 2.490 | -0.258 | 0.595 | 3.386 | 647 |
-| 11 | `v17_rookie_growth` | 2.495 | -0.208 | 0.619 | 3.283 | 647 |
-| 12 | `v21_tiered_regression` | 2.498 | +0.021 | 0.601 | 3.361 | 647 |
-| 13 | `v3_stat_weighted` | 2.528 | -0.375 | 0.580 | 3.448 | 647 |
-| 14 | `v7_regression_to_mean` | 2.529 | +0.018 | 0.595 | 3.385 | 647 |
-| 15 | `v2_age_adjusted` | 2.531 | -0.389 | 0.578 | 3.454 | 647 |
-| 16 | `v15_snap_trend` | 2.560 | -0.423 | 0.570 | 3.488 | 647 |
-| 17 | `v18_usage_level` | 2.563 | -0.520 | 0.571 | 3.484 | 647 |
-| 18 | `v4_availability_adjusted` | 2.565 | +0.015 | 0.575 | 3.466 | 647 |
-| 19 | `v5_team_context` | 2.566 | -0.006 | 0.572 | 3.479 | 647 |
-| 20 | `v6_usage_share` | 2.583 | -0.137 | 0.568 | 3.495 | 647 |
-| 21 | `v1_baseline_weighted_ppg` | 2.632 | -0.652 | 0.545 | 3.588 | 647 |
-| 22 | `v31_depth_chart` | 2.646 | -1.067 | 0.586 | 3.385 | 635 |
-| 23 | `v20_learned_usage` | 2.683 | -1.060 | 0.588 | 3.377 | 635 |
-| 24 | `v27_vegas_full_refit` | 2.685 | -1.197 | 0.580 | 3.411 | 635 |
-| 25 | `v30_reliability_full_refit` | 2.687 | -1.201 | 0.579 | 3.415 | 635 |
-| 26 | `v26_vegas_residual` | 2.689 | -1.246 | 0.583 | 3.397 | 635 |
-| 27 | `v22_advanced_receiving` | 2.693 | -1.099 | 0.585 | 3.389 | 635 |
-| 28 | `v28_reliability_weighting` | 2.706 | -1.178 | 0.582 | 3.400 | 635 |
-| 29 | `v25_draft_capital_residual` | 2.710 | -1.222 | 0.581 | 3.407 | 635 |
-| 30 | `v29_reliability_residual` | 2.731 | -1.304 | 0.576 | 3.426 | 635 |
-| 31 | `v23_draft_capital` | 2.733 | -1.202 | 0.570 | 3.451 | 635 |
-| 32 | `naive_prior_season_ppg` | 2.754 | -0.428 | 0.482 | 3.861 | 667 |
-| 33 | `position_mean_baseline` | 3.710 | +0.458 | 0.218 | 4.745 | 667 |
+_**MAE** is the pooled-over-players ALL error. **Bal MAE** is the position-balanced MAE — the unweighted mean of the per-position MAEs over a fixed set (QB/RB/WR/TE; K excluded as essentially random and not projected by every model) — which neutralises the drifting position mix of the qualifier pool (GH #577). They can disagree: a model can win the pooled MAE while losing the balanced one if it's strong only where players are easy/plentiful._
+
+| Rank | Model | MAE | Bal MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `v14_qb_starter` | **2.450** | 2.653 | -0.149 | 0.626 | 3.251 | 647 |
+| 2 | `v19_usage_level_full` | 2.456 | 2.659 | -0.280 | 0.627 | 3.249 | 647 |
+| 3 | `external_fantasypros_v1` | 2.462 | **2.544** | +0.990 | 0.645 | 3.360 | 430 |
+| 4 | `v16_snap_trend_full` | 2.467 | 2.681 | -0.183 | 0.620 | 3.278 | 647 |
+| 5 | `v12_no_qb_trajectory` | 2.471 | 2.687 | -0.207 | 0.606 | 3.339 | 647 |
+| 6 | `v10_stat_efficiency_v2` | 2.484 | 2.697 | -0.231 | 0.600 | 3.364 | 647 |
+| 7 | `v13_qb_starter` | 2.484 | 2.697 | -0.233 | 0.598 | 3.374 | 647 |
+| 8 | `v8_age_regression` | 2.485 | 2.697 | -0.235 | 0.599 | 3.369 | 647 |
+| 9 | `v9_pos_specific` | 2.485 | 2.697 | -0.235 | 0.599 | 3.369 | 647 |
+| 10 | `v11_team_context_v2` | 2.490 | 2.703 | -0.258 | 0.595 | 3.386 | 647 |
+| 11 | `v17_rookie_growth` | 2.495 | 2.698 | -0.208 | 0.619 | 3.283 | 647 |
+| 12 | `v21_tiered_regression` | 2.498 | 2.702 | +0.021 | 0.601 | 3.361 | 647 |
+| 13 | `v3_stat_weighted` | 2.528 | 2.741 | -0.375 | 0.580 | 3.448 | 647 |
+| 14 | `v7_regression_to_mean` | 2.529 | 2.737 | +0.018 | 0.595 | 3.385 | 647 |
+| 15 | `v2_age_adjusted` | 2.531 | 2.744 | -0.389 | 0.578 | 3.454 | 647 |
+| 16 | `v15_snap_trend` | 2.560 | 2.783 | -0.423 | 0.570 | 3.488 | 647 |
+| 17 | `v18_usage_level` | 2.563 | 2.774 | -0.520 | 0.571 | 3.484 | 647 |
+| 18 | `v4_availability_adjusted` | 2.565 | 2.772 | +0.015 | 0.575 | 3.466 | 647 |
+| 19 | `v5_team_context` | 2.566 | 2.775 | -0.006 | 0.572 | 3.479 | 647 |
+| 20 | `v6_usage_share` | 2.583 | 2.791 | -0.137 | 0.568 | 3.495 | 647 |
+| 21 | `v1_baseline_weighted_ppg` | 2.632 | 2.853 | -0.652 | 0.545 | 3.588 | 647 |
+| 22 | `v31_depth_chart` | 2.646 | 2.839 | -1.067 | 0.586 | 3.385 | 635 |
+| 23 | `v20_learned_usage` | 2.683 | 2.866 | -1.060 | 0.588 | 3.377 | 635 |
+| 24 | `v27_vegas_full_refit` | 2.685 | 2.886 | -1.197 | 0.580 | 3.411 | 635 |
+| 25 | `v30_reliability_full_refit` | 2.687 | 2.889 | -1.201 | 0.579 | 3.415 | 635 |
+| 26 | `v28_reliability_weighting` | 2.706 | 2.885 | -1.178 | 0.582 | 3.400 | 635 |
+| 27 | `v22_advanced_receiving` | 2.714 | 2.884 | -1.044 | 0.581 | 3.408 | 635 |
+| 28 | `v26_vegas_residual` | 2.714 | 2.888 | -1.199 | 0.577 | 3.422 | 635 |
+| 29 | `v29_reliability_residual` | 2.731 | 2.916 | -1.304 | 0.576 | 3.426 | 635 |
+| 30 | `v25_draft_capital_residual` | 2.740 | 2.917 | -1.176 | 0.573 | 3.437 | 635 |
+| 31 | `v23_draft_capital` | 2.748 | 2.951 | -1.077 | 0.565 | 3.470 | 635 |
+| 32 | `naive_prior_season_ppg` | 2.754 | 3.020 | -0.428 | 0.482 | 3.861 | 667 |
+| 33 | `position_mean_baseline` | 3.710 | 4.070 | +0.458 | 0.218 | 4.745 | 667 |
 
 ## Combined across eval seasons — by position
 
@@ -73,12 +75,12 @@ _Generated: 2026-06-10 09:11_
 | `v20_learned_usage` | 2.683 | -1.060 | 0.588 | 3.377 | 635 |
 | `v27_vegas_full_refit` | 2.685 | -1.197 | 0.580 | 3.411 | 635 |
 | `v30_reliability_full_refit` | 2.687 | -1.201 | 0.579 | 3.415 | 635 |
-| `v26_vegas_residual` | 2.689 | -1.246 | 0.583 | 3.397 | 635 |
-| `v22_advanced_receiving` | 2.693 | -1.099 | 0.585 | 3.389 | 635 |
 | `v28_reliability_weighting` | 2.706 | -1.178 | 0.582 | 3.400 | 635 |
-| `v25_draft_capital_residual` | 2.710 | -1.222 | 0.581 | 3.407 | 635 |
+| `v22_advanced_receiving` | 2.714 | -1.044 | 0.581 | 3.408 | 635 |
+| `v26_vegas_residual` | 2.714 | -1.199 | 0.577 | 3.422 | 635 |
 | `v29_reliability_residual` | 2.731 | -1.304 | 0.576 | 3.426 | 635 |
-| `v23_draft_capital` | 2.733 | -1.202 | 0.570 | 3.451 | 635 |
+| `v25_draft_capital_residual` | 2.740 | -1.176 | 0.573 | 3.437 | 635 |
+| `v23_draft_capital` | 2.748 | -1.077 | 0.565 | 3.470 | 635 |
 | `naive_prior_season_ppg` | 2.754 | -0.428 | 0.482 | 3.861 | 667 |
 | `position_mean_baseline` | 3.710 | +0.458 | 0.218 | 4.745 | 667 |
 
@@ -86,17 +88,17 @@ _Generated: 2026-06-10 09:11_
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `v22_advanced_receiving` | 3.589 | -1.406 | 0.433 | 4.599 | 98 |
+| `v22_advanced_receiving` | 3.551 | -0.988 | 0.442 | 4.566 | 98 |
+| `v26_vegas_residual` | 3.611 | -1.321 | 0.416 | 4.667 | 98 |
 | `v28_reliability_weighting` | 3.613 | -1.548 | 0.424 | 4.638 | 98 |
 | `v31_depth_chart` | 3.624 | -1.582 | 0.430 | 4.613 | 98 |
 | `v20_learned_usage` | 3.626 | -1.493 | 0.426 | 4.629 | 98 |
-| `v26_vegas_residual` | 3.648 | -1.651 | 0.411 | 4.689 | 98 |
+| `v25_draft_capital_residual` | 3.657 | -1.300 | 0.410 | 4.694 | 98 |
 | `v27_vegas_full_refit` | 3.667 | -1.544 | 0.392 | 4.764 | 98 |
 | `v30_reliability_full_refit` | 3.673 | -1.577 | 0.387 | 4.783 | 98 |
-| `v25_draft_capital_residual` | 3.682 | -1.635 | 0.406 | 4.708 | 98 |
 | `external_fantasypros_v1` | 3.690 | +2.129 | 0.413 | 5.072 | 88 |
 | `v29_reliability_residual` | 3.702 | -1.776 | 0.395 | 4.752 | 98 |
-| `v23_draft_capital` | 3.735 | -1.521 | 0.386 | 4.786 | 98 |
+| `v23_draft_capital` | 3.745 | -1.045 | 0.389 | 4.776 | 98 |
 | `v14_qb_starter` | 3.783 | -0.742 | 0.443 | 4.826 | 102 |
 | `v17_rookie_growth` | 3.783 | -0.742 | 0.443 | 4.826 | 102 |
 | `v19_usage_level_full` | 3.783 | -0.742 | 0.443 | 4.826 | 102 |
@@ -148,14 +150,14 @@ _Generated: 2026-06-10 09:11_
 | `v1_baseline_weighted_ppg` | 2.806 | -0.518 | 0.561 | 3.716 | 137 |
 | `v31_depth_chart` | 2.963 | -0.978 | 0.568 | 3.656 | 135 |
 | `v20_learned_usage` | 3.101 | -1.005 | 0.533 | 3.802 | 135 |
-| `v26_vegas_residual` | 3.115 | -1.174 | 0.536 | 3.787 | 135 |
-| `v25_draft_capital_residual` | 3.150 | -1.147 | 0.533 | 3.801 | 135 |
 | `v28_reliability_weighting` | 3.154 | -1.172 | 0.533 | 3.802 | 135 |
 | `v29_reliability_residual` | 3.157 | -1.292 | 0.534 | 3.797 | 135 |
-| `v22_advanced_receiving` | 3.160 | -0.970 | 0.528 | 3.823 | 135 |
+| `v26_vegas_residual` | 3.173 | -1.236 | 0.520 | 3.855 | 135 |
 | `v27_vegas_full_refit` | 3.186 | -1.345 | 0.518 | 3.860 | 135 |
 | `v30_reliability_full_refit` | 3.191 | -1.350 | 0.517 | 3.867 | 135 |
-| `v23_draft_capital` | 3.215 | -1.294 | 0.511 | 3.888 | 135 |
+| `v25_draft_capital_residual` | 3.207 | -1.210 | 0.516 | 3.868 | 135 |
+| `v22_advanced_receiving` | 3.208 | -1.094 | 0.514 | 3.877 | 135 |
+| `v23_draft_capital` | 3.253 | -1.173 | 0.491 | 3.967 | 135 |
 | `position_mean_baseline` | 4.557 | +0.934 | 0.049 | 5.566 | 144 |
 
 ### WR
@@ -187,11 +189,11 @@ _Generated: 2026-06-10 09:11_
 | `v20_learned_usage` | 2.637 | -0.923 | 0.510 | 3.186 | 196 |
 | `v30_reliability_full_refit` | 2.689 | -1.484 | 0.490 | 3.252 | 196 |
 | `v27_vegas_full_refit` | 2.692 | -1.488 | 0.489 | 3.256 | 196 |
-| `v26_vegas_residual` | 2.727 | -1.637 | 0.475 | 3.298 | 196 |
-| `v22_advanced_receiving` | 2.736 | -1.360 | 0.476 | 3.297 | 196 |
-| `v25_draft_capital_residual` | 2.759 | -1.586 | 0.474 | 3.303 | 196 |
+| `v26_vegas_residual` | 2.749 | -1.615 | 0.470 | 3.315 | 196 |
+| `v22_advanced_receiving` | 2.769 | -1.347 | 0.468 | 3.321 | 196 |
 | `v28_reliability_weighting` | 2.771 | -1.450 | 0.462 | 3.340 | 196 |
-| `v23_draft_capital` | 2.772 | -1.507 | 0.465 | 3.331 | 196 |
+| `v23_draft_capital` | 2.780 | -1.432 | 0.468 | 3.320 | 196 |
+| `v25_draft_capital_residual` | 2.791 | -1.567 | 0.466 | 3.329 | 196 |
 | `v29_reliability_residual` | 2.800 | -1.627 | 0.459 | 3.349 | 196 |
 | `v31_depth_chart` | 2.815 | -1.514 | 0.416 | 3.478 | 196 |
 | `position_mean_baseline` | 3.770 | +0.975 | 0.056 | 4.549 | 207 |
@@ -223,14 +225,14 @@ _Generated: 2026-06-10 09:11_
 | `v6_usage_share` | 1.828 | +0.025 | 0.524 | 2.346 | 144 |
 | `naive_prior_season_ppg` | 1.864 | -0.197 | 0.490 | 2.435 | 150 |
 | `v31_depth_chart` | 1.953 | -0.658 | 0.529 | 2.322 | 142 |
-| `v25_draft_capital_residual` | 1.958 | -0.746 | 0.516 | 2.355 | 142 |
-| `v26_vegas_residual` | 1.968 | -0.743 | 0.519 | 2.348 | 142 |
-| `v22_advanced_receiving` | 1.976 | -0.755 | 0.506 | 2.379 | 142 |
 | `v27_vegas_full_refit` | 1.998 | -0.746 | 0.511 | 2.367 | 142 |
 | `v30_reliability_full_refit` | 2.001 | -0.748 | 0.511 | 2.367 | 142 |
 | `v28_reliability_weighting` | 2.003 | -0.737 | 0.509 | 2.372 | 142 |
 | `v29_reliability_residual` | 2.007 | -0.782 | 0.509 | 2.373 | 142 |
-| `v23_draft_capital` | 2.020 | -0.793 | 0.497 | 2.401 | 142 |
+| `v22_advanced_receiving` | 2.008 | -0.701 | 0.491 | 2.414 | 142 |
+| `v25_draft_capital_residual` | 2.013 | -0.743 | 0.492 | 2.412 | 142 |
+| `v26_vegas_residual` | 2.019 | -0.740 | 0.496 | 2.403 | 142 |
+| `v23_draft_capital` | 2.028 | -0.772 | 0.482 | 2.437 | 142 |
 | `v20_learned_usage` | 2.099 | -1.109 | 0.453 | 2.504 | 142 |
 | `position_mean_baseline` | 2.769 | +0.223 | 0.017 | 3.381 | 150 |
 
@@ -247,8 +249,8 @@ _Generated: 2026-06-10 09:11_
 | `v16_snap_trend_full` | 1.598 | +0.101 | -0.253 | 2.117 | 64 |
 | `v30_reliability_full_refit` | 1.625 | -0.454 | -0.208 | 2.079 | 64 |
 | `v27_vegas_full_refit` | 1.631 | -0.464 | -0.213 | 2.083 | 64 |
-| `v23_draft_capital` | 1.645 | -0.486 | -0.230 | 2.098 | 64 |
 | `v21_tiered_regression` | 1.658 | +0.230 | -0.397 | 2.235 | 64 |
+| `v23_draft_capital` | 1.659 | -0.517 | -0.241 | 2.107 | 64 |
 | `v8_age_regression` | 1.662 | +0.019 | -0.393 | 2.232 | 64 |
 | `v9_pos_specific` | 1.662 | +0.019 | -0.393 | 2.232 | 64 |
 | `v10_stat_efficiency_v2` | 1.662 | +0.019 | -0.393 | 2.232 | 64 |
@@ -263,9 +265,9 @@ _Generated: 2026-06-10 09:11_
 | `v29_reliability_residual` | 1.743 | -0.781 | -0.301 | 2.157 | 64 |
 | `v7_regression_to_mean` | 1.753 | +0.243 | -0.636 | 2.419 | 64 |
 | `v20_learned_usage` | 1.789 | -0.824 | -0.363 | 2.208 | 64 |
-| `v22_advanced_receiving` | 1.794 | -0.868 | -0.361 | 2.206 | 64 |
-| `v25_draft_capital_residual` | 1.810 | -0.693 | -0.407 | 2.243 | 64 |
-| `v26_vegas_residual` | 1.810 | -0.693 | -0.407 | 2.243 | 64 |
+| `v22_advanced_receiving` | 1.790 | -0.856 | -0.357 | 2.203 | 64 |
+| `v25_draft_capital_residual` | 1.812 | -0.677 | -0.409 | 2.245 | 64 |
+| `v26_vegas_residual` | 1.812 | -0.677 | -0.409 | 2.245 | 64 |
 | `v4_availability_adjusted` | 1.826 | +0.229 | -0.760 | 2.509 | 64 |
 | `v5_team_context` | 1.826 | +0.229 | -0.760 | 2.509 | 64 |
 | `v6_usage_share` | 1.826 | +0.229 | -0.760 | 2.509 | 64 |
@@ -287,20 +289,20 @@ _Generated: 2026-06-10 09:11_
 | `v8_age_regression` | 2.682 | +0.089 | 0.524 | 3.544 | 274 |
 | `v9_pos_specific` | 2.682 | +0.089 | 0.524 | 3.544 | 274 |
 | `v10_stat_efficiency_v2` | 2.690 | +0.090 | 0.524 | 3.542 | 274 |
+| `v22_advanced_receiving` | 2.691 | -0.675 | 0.535 | 3.462 | 271 |
 | `v20_learned_usage` | 2.712 | -0.796 | 0.531 | 3.477 | 271 |
-| `v22_advanced_receiving` | 2.728 | -0.842 | 0.525 | 3.499 | 271 |
+| `v23_draft_capital` | 2.719 | -0.659 | 0.519 | 3.522 | 271 |
 | `v2_age_adjusted` | 2.731 | -0.043 | 0.505 | 3.612 | 274 |
 | `v3_stat_weighted` | 2.732 | -0.026 | 0.507 | 3.606 | 274 |
+| `v26_vegas_residual` | 2.735 | -0.845 | 0.524 | 3.503 | 271 |
+| `v25_draft_capital_residual` | 2.739 | -0.815 | 0.521 | 3.514 | 271 |
 | `v21_tiered_regression` | 2.739 | +0.406 | 0.510 | 3.597 | 274 |
 | `v27_vegas_full_refit` | 2.745 | -0.993 | 0.513 | 3.544 | 271 |
-| `v25_draft_capital_residual` | 2.754 | -0.980 | 0.517 | 3.530 | 271 |
-| `v26_vegas_residual` | 2.754 | -1.012 | 0.519 | 3.523 | 271 |
 | `v30_reliability_full_refit` | 2.754 | -0.994 | 0.510 | 3.556 | 271 |
 | `v1_baseline_weighted_ppg` | 2.755 | -0.289 | 0.482 | 3.698 | 274 |
 | `v18_usage_level` | 2.757 | -0.199 | 0.500 | 3.631 | 274 |
 | `v15_snap_trend` | 2.764 | -0.059 | 0.497 | 3.642 | 274 |
 | `v28_reliability_weighting` | 2.765 | -1.016 | 0.513 | 3.545 | 271 |
-| `v23_draft_capital` | 2.767 | -0.976 | 0.505 | 3.573 | 271 |
 | `v7_regression_to_mean` | 2.796 | +0.362 | 0.497 | 3.643 | 274 |
 | `v29_reliability_residual` | 2.803 | -1.153 | 0.500 | 3.591 | 271 |
 | `v4_availability_adjusted` | 2.838 | +0.413 | 0.475 | 3.722 | 274 |
@@ -337,12 +339,12 @@ _Generated: 2026-06-10 09:11_
 | `naive_prior_season_ppg` | 2.603 | -0.761 | 0.522 | 3.671 | 389 |
 | `v30_reliability_full_refit` | 2.636 | -1.356 | 0.602 | 3.305 | 364 |
 | `v27_vegas_full_refit` | 2.641 | -1.349 | 0.601 | 3.308 | 364 |
-| `v26_vegas_residual` | 2.642 | -1.420 | 0.603 | 3.301 | 364 |
 | `v31_depth_chart` | 2.654 | -1.170 | 0.575 | 3.415 | 364 |
 | `v20_learned_usage` | 2.661 | -1.256 | 0.603 | 3.301 | 364 |
 | `v28_reliability_weighting` | 2.663 | -1.298 | 0.606 | 3.288 | 364 |
-| `v22_advanced_receiving` | 2.667 | -1.291 | 0.602 | 3.304 | 364 |
-| `v25_draft_capital_residual` | 2.677 | -1.403 | 0.600 | 3.312 | 364 |
 | `v29_reliability_residual` | 2.678 | -1.418 | 0.603 | 3.299 | 364 |
-| `v23_draft_capital` | 2.708 | -1.370 | 0.589 | 3.357 | 364 |
+| `v26_vegas_residual` | 2.699 | -1.462 | 0.588 | 3.361 | 364 |
+| `v22_advanced_receiving` | 2.731 | -1.318 | 0.587 | 3.366 | 364 |
+| `v25_draft_capital_residual` | 2.741 | -1.445 | 0.584 | 3.377 | 364 |
+| `v23_draft_capital` | 2.770 | -1.389 | 0.571 | 3.431 | 364 |
 | `position_mean_baseline` | 3.753 | +0.283 | 0.192 | 4.774 | 389 |

--- a/scripts/feature_projections/accuracy_report.py
+++ b/scripts/feature_projections/accuracy_report.py
@@ -336,6 +336,48 @@ def generate_markdown_table(seasons: list[int], include_leakage_section: bool = 
             lambda model_name, p=pos: _aggregate(model_name, p),
         )
 
+    # --- Position-balanced combined MAE (Finding 6 / #577) ---
+    lines.append("### Position-balanced MAE\n")
+    lines.append(
+        "_The `ALL` rows above pool positions weighted by how many cleared the games filter — "
+        "a mix that drifts season to season (QB ~3.7 MAE vs K ~1.0), so a model can look better "
+        "just by having more easy/plentiful players in the pool. **Balanced MAE** is the "
+        "unweighted mean of the per-position combined MAEs over a fixed set (QB/RB/WR/TE; K is "
+        "excluded — essentially random and not projected by every model), removing that mix "
+        "effect and keeping all models comparable. Compare against the pooled `ALL` MAE above. "
+        "(GH #577.)_\n"
+    )
+    lines.append("| Model | Balanced MAE | Pooled ALL MAE |")
+    lines.append("| --- | --- | --- |")
+
+    # K excluded — see note above and holdout_eval.BALANCED_POSITIONS.
+    balanced_positions = ("QB", "RB", "WR", "TE")
+
+    def _balanced(model_name: str) -> float | None:
+        maes = []
+        for pos in balanced_positions:
+            agg = _aggregate(model_name, pos)
+            if agg and agg.get("mae") is not None:
+                maes.append(agg["mae"])
+        return sum(maes) / len(maes) if maes else None
+
+    bal_rows = []
+    for model_name in model_names:
+        bal = _balanced(model_name)
+        all_agg = _aggregate(model_name, "ALL")
+        pooled = all_agg.get("mae") if all_agg else None
+        if bal is not None:
+            bal_rows.append((model_name, bal, pooled))
+    bal_rows.sort(key=lambda r: r[1])
+    best_bal = bal_rows[0][1] if bal_rows else None
+    for model_name, bal, pooled in bal_rows:
+        bal_str = _format_val(bal, ".3f")
+        if best_bal is not None and bal == best_bal:
+            bal_str = f"**{bal_str}**"
+        label = f"`{model_name}`" + (" _(baseline)_" if MODELS[model_name].is_baseline else "")
+        lines.append(f"| {label} | {bal_str} | {_format_val(pooled, '.3f')} |")
+    lines.append("")
+
     # --- Out-of-sample reference (Finding 1) ---
     if include_leakage_section and provenance:
         lines.append("## Out-of-Sample Reference (LOSO CV)\n")

--- a/scripts/feature_projections/availability_backtest.py
+++ b/scripts/feature_projections/availability_backtest.py
@@ -144,6 +144,25 @@ def _fmt(val, fmt: str) -> str:
         return str(val)
 
 
+# Fixed set for the balanced MAE (K excluded — essentially random and not
+# projected by every model; see holdout_eval.BALANCED_POSITIONS).
+BALANCED_POSITIONS = ("QB", "RB", "WR", "TE")
+
+
+def _balanced_mae(pos_metrics: dict) -> float | None:
+    """Position-balanced MAE: unweighted mean of per-position MAE (GH #577).
+
+    Neutralises the drifting position mix of the qualifier pool; averaged over a
+    fixed position set so all models are comparable.
+    """
+    maes = [
+        pos_metrics[p]["mae"]
+        for p in BALANCED_POSITIONS
+        if p in pos_metrics and pos_metrics[p].get("mae") is not None
+    ]
+    return sum(maes) / len(maes) if maes else None
+
+
 def run(seasons: list[int], model_names: list[str]) -> str:
     supabase = get_supabase_client()
     players_data = fetch_all_rows(supabase, "players", "id, position")
@@ -199,8 +218,13 @@ def _render(combined: dict[str, dict], seasons: list[int]) -> str:
 
     # Decomposition: rate vs availability, sorted by avail MAE.
     lines.append("## Rate vs availability decomposition (combined ALL)\n")
-    lines.append("| Model | N | Mean games | Rate MAE | Avail MAE | Availability budget | Avail bias |")
-    lines.append("| --- | --- | --- | --- | --- | --- | --- |")
+    lines.append(
+        "_**Avail MAE** is pooled over players; **Bal Avail MAE** is the position-balanced "
+        "availability MAE (unweighted mean of per-position avail MAE over QB/RB/WR/TE; K "
+        "excluded), which removes the drifting position mix of the qualifier pool (GH #577)._\n"
+    )
+    lines.append("| Model | N | Mean games | Rate MAE | Avail MAE | Bal Avail MAE | Availability budget | Avail bias |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- | --- |")
     ranked = sorted(
         (m for m in combined if combined[m]["avail"]["ALL"]),
         key=lambda m: combined[m]["avail"]["ALL"]["mae"],
@@ -209,10 +233,11 @@ def _render(combined: dict[str, dict], seasons: list[int]) -> str:
         rate = combined[name]["rate"]["ALL"]
         avail = combined[name]["avail"]["ALL"]
         budget = (avail["mae"] - rate["mae"]) if (rate and avail) else None
+        bal_avail = _balanced_mae(combined[name]["avail"])
         lines.append(
             f"| `{name}` | {_fmt(avail['player_count'], 'd')} | {_fmt(combined[name]['mean_games'], '.1f')} "
-            f"| {_fmt(rate['mae'], '.3f')} | {_fmt(avail['mae'], '.3f')} | {_fmt(budget, '+.3f')} "
-            f"| {_fmt(avail['bias'], '+.3f')} |"
+            f"| {_fmt(rate['mae'], '.3f')} | {_fmt(avail['mae'], '.3f')} | {_fmt(bal_avail, '.3f')} "
+            f"| {_fmt(budget, '+.3f')} | {_fmt(avail['bias'], '+.3f')} |"
         )
     lines.append("")
 

--- a/scripts/feature_projections/holdout_eval.py
+++ b/scripts/feature_projections/holdout_eval.py
@@ -260,6 +260,29 @@ def _fmt(val, fmt: str) -> str:
         return str(val)
 
 
+# Positions used for the balanced MAE. K is excluded: it is essentially random
+# (R² < 0 for every model) and not all models project it (FantasyPros has none),
+# so including it would add noise and break cross-model comparability.
+BALANCED_POSITIONS = ("QB", "RB", "WR", "TE")
+
+
+def _balanced_mae(pos_metrics: dict[str, dict]) -> Optional[float]:
+    """Position-balanced MAE: unweighted mean of per-position MAE (GH #577).
+
+    The pooled `ALL` MAE weights positions by how many cleared the games filter,
+    a mix that drifts season to season and lets a model look better just by
+    having more easy (low-MAE) players in the qualifier pool. Averaging the
+    per-position MAEs with equal weight over a fixed position set
+    (`BALANCED_POSITIONS`) neutralises that.
+    """
+    maes = [
+        pos_metrics[p]["mae"]
+        for p in BALANCED_POSITIONS
+        if p in pos_metrics and pos_metrics[p].get("mae") is not None
+    ]
+    return sum(maes) / len(maes) if maes else None
+
+
 def gather_predictions(
     train_seasons: list[int],
     eval_seasons: list[int],
@@ -410,20 +433,36 @@ def _render(
 
     # --- Ranking by combined ALL MAE ---
     lines.append("## Ranking — combined held-out ALL (lower MAE = better)\n")
-    lines.append("| Rank | Model | MAE | Bias | R² | RMSE | N |")
-    lines.append("| --- | --- | --- | --- | --- | --- | --- |")
+    lines.append(
+        "_**MAE** is the pooled-over-players ALL error. **Bal MAE** is the position-balanced "
+        "MAE — the unweighted mean of the per-position MAEs over a fixed set (QB/RB/WR/TE; K "
+        "excluded as essentially random and not projected by every model) — which neutralises the "
+        "drifting position mix of the qualifier pool (GH #577). They can disagree: a model can win "
+        "the pooled MAE while losing the balanced one if it's strong only where players are easy/"
+        "plentiful._\n"
+    )
+    lines.append("| Rank | Model | MAE | Bal MAE | Bias | R² | RMSE | N |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- | --- |")
     ranked = sorted(
         (m for m in combined if combined[m].get("ALL") and combined[m]["ALL"].get("mae") is not None),
         key=lambda m: combined[m]["ALL"]["mae"],
     )
     best_mae = combined[ranked[0]]["ALL"]["mae"] if ranked else None
+    best_bal = min(
+        (b for b in (_balanced_mae(combined[m]) for m in ranked) if b is not None),
+        default=None,
+    )
     for i, model_name in enumerate(ranked, 1):
         row = combined[model_name]["ALL"]
         mae_str = _fmt(row["mae"], ".3f")
         if best_mae is not None and row["mae"] == best_mae:
             mae_str = f"**{mae_str}**"
+        bal = _balanced_mae(combined[model_name])
+        bal_str = _fmt(bal, ".3f")
+        if best_bal is not None and bal == best_bal:
+            bal_str = f"**{bal_str}**"
         lines.append(
-            f"| {i} | `{model_name}` | {mae_str} | {_fmt(row['bias'], '+.3f')} "
+            f"| {i} | `{model_name}` | {mae_str} | {bal_str} | {_fmt(row['bias'], '+.3f')} "
             f"| {_fmt(row['r_squared'], '.3f')} | {_fmt(row['rmse'], '.3f')} "
             f"| {_fmt(row['player_count'], 'd')} |"
         )


### PR DESCRIPTION
Implements Finding 6 (the last evaluation-methodology finding) of the audit: the pooled `ALL` MAE weights positions by how many cleared the games filter — a mix that drifts season to season (QB ~3.7 MAE vs K ~1.0), so a model can look better just by having more easy/plentiful players in the qualifier pool.

## What
Adds a **position-balanced MAE** — the unweighted mean of per-position MAEs over a fixed **QB/RB/WR/TE** set. K is excluded: it's essentially random (R²<0 for every model) and not projected by every model (FantasyPros has none), so a fixed K-free set keeps all models comparable.

- `holdout_eval.py` / `availability_backtest.py`: new `Bal MAE` / `Bal Avail MAE` column.
- `accuracy_report.py`: new **Position-balanced MAE** ranking table in the combined section.

## Result
- On the **matched** held-out sample (same 416 players — the clean comparison), `v14` leads on **both** pooled (2.494) and balanced (2.564) MAE. The position-mix worry does not overturn the leader.
- In the **full** (unmatched) report the two disagree — `v14` wins pooled (2.450), FantasyPros wins balanced (2.544 vs 2.653) — but that flip is FP's smaller, per-position-favourable coverage (N=430 vs 647) and vanishes once players are matched. So balanced (#577) and matched (#575) are complementary guards (mix gaming vs coverage gaming); together they show `v14` robustly ahead.

The balanced headline mostly **confirms** the pooled ranking here rather than overturning it — the reassuring outcome — while making any future mix-driven illusion visible.

## Validation
- 192 tests pass (feature + architecture).
- All four reports regenerated. Fixed QB/RB/WR/TE set makes the balanced metric comparable across all models including FP.

Closes #577 — completes the six evaluation findings of the methodology audit (#571–#577).

🤖 Generated with [Claude Code](https://claude.com/claude-code)