### PR TITLE
feat(eval): rolling-origin protocol + player-clustered bootstrap (#594)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -123,11 +123,13 @@ train model seasons="2021,2022,2023,2024,2025":
     {{python}} scripts/feature_projections/train_model.py --model {{model}} --seasons {{seasons}}
 
 # Held-out re-rank: retrain learned models on a clean window, score all models OOS (GH #572)
+#   rolling-origin folds (#594): just holdout-eval --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
 holdout-eval *args:
     {{python}} scripts/feature_projections/holdout_eval.py {{args}}
 
-# Paired bootstrap: is the held-out MAE gap between two models significant? (GH #573)
+# Paired bootstrap (player-clustered): is the held-out MAE gap between two models significant? (GH #573, #594)
 #   e.g. just significance v14_qb_starter v31_depth_chart
+#   rolling: just significance NEW v14_qb_starter --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
 significance model_a model_b *args:
     {{python}} scripts/feature_projections/significance.py {{model_a}} {{model_b}} {{args}}
 

--- a/docs/exec-plans/projection-methodology-audit.md
+++ b/docs/exec-plans/projection-methodology-audit.md
@@ -111,6 +111,39 @@ learned model is trusted/re-promoted, fix its out-of-sample over-projection bias
 (recalibration) and re-evaluate via `just holdout-eval`, not the leaked
 backtest.
 
+### Rolling-origin protocol (`just holdout-eval --protocol rolling`, #594)
+
+The fixed single-window holdout has two weaknesses the 2026-06 review flagged:
+the same 2024–2025 window driving ≥6 planned experiments recreates the Finding 2
+multiple-comparisons problem one floor up (the window stops being held out once
+it drives many accept/reject decisions), and learned models train on only 3
+seasons vs the 5 production would use (the caveat above). Both are fixed by an
+**expanding-window (rolling-origin)** protocol:
+
+```
+just holdout-eval --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
+just significance NEW v14_qb_starter --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
+```
+
+Each eval season is scored by models retrained on *only the seasons strictly
+before it* (`train 2021,2022 → eval 2023`; `train 2021,2022,2023 → eval 2024`;
+`train 2021,2022,2023,2024 → eval 2025`). Learned models therefore get a
+growing, time-honest training window (5 seasons by the final fold); additive and
+external models need no retraining (their projections already only use
+prior-season data). The combined report rows pool every fold's player-seasons;
+the per-season tables are the individual folds.
+
+`significance.py` pools the paired errors across folds and **clusters the
+bootstrap by player** — the same player appearing in 2024 and 2025 is one
+correlated unit, not two independent rows, so the CI no longer narrows
+artificially (review Finding C). The player-cluster bootstrap is now the default
+for the fixed protocol too.
+
+**Protocol for experiments (#587–#592):** iterate against the rolling folds; the
+**final window (2025, then 2026 actuals when they arrive) is confirmation-only —
+one look per experiment.** Promotion still requires a *significant* held-out win
+over the active model (`just significance`), never a point-estimate delta.
+
 ---
 
 ## 🟠 Finding 2: backtest overfitting / multiple comparisons

--- a/scripts/feature_projections/holdout_eval.py
+++ b/scripts/feature_projections/holdout_eval.py
@@ -342,6 +342,69 @@ def gather_predictions(
     return preds, actuals_by_season, pos_map
 
 
+def rolling_folds(
+    eval_seasons: list[int], min_train_season: int
+) -> list[tuple[list[int], int]]:
+    """Expanding-window folds: each eval season trains on everything strictly before it.
+
+    For eval seasons ``[2023, 2024, 2025]`` and ``min_train_season=2021`` this
+    yields ``([2021,2022] → 2023, [2021,2022,2023] → 2024,
+    [2021,2022,2023,2024] → 2025)`` — a rolling-origin protocol (GH #594). Each
+    fold's learned models retrain on only the seasons available *at that point in
+    time*, mirroring how production would have built them, and no single eval
+    window drives every accept/reject decision.
+    """
+    folds: list[tuple[list[int], int]] = []
+    for season in sorted(set(eval_seasons)):
+        train = [s for s in range(min_train_season, season)]
+        if not train:
+            raise ValueError(
+                f"eval season {season} has no training seasons ≥ {min_train_season} before it"
+            )
+        folds.append((train, season))
+    return folds
+
+
+def gather_predictions_rolling(
+    folds: list[tuple[list[int], int]],
+    only_models: Optional[list[str]] = None,
+) -> tuple[
+    dict[str, dict[int, dict[str, float]]],
+    dict[int, dict[str, float]],
+    dict[str, str],
+    dict[int, list[int]],
+]:
+    """Run ``gather_predictions`` once per rolling fold and merge by eval season.
+
+    Each fold retrains learned models on its own (expanding) training window, so
+    a model's 2025 prediction was produced by a model that never saw 2025 — and,
+    unlike the fixed protocol, also never saw 2024 when predicting 2024. Returns
+    the same ``(preds, actuals_by_season, pos_map)`` shape as
+    ``gather_predictions`` plus a ``{eval_season: train_seasons}`` map for the
+    report header.
+    """
+    merged_preds: dict[str, dict[int, dict[str, float]]] = {}
+    merged_actuals: dict[int, dict[str, float]] = {}
+    pos_map: dict[str, str] = {}
+    fold_train: dict[int, list[int]] = {}
+
+    for train_seasons, eval_season in folds:
+        print(f"\n########## Rolling fold: train {train_seasons} → eval {eval_season} ##########")
+        preds, actuals_by_season, pmap = gather_predictions(
+            train_seasons, [eval_season], only_models
+        )
+        if pmap:
+            pos_map = pmap
+        merged_actuals[eval_season] = actuals_by_season.get(eval_season, {})
+        fold_train[eval_season] = train_seasons
+        for model_name, by_season in preds.items():
+            merged_preds.setdefault(model_name, {})[eval_season] = by_season.get(
+                eval_season, {}
+            )
+
+    return merged_preds, merged_actuals, pos_map, fold_train
+
+
 def _restrict_to_common_players(
     preds: dict[str, dict[int, dict[str, float]]],
     actuals_by_season: dict[int, dict[str, float]],
@@ -368,10 +431,22 @@ def run(
     eval_seasons: list[int],
     only_models: Optional[list[str]] = None,
     matched: bool = False,
+    protocol: str = "fixed",
+    min_train_season: Optional[int] = None,
 ) -> str:
-    preds, actuals_by_season, pos_map = gather_predictions(
-        train_seasons, eval_seasons, only_models
-    )
+    if protocol == "rolling":
+        if min_train_season is None:
+            min_train_season = min(train_seasons)
+        folds = rolling_folds(eval_seasons, min_train_season)
+        preds, actuals_by_season, pos_map, fold_train = gather_predictions_rolling(
+            folds, only_models
+        )
+        eval_seasons = [s for _, s in folds]
+    else:
+        preds, actuals_by_season, pos_map = gather_predictions(
+            train_seasons, eval_seasons, only_models
+        )
+        fold_train = {s: train_seasons for s in eval_seasons}
 
     if matched:
         actuals_by_season = _restrict_to_common_players(preds, actuals_by_season)
@@ -392,7 +467,10 @@ def run(
         for model_name, model_preds in preds.items()
     }
 
-    return _render(results, combined, train_seasons, eval_seasons, matched=matched)
+    return _render(
+        results, combined, train_seasons, eval_seasons,
+        matched=matched, protocol=protocol, fold_train=fold_train,
+    )
 
 
 def _render(
@@ -401,16 +479,37 @@ def _render(
     train_seasons: list[int],
     eval_seasons: list[int],
     matched: bool = False,
+    protocol: str = "fixed",
+    fold_train: Optional[dict[int, list[int]]] = None,
 ) -> str:
+    fold_train = fold_train or {s: train_seasons for s in eval_seasons}
     metric_cols = [("mae", "MAE", ".3f"), ("bias", "Bias", "+.3f"),
                    ("r_squared", "R²", ".3f"), ("rmse", "RMSE", ".3f"),
                    ("player_count", "N", "d")]
     report_positions = ["ALL"] + list(POSITIONS)
 
+    is_rolling = protocol == "rolling"
     lines: list[str] = []
     title_suffix = " — matched-sample (common players only)" if matched else ""
+    if is_rolling:
+        title_suffix += " — rolling-origin"
     lines.append(f"# Projection Held-Out Evaluation (GH #572){title_suffix}\n")
     lines.append(f"_Generated: {datetime.now().strftime('%Y-%m-%d %H:%M')}_\n")
+    if is_rolling:
+        fold_desc = "; ".join(
+            f"train {','.join(map(str, fold_train[s]))} → eval {s}"
+            for s in sorted(fold_train)
+        )
+        lines.append(
+            "**Rolling-origin protocol (GH #594).** Each eval season is scored by "
+            "models that trained on an *expanding window of only the seasons before it* "
+            f"— {fold_desc}. This guards the single fixed holdout against decay (no one "
+            "window drives every accept/reject decision) and removes the fixed protocol's "
+            "3-vs-5 training-season handicap on learned models. The combined rows below "
+            "pool every fold's player-seasons; the per-season tables are the individual "
+            "folds. See [docs/exec-plans/projection-methodology-audit.md]"
+            "(../exec-plans/projection-methodology-audit.md) (rolling-origin protocol).\n"
+        )
     if matched:
         lines.append(
             "**Matched-sample mode (Finding 4):** every model is scored on the *same* players "
@@ -418,18 +517,19 @@ def _render(
             "the FantasyPros comparison apples-to-apples (FP projects a smaller, more-available "
             "set), at the cost of a smaller N. Run without `--matched` for the full-coverage report.\n"
         )
-    lines.append(
-        f"**Every model is evaluated out-of-sample on a shared held-out window.** "
-        f"Learned/residual models were retrained on **{','.join(map(str, train_seasons))}** "
-        f"and never saw the eval seasons **{','.join(map(str, eval_seasons))}**; additive and "
-        f"external models are parameter-free w.r.t. training seasons, so their existing "
-        f"projections are already held-out. All models are scored through the identical "
-        f"`backtest_model` filter (target-season games ≥ {MIN_GAMES}, true rookies excluded). "
-        f"Unlike [projection-accuracy.md](projection-accuracy.md), **no model here is scored "
-        f"on data it trained on** — this is the honest ranking. See "
-        f"[docs/exec-plans/projection-methodology-audit.md](../exec-plans/projection-methodology-audit.md) "
-        f"(Finding 1b).\n"
-    )
+    if not is_rolling:
+        lines.append(
+            f"**Every model is evaluated out-of-sample on a shared held-out window.** "
+            f"Learned/residual models were retrained on **{','.join(map(str, train_seasons))}** "
+            f"and never saw the eval seasons **{','.join(map(str, eval_seasons))}**; additive and "
+            f"external models are parameter-free w.r.t. training seasons, so their existing "
+            f"projections are already held-out. All models are scored through the identical "
+            f"`backtest_model` filter (target-season games ≥ {MIN_GAMES}, true rookies excluded). "
+            f"Unlike [projection-accuracy.md](projection-accuracy.md), **no model here is scored "
+            f"on data it trained on** — this is the honest ranking. See "
+            f"[docs/exec-plans/projection-methodology-audit.md](../exec-plans/projection-methodology-audit.md) "
+            f"(Finding 1b).\n"
+        )
 
     # --- Ranking by combined ALL MAE ---
     lines.append("## Ranking — combined held-out ALL (lower MAE = better)\n")
@@ -485,9 +585,14 @@ def _render(
             lines.append(f"| `{model_name}` | " + " | ".join(cells) + " |")
         lines.append("")
 
-    # --- Per-season ALL ---
+    # --- Per-season ALL (one fold each under the rolling protocol) ---
     for season in eval_seasons:
-        lines.append(f"## Season {season} — ALL (held-out)\n")
+        fold_label = (
+            f" — fold (train {','.join(map(str, fold_train[season]))})"
+            if is_rolling and season in fold_train
+            else ""
+        )
+        lines.append(f"## Season {season} — ALL (held-out){fold_label}\n")
         lines.append("| Model | " + " | ".join(n for _, n, _ in metric_cols) + " |")
         lines.append("| " + " | ".join(["---"] * (len(metric_cols) + 1)) + " |")
         season_models = sorted(
@@ -506,9 +611,17 @@ def _render(
 def main() -> None:
     parser = argparse.ArgumentParser(description="Held-out evaluation of all projection models (#572)")
     parser.add_argument("--train-seasons", default="2021,2022,2023",
-                        help="Comma-separated training seasons (must precede eval seasons)")
+                        help="Comma-separated training seasons (fixed protocol; must precede eval seasons)")
     parser.add_argument("--eval-seasons", default="2024,2025",
-                        help="Comma-separated held-out evaluation seasons")
+                        help="Comma-separated held-out evaluation seasons "
+                             "(rolling protocol: each is one fold)")
+    parser.add_argument("--protocol", choices=("fixed", "rolling"), default="fixed",
+                        help="fixed: single train/eval split (default). "
+                             "rolling: expanding-window folds, one per eval season (#594).")
+    parser.add_argument("--min-train-season", type=int, default=None,
+                        help="Rolling protocol: earliest training season "
+                             "(default: min of --train-seasons). Each eval season trains on "
+                             "[min-train-season, eval-season).")
     parser.add_argument("--models", default=None,
                         help="Optional comma-separated subset of models (default: all)")
     parser.add_argument("--matched", action="store_true",
@@ -520,19 +633,33 @@ def main() -> None:
 
     train_seasons = [int(s) for s in args.train_seasons.split(",")]
     eval_seasons = [int(s) for s in args.eval_seasons.split(",")]
-    if set(train_seasons) & set(eval_seasons):
-        parser.error("train-seasons and eval-seasons must not overlap")
-    if max(train_seasons) >= min(eval_seasons):
-        parser.error("all train-seasons must precede all eval-seasons (no future leakage)")
+    if args.protocol == "fixed":
+        if set(train_seasons) & set(eval_seasons):
+            parser.error("train-seasons and eval-seasons must not overlap")
+        if max(train_seasons) >= min(eval_seasons):
+            parser.error("all train-seasons must precede all eval-seasons (no future leakage)")
+    else:
+        min_train = args.min_train_season if args.min_train_season is not None else min(train_seasons)
+        if min(eval_seasons) <= min_train:
+            parser.error(
+                f"rolling: every eval season must be > --min-train-season ({min_train}) "
+                "so each fold has a non-empty training window"
+            )
 
     only_models = [m.strip() for m in args.models.split(",")] if args.models else None
 
-    output = args.output or os.path.join(
-        repo_root, "docs", "generated",
-        "projection-holdout-eval-matched.md" if args.matched else "projection-holdout-eval.md",
-    )
+    if args.protocol == "rolling":
+        default_name = "projection-holdout-eval-rolling.md"
+    elif args.matched:
+        default_name = "projection-holdout-eval-matched.md"
+    else:
+        default_name = "projection-holdout-eval.md"
+    output = args.output or os.path.join(repo_root, "docs", "generated", default_name)
 
-    table = run(train_seasons, eval_seasons, only_models, matched=args.matched)
+    table = run(
+        train_seasons, eval_seasons, only_models, matched=args.matched,
+        protocol=args.protocol, min_train_season=args.min_train_season,
+    )
 
     os.makedirs(os.path.dirname(output), exist_ok=True)
     with open(output, "w") as f:

--- a/scripts/feature_projections/significance.py
+++ b/scripts/feature_projections/significance.py
@@ -29,7 +29,11 @@ from typing import Optional
 
 import numpy as np
 
-from scripts.feature_projections.holdout_eval import gather_predictions
+from scripts.feature_projections.holdout_eval import (
+    gather_predictions,
+    gather_predictions_rolling,
+    rolling_folds,
+)
 from scripts.feature_projections.model_config import get_model
 
 
@@ -58,10 +62,16 @@ def _paired_errors(
     model_a: str,
     model_b: str,
     position: str,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Per-player |error| arrays for both models over the common (paired) players."""
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Per-player |error| arrays for both models + the player id of each row.
+
+    The player ids are the bootstrap cluster labels: the same player appearing in
+    multiple eval seasons (e.g. 2024 and 2025) is correlated, not independent, so
+    the bootstrap must resample whole players, not rows (GH #594, Finding C).
+    """
     err_a: list[float] = []
     err_b: list[float] = []
+    pids: list[str] = []
     pa, pb = preds.get(model_a, {}), preds.get(model_b, {})
     for season, actuals in actuals_by_season.items():
         sa, sb = pa.get(season, {}), pb.get(season, {})
@@ -72,21 +82,30 @@ def _paired_errors(
                 continue
             err_a.append(abs(sa[pid] - actual))
             err_b.append(abs(sb[pid] - actual))
-    return np.array(err_a, dtype=np.float64), np.array(err_b, dtype=np.float64)
+            pids.append(pid)
+    return (
+        np.array(err_a, dtype=np.float64),
+        np.array(err_b, dtype=np.float64),
+        np.array(pids, dtype=object),
+    )
 
 
 def bootstrap_mae_difference(
     err_a: np.ndarray,
     err_b: np.ndarray,
+    clusters: Optional[np.ndarray] = None,
     iterations: int = 10000,
     seed: int = 0,
 ) -> dict:
     """Paired bootstrap of MAE(A) − MAE(B). Negative delta ⇒ A more accurate.
 
-    Resamples players (rows) with replacement, recomputing the paired MAE delta
-    each time. Returns observed delta, 95% CI, and a two-sided bootstrap p-value
-    (the share of resamples landing on the opposite side of zero from the
-    observed delta, doubled).
+    Resamples with replacement, recomputing the paired MAE delta each time.
+    When ``clusters`` (one player id per row) is given, resampling is **by
+    player**: the same player's multiple eval-season rows are drawn together, so
+    the CI accounts for within-player correlation instead of treating each
+    player-season as independent (GH #594, Finding C). Returns observed delta,
+    95% CI, and a two-sided bootstrap p-value (the share of resamples landing on
+    the opposite side of zero from the observed delta, doubled).
     """
     n = len(err_a)
     if n == 0:
@@ -95,9 +114,23 @@ def bootstrap_mae_difference(
     observed = float(err_a.mean() - err_b.mean())
 
     deltas = np.empty(iterations, dtype=np.float64)
-    for i in range(iterations):
-        idx = rng.integers(0, n, n)
-        deltas[i] = err_a[idx].mean() - err_b[idx].mean()
+    if clusters is not None and len(clusters):
+        # Group row indices by player; resample players, concatenating their rows.
+        groups: dict = {}
+        for i, c in enumerate(clusters):
+            groups.setdefault(c, []).append(i)
+        cluster_rows = [np.array(v, dtype=np.intp) for v in groups.values()]
+        m = len(cluster_rows)
+        for i in range(iterations):
+            chosen = rng.integers(0, m, m)
+            rows = np.concatenate([cluster_rows[j] for j in chosen])
+            deltas[i] = err_a[rows].mean() - err_b[rows].mean()
+        n_clusters = m
+    else:
+        for i in range(iterations):
+            idx = rng.integers(0, n, n)
+            deltas[i] = err_a[idx].mean() - err_b[idx].mean()
+        n_clusters = n
 
     lo, hi = np.percentile(deltas, [2.5, 97.5])
     # Two-sided bootstrap p-value: how often resamples cross to the other side of 0.
@@ -111,13 +144,14 @@ def bootstrap_mae_difference(
 
     return {
         "n": n,
+        "n_clusters": n_clusters,
         "mae_a": float(err_a.mean()),
         "mae_b": float(err_b.mean()),
         "delta": observed,
         "ci_low": float(lo),
         "ci_high": float(hi),
         "p_value": p,
-        "significant": (lo > 0) or (hi < 0),
+        "significant": bool((lo > 0) or (hi < 0)),
     }
 
 
@@ -129,25 +163,46 @@ def run(
     position: str = "ALL",
     iterations: int = 10000,
     seed: int = 0,
+    protocol: str = "fixed",
+    min_train_season: Optional[int] = None,
 ) -> dict:
     models = _expand_with_bases([model_a, model_b])
-    preds, actuals_by_season, pos_map = gather_predictions(train_seasons, eval_seasons, models)
-    err_a, err_b = _paired_errors(preds, actuals_by_season, pos_map, model_a, model_b, position)
-    res = bootstrap_mae_difference(err_a, err_b, iterations=iterations, seed=seed)
-    res.update({"model_a": model_a, "model_b": model_b, "position": position})
+    if protocol == "rolling":
+        if min_train_season is None:
+            min_train_season = min(train_seasons)
+        folds = rolling_folds(eval_seasons, min_train_season)
+        preds, actuals_by_season, pos_map, _ = gather_predictions_rolling(folds, models)
+    else:
+        preds, actuals_by_season, pos_map = gather_predictions(
+            train_seasons, eval_seasons, models
+        )
+    err_a, err_b, pids = _paired_errors(
+        preds, actuals_by_season, pos_map, model_a, model_b, position
+    )
+    res = bootstrap_mae_difference(
+        err_a, err_b, clusters=pids, iterations=iterations, seed=seed
+    )
+    res.update(
+        {"model_a": model_a, "model_b": model_b, "position": position, "protocol": protocol}
+    )
     return res
 
 
 def _print_result(res: dict, train_seasons: list[int], eval_seasons: list[int]) -> None:
     a, b = res["model_a"], res["model_b"]
+    protocol = res.get("protocol", "fixed")
     print("\n" + "=" * 72)
     print(f"Paired bootstrap — MAE({a}) − MAE({b})")
-    print(f"Held-out window: train {train_seasons} → eval {eval_seasons} | position {res['position']}")
+    if protocol == "rolling":
+        print(f"Rolling-origin: expanding-window folds → eval {eval_seasons} | position {res['position']}")
+    else:
+        print(f"Held-out window: train {train_seasons} → eval {eval_seasons} | position {res['position']}")
+    print(f"Bootstrap: player-clustered resampling ({res.get('n_clusters', '—')} unique players)")
     print("=" * 72)
     if res.get("n", 0) == 0:
         print("No paired players found — cannot test.")
         return
-    print(f"  Paired players (N): {res['n']}")
+    print(f"  Paired player-seasons (N): {res['n']}  |  unique players: {res.get('n_clusters', '—')}")
     print(f"  MAE {a}: {res['mae_a']:.4f}")
     print(f"  MAE {b}: {res['mae_b']:.4f}")
     print(f"  Observed delta (A−B): {res['delta']:+.4f}  "
@@ -167,6 +222,12 @@ def main() -> None:
     parser.add_argument("model_b")
     parser.add_argument("--train-seasons", default="2021,2022,2023")
     parser.add_argument("--eval-seasons", default="2024,2025")
+    parser.add_argument("--protocol", choices=("fixed", "rolling"), default="fixed",
+                        help="fixed: single train/eval split (default). "
+                             "rolling: expanding-window folds, pooled paired errors (#594).")
+    parser.add_argument("--min-train-season", type=int, default=None,
+                        help="Rolling protocol: earliest training season "
+                             "(default: min of --train-seasons).")
     parser.add_argument("--position", default="ALL", help="ALL | QB | RB | WR | TE | K")
     parser.add_argument("--iterations", type=int, default=10000)
     parser.add_argument("--seed", type=int, default=0)
@@ -174,14 +235,22 @@ def main() -> None:
 
     train_seasons = [int(s) for s in args.train_seasons.split(",")]
     eval_seasons = [int(s) for s in args.eval_seasons.split(",")]
-    if set(train_seasons) & set(eval_seasons):
-        parser.error("train-seasons and eval-seasons must not overlap")
-    if max(train_seasons) >= min(eval_seasons):
-        parser.error("all train-seasons must precede all eval-seasons (no future leakage)")
+    if args.protocol == "fixed":
+        if set(train_seasons) & set(eval_seasons):
+            parser.error("train-seasons and eval-seasons must not overlap")
+        if max(train_seasons) >= min(eval_seasons):
+            parser.error("all train-seasons must precede all eval-seasons (no future leakage)")
+    else:
+        min_train = args.min_train_season if args.min_train_season is not None else min(train_seasons)
+        if min(eval_seasons) <= min_train:
+            parser.error(
+                f"rolling: every eval season must be > --min-train-season ({min_train})"
+            )
 
     res = run(
         args.model_a, args.model_b, train_seasons, eval_seasons,
         position=args.position, iterations=args.iterations, seed=args.seed,
+        protocol=args.protocol, min_train_season=args.min_train_season,
     )
     _print_result(res, train_seasons, eval_seasons)
 

--- a/scripts/tests/test_holdout_eval.py
+++ b/scripts/tests/test_holdout_eval.py
@@ -1,0 +1,70 @@
+"""Tests for the rolling-origin protocol + player-clustered bootstrap (GH #594).
+
+Exercises the pure, deterministic core that needs no DB access: the
+expanding-window fold generator and the cluster bootstrap's resampling unit.
+"""
+
+import numpy as np
+import pytest
+
+from scripts.feature_projections.holdout_eval import rolling_folds
+from scripts.feature_projections.significance import bootstrap_mae_difference
+
+
+class TestRollingFolds:
+    def test_expanding_window(self):
+        folds = rolling_folds([2023, 2024, 2025], min_train_season=2021)
+        assert folds == [
+            ([2021, 2022], 2023),
+            ([2021, 2022, 2023], 2024),
+            ([2021, 2022, 2023, 2024], 2025),
+        ]
+
+    def test_each_train_window_precedes_its_eval(self):
+        for train, ev in rolling_folds([2023, 2024, 2025], 2018):
+            assert max(train) < ev
+            assert min(train) == 2018
+
+    def test_unsorted_input_is_sorted(self):
+        folds = rolling_folds([2025, 2023, 2024], 2022)
+        assert [ev for _, ev in folds] == [2023, 2024, 2025]
+
+    def test_empty_training_window_raises(self):
+        # eval 2021 with min_train_season 2021 leaves no prior seasons to train on.
+        with pytest.raises(ValueError):
+            rolling_folds([2021], min_train_season=2021)
+
+
+class TestClusterBootstrap:
+    def test_clustering_widens_ci_vs_independent(self):
+        # Two players, each appearing in two eval seasons with identical errors:
+        # model A always beats model B by 1.0. Independent resampling sees 4 "rows";
+        # clustered resampling correctly sees only 2 independent units, so its CI
+        # must be at least as wide (fewer effective samples ⇒ more uncertainty).
+        err_a = np.array([1.0, 1.0, 3.0, 3.0])
+        err_b = np.array([2.0, 2.0, 4.0, 4.0])
+        clusters = np.array(["p1", "p1", "p2", "p2"], dtype=object)
+
+        indep = bootstrap_mae_difference(err_a, err_b, clusters=None, iterations=2000, seed=1)
+        clust = bootstrap_mae_difference(err_a, err_b, clusters=clusters, iterations=2000, seed=1)
+
+        assert indep["n_clusters"] == 4
+        assert clust["n_clusters"] == 2
+        # Same point estimate, wider (or equal) interval under clustering.
+        assert clust["delta"] == pytest.approx(indep["delta"])
+        clust_width = clust["ci_high"] - clust["ci_low"]
+        indep_width = indep["ci_high"] - indep["ci_low"]
+        assert clust_width >= indep_width
+
+    def test_empty_input(self):
+        res = bootstrap_mae_difference(np.array([]), np.array([]))
+        assert res == {"n": 0}
+
+    def test_observed_delta_sign(self):
+        err_a = np.array([1.0, 1.0, 1.0])
+        err_b = np.array([2.0, 2.0, 2.0])
+        clusters = np.array(["a", "b", "c"], dtype=object)
+        res = bootstrap_mae_difference(err_a, err_b, clusters=clusters, iterations=500, seed=0)
+        # A's errors are smaller ⇒ delta (A−B) negative ⇒ A more accurate.
+        assert res["delta"] < 0
+        assert res["significant"] is True


### PR DESCRIPTION
Closes #594 (Wave 1 of the 2026-06 projection-system review).

## Problem
The honest harness uses a single fixed holdout (train 2021–2023, eval 2024–2025). The post-audit backlog plans ≥6 experiments, each iterated against that same window — recreating the Finding 2 multiple-comparisons problem one level up: the holdout stops being held out once it drives many accept/reject decisions. A second distortion: learned models train on only 3 seasons while production would use 5, understating their capacity. A third (Finding C): the bootstrap treats the same player's 2024 and 2025 rows as independent, narrowing the CI.

## Changes
- **`holdout_eval.py`** — `--protocol rolling` with expanding-window folds (`train ≤2022 → 2023`, `train ≤2023 → 2024`, `train ≤2024 → 2025`). Learned models retrain per fold in the existing temp-dir sandbox; additive/external models need no retrain. Pooled + per-fold report, rolling-aware header, writes `projection-holdout-eval-rolling.md`. New `--min-train-season`.
- **`significance.py`** — pools paired errors across folds and **cluster-resamples the bootstrap by player**. Clustered bootstrap is now the default for the fixed protocol too. Output reports unique-player count vs player-seasons.
- **Docs** — rolling-origin protocol + the confirmation-only final-window rule documented in `projection-methodology-audit.md`; justfile recipe hints updated.
- **Tests** — `scripts/tests/test_holdout_eval.py` covers fold generation and the cluster bootstrap (no DB).

## Verification
`just holdout-eval --protocol rolling --eval-seasons 2024,2025 --min-train-season 2021 --models v14_qb_starter,naive_prior_season_ppg,v20_learned_usage` ranks v14 first (pooled MAE 2.450) with v20 now trained on 4 seasons for the 2025 fold. `just significance v14_qb_starter v20_learned_usage --protocol rolling …` reports 635 player-seasons → 402 unique players, v14 significantly better (CI [-0.29, -0.10]). 27 python tests pass; arch checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)