### PR TITLE
feat(eval): held-out prediction cache (#597)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Python / Backend
 venv/
+.cache/
 __pycache__/
 *.py[cod]
 *$py.class

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -120,7 +120,18 @@ just promote <model>                                # Promote model to productio
 just compare <models> [season]                      # Compare two or more models
 just diagnostics [--model <m>] [--season <s>] ...  # Per-player diagnostics
 just segment-analysis [--segments <s>] ...          # Segmented accuracy analysis
-just accuracy-report [--run-backtest] ...           # Generate accuracy report
+just accuracy-report [--run-backtest] ...           # Generate accuracy report (in-sample diagnostic)
+
+# Honest (leakage-free) evaluation harness — the gate for any projection change
+just holdout-eval [--protocol rolling] [--eval-seasons ...] [--min-train-season Y] [--models ...] [--matched] [--no-cache]
+                                                    # Re-rank all models out-of-sample (GH #572, #594)
+just significance <model_a> <model_b> [--protocol rolling] [--eval-seasons ...] [--no-cache]
+                                                    # Player-clustered paired bootstrap of the MAE gap (GH #573, #594)
+just availability-backtest [...]                    # Availability-inclusive backtest (rate vs availability budget, GH #574)
+# Held-out predictions are cached under .cache/holdout/, keyed on (model, train window, eval window,
+# model-definition fingerprint), so a second holdout-eval/significance run skips retraining (GH #597).
+# Editing a model's definition or any feature code invalidates the affected entries automatically;
+# pass --no-cache to force a full retrain.
 
 # Backfills / seeds
 just backfill-nfl-stats [--seasons ...] [--dry-run]    # Backfill nfl_stats from nflverse

--- a/scripts/feature_projections/holdout_cache.py
+++ b/scripts/feature_projections/holdout_cache.py
@@ -1,0 +1,131 @@
+"""On-disk cache for held-out learned/residual predictions (GH #597).
+
+``holdout_eval.gather_predictions`` retrains every learned/residual model from
+scratch (plus full DB fetches + feature computation) on every invocation, and
+``significance.py`` calls it once per pair. That makes the honest workflow much
+slower than the leaked ``accuracy-report`` flow it must replace — a friction tax
+that pushes agents back toward the in-sample shortcut. With the rolling protocol
+(#594) multiplying folds, it gets worse.
+
+This module caches a learned model's held-out output per
+``(model_name, train_window, eval_window, model-definition fingerprint)``. The
+fingerprint hashes the model's definition *chain* (its own + every base it
+depends on: features, interactions, combiner type, base chain, training filter)
+plus a global feature-code version (the hash of the feature modules + the
+training/combiner code). Editing a model's definition — or any feature code —
+invalidates only the affected entries; everything else is reused.
+
+The cached payload stores both the trained ``params`` (so a dependent residual
+can still load its base from the sandbox on a cache hit) and the per-season
+``preds`` ``{season: {player_id: projected_ppg}}``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+from scripts.feature_projections.model_config import get_model
+
+_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+CACHE_DIR = Path(_repo_root) / ".cache" / "holdout"
+
+# Source files whose contents define how a learned model is trained / how its
+# features are computed. Any edit here conservatively invalidates the whole
+# cache (the predictions could change), which is the safe default.
+_FEATURE_DIR = Path(os.path.dirname(os.path.abspath(__file__))) / "features"
+_CODE_FILES = [
+    Path(os.path.dirname(os.path.abspath(__file__))) / "train_model.py",
+    Path(os.path.dirname(os.path.abspath(__file__))) / "learned_combiner.py",
+    Path(os.path.dirname(os.path.abspath(__file__))) / "combiner.py",
+]
+
+_feature_code_version_cache: Optional[str] = None
+
+
+def feature_code_version() -> str:
+    """Hash the feature modules + training/combiner code (memoized per process)."""
+    global _feature_code_version_cache
+    if _feature_code_version_cache is not None:
+        return _feature_code_version_cache
+    h = hashlib.sha256()
+    files = sorted(_FEATURE_DIR.glob("*.py")) + _CODE_FILES
+    for f in files:
+        try:
+            h.update(f.read_bytes())
+        except OSError:
+            h.update(f"missing:{f.name}".encode())
+    _feature_code_version_cache = h.hexdigest()[:16]
+    return _feature_code_version_cache
+
+
+def _definition_chain(model_name: str) -> list:
+    """Serializable definition of a model and every base it depends on."""
+    chain: list = []
+    cur: Optional[str] = model_name
+    seen: set = set()
+    while cur and cur not in seen:
+        seen.add(cur)
+        m = get_model(cur)
+        chain.append(
+            {
+                "name": cur,
+                "features": list(m.features),
+                "interaction_terms": list(m.interaction_terms),
+                "combiner_type": m.combiner_type,
+                "base_model_name": m.base_model_name,
+                "training_filter": dict(m.training_filter),
+            }
+        )
+        cur = m.base_model_name
+    return chain
+
+
+def model_fingerprint(model_name: str) -> str:
+    """Stable hash of a model's definition chain + the feature-code version."""
+    payload = json.dumps(
+        {"chain": _definition_chain(model_name), "code": feature_code_version()},
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def _cache_path(model_name: str, train_seasons: list, eval_seasons: list) -> Path:
+    train = "-".join(str(s) for s in sorted(train_seasons))
+    ev = "-".join(str(s) for s in sorted(eval_seasons))
+    fp = model_fingerprint(model_name)
+    return CACHE_DIR / f"{model_name}__train{train}__eval{ev}__{fp}.json"
+
+
+def load(
+    model_name: str, train_seasons: list, eval_seasons: list
+) -> Optional[dict]:
+    """Return ``{"params": ..., "preds": {season:int -> {pid: ppg}}}`` or None."""
+    path = _cache_path(model_name, train_seasons, eval_seasons)
+    if not path.exists():
+        return None
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    preds = {int(s): v for s, v in raw.get("preds", {}).items()}
+    return {"params": raw.get("params"), "preds": preds}
+
+
+def store(
+    model_name: str,
+    train_seasons: list,
+    eval_seasons: list,
+    params: dict,
+    preds: dict,
+) -> None:
+    """Persist a model's held-out params + per-season predictions."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _cache_path(model_name, train_seasons, eval_seasons)
+    payload = {"params": params, "preds": {str(s): v for s, v in preds.items()}}
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload))
+    tmp.replace(path)

--- a/scripts/feature_projections/holdout_eval.py
+++ b/scripts/feature_projections/holdout_eval.py
@@ -44,7 +44,7 @@ from typing import Optional
 import pandas as pd
 
 from scripts.config import get_supabase_client, fetch_all_rows, POSITIONS, MIN_GAMES
-from scripts.feature_projections import learned_combiner
+from scripts.feature_projections import holdout_cache, learned_combiner
 from scripts.feature_projections.learned_combiner import predict, predict_residual
 from scripts.feature_projections.model_config import MODELS, get_model
 from scripts.feature_projections.backtest import (
@@ -137,11 +137,12 @@ def _learned_preds_for_eval(
     train_seasons: list[int],
     eval_seasons: list[int],
     temp_dir: Path,
-) -> dict[int, dict[str, float]]:
+) -> tuple[dict[int, dict[str, float]], Optional[dict]]:
     """Retrain a learned/residual model on train_seasons; predict eval_seasons.
 
-    Returns {season: {player_id: predicted_ppg}}. Saves the held-out params to
-    temp_dir so dependent residual models can load this as their base.
+    Returns ``({season: {player_id: predicted_ppg}}, params)``. Saves the
+    held-out params to temp_dir so dependent residual models can load this as
+    their base; the returned params are also persisted to the prediction cache.
     """
     # Imported here so the monkeypatched TRAINED_MODELS_DIR is in effect when
     # train_ridge_residual calls load_model_params.
@@ -155,12 +156,12 @@ def _learned_preds_for_eval(
     td = collect_training_data(model_name, train_seasons + eval_seasons)
     if td.empty:
         print(f"  {model_name}: no training data, skipping")
-        return {}
+        return {}, None
 
     train_df = td[td["season"].isin(train_seasons)]
     if train_df.empty:
         print(f"  {model_name}: no rows in training window {train_seasons}, skipping")
-        return {}
+        return {}, None
 
     is_residual = model_def.combiner_type == "residual"
     if is_residual:
@@ -192,7 +193,7 @@ def _learned_preds_for_eval(
             if pred is not None:
                 season_preds[str(r["player_id"])] = float(pred)
         preds_by_season[season] = season_preds
-    return preds_by_season
+    return preds_by_season, params
 
 
 def _db_preds_for_eval(
@@ -287,6 +288,7 @@ def gather_predictions(
     train_seasons: list[int],
     eval_seasons: list[int],
     only_models: Optional[list[str]] = None,
+    use_cache: bool = True,
 ) -> tuple[dict[str, dict[int, dict[str, float]]], dict[int, dict[str, float]], dict[str, str]]:
     """Produce held-out predictions for every model on the eval seasons.
 
@@ -295,6 +297,10 @@ def gather_predictions(
     models are retrained on train_seasons in a sandboxed temp dir; parameter-free
     models are read from their already-held-out model_projections. This is the
     shared machinery behind both the held-out report and the significance test.
+
+    Learned/residual predictions are cached per (model, train window, eval
+    window, model-definition fingerprint) under ``.cache/holdout`` (GH #597), so
+    a second invocation skips retraining. ``use_cache=False`` forces a retrain.
     """
     supabase = get_supabase_client()
 
@@ -329,12 +335,25 @@ def gather_predictions(
     learned_combiner.TRAINED_MODELS_DIR = temp_dir
     try:
         for model_name in _dependency_order(learned):
+            cached = holdout_cache.load(model_name, train_seasons, eval_seasons) if use_cache else None
+            if cached is not None:
+                print(f"\n=== Held-out cache hit: {model_name} (train {train_seasons}) ===")
+                # Re-materialize params so a dependent residual can load this base.
+                if cached.get("params") is not None:
+                    (temp_dir / f"{model_name}.json").write_text(json.dumps(cached["params"]))
+                if cached["preds"]:
+                    preds[model_name] = cached["preds"]
+                continue
             print(f"\n=== Held-out retrain: {model_name} (train {train_seasons}) ===")
-            preds_by_season = _learned_preds_for_eval(
+            preds_by_season, params = _learned_preds_for_eval(
                 model_name, train_seasons, eval_seasons, temp_dir
             )
             if preds_by_season:
                 preds[model_name] = preds_by_season
+                if use_cache and params is not None:
+                    holdout_cache.store(
+                        model_name, train_seasons, eval_seasons, params, preds_by_season
+                    )
     finally:
         learned_combiner.TRAINED_MODELS_DIR = orig_dir
         shutil.rmtree(temp_dir, ignore_errors=True)
@@ -368,6 +387,7 @@ def rolling_folds(
 def gather_predictions_rolling(
     folds: list[tuple[list[int], int]],
     only_models: Optional[list[str]] = None,
+    use_cache: bool = True,
 ) -> tuple[
     dict[str, dict[int, dict[str, float]]],
     dict[int, dict[str, float]],
@@ -391,7 +411,7 @@ def gather_predictions_rolling(
     for train_seasons, eval_season in folds:
         print(f"\n########## Rolling fold: train {train_seasons} → eval {eval_season} ##########")
         preds, actuals_by_season, pmap = gather_predictions(
-            train_seasons, [eval_season], only_models
+            train_seasons, [eval_season], only_models, use_cache=use_cache
         )
         if pmap:
             pos_map = pmap
@@ -433,18 +453,19 @@ def run(
     matched: bool = False,
     protocol: str = "fixed",
     min_train_season: Optional[int] = None,
+    use_cache: bool = True,
 ) -> str:
     if protocol == "rolling":
         if min_train_season is None:
             min_train_season = min(train_seasons)
         folds = rolling_folds(eval_seasons, min_train_season)
         preds, actuals_by_season, pos_map, fold_train = gather_predictions_rolling(
-            folds, only_models
+            folds, only_models, use_cache=use_cache
         )
         eval_seasons = [s for _, s in folds]
     else:
         preds, actuals_by_season, pos_map = gather_predictions(
-            train_seasons, eval_seasons, only_models
+            train_seasons, eval_seasons, only_models, use_cache=use_cache
         )
         fold_train = {s: train_seasons for s in eval_seasons}
 
@@ -628,6 +649,8 @@ def main() -> None:
                         help="Matched-sample mode: score all models on the common player set "
                              "(apples-to-apples FantasyPros comparison, #575). Writes to a "
                              "-matched output path unless --output is given.")
+    parser.add_argument("--no-cache", action="store_true",
+                        help="Force a retrain instead of reusing cached held-out predictions (#597).")
     parser.add_argument("--output", default=None)
     args = parser.parse_args()
 
@@ -659,6 +682,7 @@ def main() -> None:
     table = run(
         train_seasons, eval_seasons, only_models, matched=args.matched,
         protocol=args.protocol, min_train_season=args.min_train_season,
+        use_cache=not args.no_cache,
     )
 
     os.makedirs(os.path.dirname(output), exist_ok=True)

--- a/scripts/feature_projections/significance.py
+++ b/scripts/feature_projections/significance.py
@@ -165,16 +165,19 @@ def run(
     seed: int = 0,
     protocol: str = "fixed",
     min_train_season: Optional[int] = None,
+    use_cache: bool = True,
 ) -> dict:
     models = _expand_with_bases([model_a, model_b])
     if protocol == "rolling":
         if min_train_season is None:
             min_train_season = min(train_seasons)
         folds = rolling_folds(eval_seasons, min_train_season)
-        preds, actuals_by_season, pos_map, _ = gather_predictions_rolling(folds, models)
+        preds, actuals_by_season, pos_map, _ = gather_predictions_rolling(
+            folds, models, use_cache=use_cache
+        )
     else:
         preds, actuals_by_season, pos_map = gather_predictions(
-            train_seasons, eval_seasons, models
+            train_seasons, eval_seasons, models, use_cache=use_cache
         )
     err_a, err_b, pids = _paired_errors(
         preds, actuals_by_season, pos_map, model_a, model_b, position
@@ -231,6 +234,8 @@ def main() -> None:
     parser.add_argument("--position", default="ALL", help="ALL | QB | RB | WR | TE | K")
     parser.add_argument("--iterations", type=int, default=10000)
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--no-cache", action="store_true",
+                        help="Force a retrain instead of reusing cached held-out predictions (#597).")
     args = parser.parse_args()
 
     train_seasons = [int(s) for s in args.train_seasons.split(",")]
@@ -251,6 +256,7 @@ def main() -> None:
         args.model_a, args.model_b, train_seasons, eval_seasons,
         position=args.position, iterations=args.iterations, seed=args.seed,
         protocol=args.protocol, min_train_season=args.min_train_season,
+        use_cache=not args.no_cache,
     )
     _print_result(res, train_seasons, eval_seasons)
 

--- a/scripts/tests/test_holdout_eval.py
+++ b/scripts/tests/test_holdout_eval.py
@@ -7,6 +7,7 @@ expanding-window fold generator and the cluster bootstrap's resampling unit.
 import numpy as np
 import pytest
 
+from scripts.feature_projections import holdout_cache
 from scripts.feature_projections.holdout_eval import rolling_folds
 from scripts.feature_projections.significance import bootstrap_mae_difference
 
@@ -68,3 +69,36 @@ class TestClusterBootstrap:
         # A's errors are smaller ⇒ delta (A−B) negative ⇒ A more accurate.
         assert res["delta"] < 0
         assert res["significant"] is True
+
+
+class TestHoldoutCache:
+    def test_fingerprint_stable(self):
+        fp1 = holdout_cache.model_fingerprint("v14_qb_starter")
+        fp2 = holdout_cache.model_fingerprint("v14_qb_starter")
+        assert fp1 == fp2 and len(fp1) == 16
+
+    def test_fingerprint_differs_between_models(self):
+        assert holdout_cache.model_fingerprint("v14_qb_starter") != holdout_cache.model_fingerprint(
+            "v20_learned_usage"
+        )
+
+    def test_round_trip(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(holdout_cache, "CACHE_DIR", tmp_path / "holdout")
+        model = "v20_learned_usage"
+        train, ev = [2021, 2022, 2023], [2024]
+        assert holdout_cache.load(model, train, ev) is None
+        params = {"intercept": 1.0, "coefs": {"weighted_ppg": 0.9}}
+        preds = {2024: {"p1": 12.3, "p2": 8.1}}
+        holdout_cache.store(model, train, ev, params, preds)
+        got = holdout_cache.load(model, train, ev)
+        assert got["params"] == params
+        # Seasons round-trip back to ints (JSON keys are strings on disk).
+        assert got["preds"] == preds
+
+    def test_eval_window_keys_distinctly(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(holdout_cache, "CACHE_DIR", tmp_path / "holdout")
+        model = "v20_learned_usage"
+        holdout_cache.store(model, [2021], [2024], {"a": 1}, {2024: {"p": 1.0}})
+        # Different eval window ⇒ separate cache entry (miss).
+        assert holdout_cache.load(model, [2021], [2025]) is None
+        assert holdout_cache.load(model, [2021], [2024]) is not None


### PR DESCRIPTION
Closes #597 (Wave 1 of the 2026-06 projection-system review). Rebased onto `main` now that #594 has merged.

## Problem
`holdout_eval.gather_predictions` retrains every learned/residual model from scratch (plus full DB fetches + feature computation) on every invocation, and `significance.py` calls it once per pair. The honest workflow is therefore much slower than the leaked `accuracy-report` flow it must replace — a friction tax that pushes agents back toward the in-sample shortcut, and worse under the rolling protocol (#594) that multiplies folds.

## Changes
- **`holdout_cache.py`** (new) — caches held-out predictions per `(model_name, train_window, eval_window, model-definition fingerprint)` under `.cache/holdout/*.json`. Fingerprint = hash of the model's definition chain (its own + every base it depends on) + a global feature-code version (hash of the feature modules + train/combiner code). Editing a model's definition or any feature code invalidates only the affected entries.
- **`holdout_eval.py`** — `gather_predictions` reads through the cache and stores `params + per-season preds`. On a cache hit it re-materializes the base's params into the sandbox temp dir, so a dependent residual that is a *miss* can still train against a *hit* base. `--no-cache` forces a retrain.
- **`significance.py`** — threads `--no-cache` / `use_cache`.
- `.cache/` gitignored; cache + the (previously undocumented) honest-harness recipes documented in `COMMANDS.md`.
- Tests: fingerprint stability/uniqueness, cache round-trip, eval-window keying.

## Verification
Cold `significance` run **34s → 3s warm**, identical SIGNIFICANT verdict. Mixed hit/miss residual chain (base `v22` hit, dependent `v25` miss) retrains correctly with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)