### PR TITLE
docs: #579 negative result + re-plan projection backlog around honest findings

### DIFF
--- a/docs/exec-plans/projection-accuracy-improvement.md
+++ b/docs/exec-plans/projection-accuracy-improvement.md
@@ -95,45 +95,63 @@ New data sources and learned models. Expected: MAE < 2.3, R² > 0.60.
 
 ---
 
-## Prioritized Backlog (2026-05-05)
+## Experiment Backlog (post-audit 2026-06-10)
 
-Issue audit (2026-05-05) consolidated duplicates and ranked open work by impact × effort, weighted toward **early, season-long projection accuracy** (i.e., features knowable in the offseason are favored). Closed: #56, #58, #59, #60 (done or stale); #392 (dup of #376), #394 (dup of #378), #393 (split into #375 + #379).
+> The pre-audit backlog below this was **invalidated** by the
+> [methodology audit](projection-methodology-audit.md). Its ranking was built on
+> leaked, in-sample numbers; the held-out re-ranking inverted it (every learned
+> model `v20`–`v31` fell below the additive `v14`), and the `#579` diagnostic
+> showed recalibration can only *tie* `v14`, while adding features (`v27`) made
+> out-of-sample accuracy *worse*. So "add more features / fancier learned models"
+> is the wrong direction. The pre-audit issues (#377, #379, #381–#387, #570) are
+> **closed**. The new backlog is grounded in the honest held-out evidence and
+> every item must clear `just holdout-eval` + `just significance` (not the leaked
+> backtest).
+
+**Active model: `v14_qb_starter`** (additive — the honest out-of-sample leader).
+
+### Priority 1 — Orthogonal axis (the real opportunity)
+
+| # | Experiment | Why |
+|---|---|---|
+| [#587](https://github.com/alex-monroe/ottoneu-db/issues/587) | Availability / expected-games model | Availability is a large *unmodeled* budget (+0.633 MAE / ~20% for `v14`, Finding 3) and is **orthogonal** to rate accuracy where `v14` is near a ceiling. Highest-value direction. |
+
+### Priority 2 — Honest re-validation (cheap, high information)
+
+| # | Experiment | Why |
+|---|---|---|
+| [#588](https://github.com/alex-monroe/ottoneu-db/issues/588) | Honest feature ablation under the held-out harness | Every feature was validated on leaked data; `v27` (all features) de-biases *worse* than minimal `v20`. Prune, don't add. |
+| [#589](https://github.com/alex-monroe/ottoneu-db/issues/589) | Tune the base `weighted_ppg` against the held-out harness | `v14` ≈ base + tiny adjustments; the base does ~all the work and is the highest-leverage target. |
+
+### Priority 3 — Bounded recalibration / ranking experiments
+
+| # | Experiment | Why |
+|---|---|---|
+| [#590](https://github.com/alex-monroe/ottoneu-db/issues/590) | Delta-anchored learned model | Fixes the level-drift bias by anchoring to the per-player base; expected ceiling ≈ tie with `v14`. |
+| [#591](https://github.com/alex-monroe/ottoneu-db/issues/591) | Training-window recalibration (level-matched 2018–2020) | 2018–2020 PPG (~6.9) matches eval seasons (~7.0); wider training window may recalibrate the learned intercept. |
+| [#592](https://github.com/alex-monroe/ottoneu-db/issues/592) | QB-specific anchored model | QB is the one position where learned *beats* `v14` out-of-sample (Finding 1b). |
+
+Deferred (not in the accuracy plan): uncertainty-aware/Bayesian intervals (a separate decision-quality value prop, not point-MAE).
+
+---
+
+## Pre-audit backlog (2026-05-05) — SUPERSEDED, kept for history
+
+_The ranking and "current best" claims below are in-sample and **not valid** — see the audit. All issues here are closed._
 
 ### Tier 1 — Do first (high impact, low/medium effort)
 
 | # | Title | Effort | Why first |
 |---|---|---|---|
-| ~~[#380](https://github.com/alex-monroe/ottoneu-db/issues/380)~~ | ~~Backfill 2021 training season~~ ✅ | medium | Enabler — backfilled `player_stats` 2018–2020, added 2021 + 2025 as training seasons. v31 training set 613 → 1203 samples; combined backtest (2022–2025, N=989) ALL MAE 2.427 → 2.358, R² 0.624 → 0.645. `just train` default now `2021,2022,2023,2024,2025`. Raises the safe feature-dimension ceiling for #381/#382 |
-| ~~[#376](https://github.com/alex-monroe/ottoneu-db/issues/376)~~ | ~~NFL draft capital~~ ✅ | low | v25_draft_capital_residual: ALL MAE 2.370 (current best), R² 0.575, vet predictions byte-identical to v22 |
-| ~~[#391](https://github.com/alex-monroe/ottoneu-db/issues/391)~~ | ~~Depth chart / offseason movement~~ ✅ | medium | v31_depth_chart: ALL MAE 2.439 (vs v27 2.483), R² 0.620, RMSE 3.183. Biggest gains QB −0.126 / RB −0.203 MAE. `depth_charts` table (opening-day depth tier) from nflverse; replaces broken historical `team_context` with forward-looking role info |
-| ~~[#375](https://github.com/alex-monroe/ottoneu-db/issues/375)~~ | ~~Advanced receiving (target_share, air_yards, WOPR)~~ ✅ | low | v22_advanced_receiving: ALL MAE 2.380 (vs v20 2.412), R² 0.572, n=583 backtest seasons |
-| ~~[#378](https://github.com/alex-monroe/ottoneu-db/issues/378)~~ | ~~Vegas implied team totals~~ ✅ | low | v27_vegas_full_refit: ALL MAE 2.458 (vs v25 2.551), R² 0.582, bias −0.041. 320 (team, season) rows from nflverse; replaces broken `team_context` |
+| ~~[#380](https://github.com/alex-monroe/ottoneu-db/issues/380)~~ | ~~Backfill 2021 training season~~ ✅ | medium | Enabler — backfilled `player_stats` 2018–2020, added 2021 + 2025 as training seasons |
+| ~~[#376](https://github.com/alex-monroe/ottoneu-db/issues/376)~~ | ~~NFL draft capital~~ ✅ | low | v25_draft_capital_residual (in-sample numbers — not OOS-validated) |
+| ~~[#391](https://github.com/alex-monroe/ottoneu-db/issues/391)~~ | ~~Depth chart / offseason movement~~ ✅ | medium | v31_depth_chart (in-sample) |
+| ~~[#375](https://github.com/alex-monroe/ottoneu-db/issues/375)~~ | ~~Advanced receiving~~ ✅ | low | v22_advanced_receiving (in-sample) |
+| ~~[#378](https://github.com/alex-monroe/ottoneu-db/issues/378)~~ | ~~Vegas implied team totals~~ ✅ | low | v27_vegas_full_refit (in-sample) |
 
-### Tier 2 — Strong second wave (medium effort)
+### Tiers 2–4 (all closed post-audit)
 
-| # | Title | Effort | Notes |
-|---|---|---|---|
-| [#377](https://github.com/alex-monroe/ottoneu-db/issues/377) | Expand raw features + asymmetric regression fix | medium | Addresses +2.69 elite under-projection bias |
-| [#379](https://github.com/alex-monroe/ottoneu-db/issues/379) | Red zone usage from PBP | medium | New pipeline cost; RB/TE TD signal |
-| [#381](https://github.com/alex-monroe/ottoneu-db/issues/381) | LightGBM combiner | medium | Eliminates manual interaction terms; benefits from #380 |
-| [#382](https://github.com/alex-monroe/ottoneu-db/issues/382) | Position-specific learned models | medium | Biggest QB win; benefits from #380 |
-
-### Tier 3 — High impact but heavy
-
-| # | Title | Effort | Notes |
-|---|---|---|---|
-| [#384](https://github.com/alex-monroe/ottoneu-db/issues/384) | Injury availability model | high | 24% of error budget; two-stage modeling, possibly new data |
-| [#383](https://github.com/alex-monroe/ottoneu-db/issues/383) | Stacked ensemble | medium | Worth most after #381 + #382 land |
-
-### Tier 4 — Defer
-
-| # | Title | Effort | Notes |
-|---|---|---|---|
-| [#387](https://github.com/alex-monroe/ottoneu-db/issues/387) | Coaching/scheme change detection | high | Vegas (#378) captures most of the same signal more efficiently |
-| [#386](https://github.com/alex-monroe/ottoneu-db/issues/386) | Transfer learning weekly→season | high | Requires weekly data pipeline; high complexity |
-| [#385](https://github.com/alex-monroe/ottoneu-db/issues/385) | Bayesian hierarchical model | high | Small MAE gain; main value is decision-quality intervals |
-
-Issues are labeled `priority:p1`–`priority:p4` and `effort:low/medium/high` on GitHub.
+#377, #379, #381, #382, #383 (learned-model expansion — superseded by #588/#590/#592; learned approach only ties `v14` OOS); #384 (injury — superseded by #587); #570 (expand 2016–2020 — superseded by #591); #385/#386/#387 (deferred/closed).
 
 ---
 

--- a/docs/exec-plans/projection-methodology-audit.md
+++ b/docs/exec-plans/projection-methodology-audit.md
@@ -312,6 +312,51 @@ mix-driven illusion visible at a glance.
 
 ---
 
+## 🔬 Modeling follow-up (#579): recalibration ties `v14` but doesn't beat it — NEGATIVE RESULT
+
+Finding 1b left a 🔴 follow-up: the learned models over-project out-of-sample
+(bias −1.0 to −1.3) — recalibrate before re-promoting. A diagnostic settled it,
+and the answer is a **negative result**: recalibration alone cannot make a
+learned model beat the additive production model.
+
+**Why they over-project.** The eval population's mean PPG swings from ~9.7 in the
+training seasons (2021–2023) to ~7.0 in the held-out seasons (2024–2025) —
+partly scoring environment, largely coverage (the qualifying N nearly tripled,
+2022 N=154 → 2025 N=398, as more marginal players are tracked). A Ridge with a
+global intercept (≈ mean training PPG) plus an amplified `regression_to_mean`
+coefficient (1.46) pulling toward stale, high positional means **bakes in the
+training-season scoring level**, which doesn't transfer to the lower-mean eval
+population. The additive `v14` avoids this by anchoring each prediction to the
+player's own recency-weighted PPG (which adapts per-season) and using small fixed
+adjustment factors.
+
+**The deficit is almost entirely correctable bias — but the ceiling is a tie.**
+Held-out (train 2021–2023, eval 2024–2025):
+
+| Model | Raw MAE | Raw bias | MAE after oracle de-bias |
+|---|---|---|---|
+| `v14_qb_starter` (additive, production) | 2.450 | −0.149 | 2.437 |
+| `v20_learned_usage` | 2.683 | −1.060 | **2.465** |
+| `v27_vegas_full_refit` (all features) | 2.707 | −1.066 | 2.512 |
+
+Removing the systematic bias collapses `v20`'s gap to `v14` from 0.233 to **0.015
+— a tie**, confirming the *ranking* is fine and only the *level* was wrong. But
+even with an **oracle** de-bias (not achievable in practice), the learned models
+only **match** `v14`; they never beat it. And `v27`, with the full
+receiving/draft/Vegas feature set, de-biases *worse* than the minimal `v20`
+(2.512 vs 2.465) — extra features add no out-of-sample value.
+
+**Decision.** Keep `v14_qb_starter` in production. Pure recalibration is not
+worth shipping (best case = parity with a simpler, already-deployed model).
+Beating `v14` requires **better ranking signal or an orthogonal axis
+(availability), not calibration** — which reframes the whole projection backlog
+(see [the new experiment plan](projection-accuracy-improvement.md#experiment-backlog-post-audit-2026-06-10)).
+The leakage-free tooling built for Findings 1b/2/3/6 (`just holdout-eval`,
+`just significance`, `just availability-backtest`, `--matched`, balanced MAE) is
+now the harness every new experiment must clear.
+
+---
+
 ## What the audit found to be sound (keep doing)
 
 - **Two-stage residual design (`v25`)** — freezing the base, `fit_intercept=False`
@@ -334,7 +379,7 @@ mix-driven illusion visible at a glance.
 | 1 — train/test leakage (report honesty) | 🔴 | [#571](https://github.com/alex-monroe/ottoneu-db/issues/571) | shipped in this PR |
 | 1b — held-out evaluation window | 🔴 | [#572](https://github.com/alex-monroe/ottoneu-db/issues/572) | shipped (`just holdout-eval`); ranking inverts — see above |
 | 2 — bootstrap significance on MAE deltas | 🟠 | [#573](https://github.com/alex-monroe/ottoneu-db/issues/573) | shipped (`just significance`); see Finding 2 result |
-| (rec) recalibrate learned models before re-promotion | 🔴 | [#579](https://github.com/alex-monroe/ottoneu-db/issues/579) | open |
+| (rec) recalibrate learned models before re-promotion | 🔴 | [#579](https://github.com/alex-monroe/ottoneu-db/issues/579) | closed — NEGATIVE RESULT (recalibration ties but can't beat `v14`); backlog re-planned |
 | 3 — availability-inclusive evaluation | 🟠 | [#574](https://github.com/alex-monroe/ottoneu-db/issues/574) | shipped (`just availability-backtest`); see Finding 3 result |
 | 4 — naïve baselines + matched-sample FP | 🟠 | [#575](https://github.com/alex-monroe/ottoneu-db/issues/575) | shipped (2 baseline models + `--matched`); see Finding 4 result |
 | 5 — R² aggregation discipline | 🟡 | [#576](https://github.com/alex-monroe/ottoneu-db/issues/576) | shipped (pooled R² where possible, omitted where not) |

--- a/docs/generated/experiment-log.md
+++ b/docs/generated/experiment-log.md
@@ -2,6 +2,14 @@
 
 _Tracks every model iteration attempt to prevent re-trying failed approaches._
 
+> ⚠️ **The `ALL MAE`/`R²` columns below are in-sample for the learned models
+> (`v20`–`v31`) — they were trained on the seasons they're scored on. The
+> [methodology audit](../exec-plans/projection-methodology-audit.md) (2026-06-10)
+> re-ranked everything out-of-sample: the additive **`v14_qb_starter`** is the
+> honest best and is in production; the entire `v20`→`v31` "progression" was a
+> leakage artifact. Do not read the deltas below as real gains. New experiments
+> are validated via `just holdout-eval` + `just significance` (backlog: #587–#592).
+
 | Date | Model | Change | ALL MAE | ALL R² | ALL Bias | Verdict | PR |
 |------|-------|--------|---------|--------|----------|---------|-----|
 | 2026-01-15 | v2 | + age_curve | 2.584 | 0.499 | -0.120 | IMPROVEMENT | — |


### PR DESCRIPTION
Lands the already-pushed re-plan commit that was never PR'd (found dangling during the 2026-06-10 methodology review).

Documents the #579 modeling conclusion as a NEGATIVE RESULT (recalibration ties `v14` but can't beat it; learned over-projection is training-level drift), adds the post-audit experiment backlog (#587–#592), and stamps the in-sample warning header onto `experiment-log.md`.

- `projection-methodology-audit.md`: #579 negative-result section + tracking-table update
- `projection-accuracy-improvement.md`: new post-audit experiment backlog; pre-audit backlog kept as superseded history
- `experiment-log.md`: warning header that its numbers are in-sample

Follow-up issues from the 2026-06-10 review build on this: #594 (rolling-origin protocol), #595 (additive tuning protocol), #596 (skill/CLAUDE.md refresh), #597 (prediction cache), #598 (decision metrics), #599 (coverage drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)