### PR TITLE
feat(eval): honest tuning protocol for additive hyperparameters (#595)

### DIFF
--- a/docs/exec-plans/projection-accuracy-improvement.md
+++ b/docs/exec-plans/projection-accuracy-improvement.md
@@ -121,7 +121,7 @@ New data sources and learned models. Expected: MAE < 2.3, R² > 0.60.
 | # | Experiment | Why |
 |---|---|---|
 | [#588](https://github.com/alex-monroe/ottoneu-db/issues/588) | Honest feature ablation under the held-out harness | Every feature was validated on leaked data; `v27` (all features) de-biases *worse* than minimal `v20`. Prune, don't add. |
-| [#589](https://github.com/alex-monroe/ottoneu-db/issues/589) | Tune the base `weighted_ppg` against the held-out harness | `v14` ≈ base + tiny adjustments; the base does ~all the work and is the highest-leverage target. |
+| [#589](https://github.com/alex-monroe/ottoneu-db/issues/589) **(blocked on [#595](https://github.com/alex-monroe/ottoneu-db/issues/595))** | Tune the base `weighted_ppg` — on the **inner folds**, confirm once on the held-out window | `v14` ≈ base + tiny adjustments; the base does ~all the work and is the highest-leverage target. Must use the honest tuning protocol (`tuning_protocol.py`) — tuning directly on the held-out window would burn it (Finding A). |
 
 ### Priority 3 — Bounded recalibration / ranking experiments
 

--- a/docs/exec-plans/projection-methodology-audit.md
+++ b/docs/exec-plans/projection-methodology-audit.md
@@ -144,6 +144,35 @@ for the fixed protocol too.
 one look per experiment.** Promotion still requires a *significant* held-out win
 over the active model (`just significance`), never a point-estimate delta.
 
+### Honest hyperparameter-tuning protocol (`tuning_protocol.py`, #595)
+
+Finding 1 caught the *learned* models training on the seasons they were scored
+on. The *additive* models have a milder version of the same leak one floor up:
+their hyperparameters were chosen by grid search whose default `--seasons`
+included the 2024–2025 holdout — `tune_age_curve.py` (#272 age-curve params),
+`sweep_recency_weights.py` (#271 recency weights), and `sweep_feature_combos.py`
+all defaulted to `2022,2023,2024,2025`. The headline conclusion (v14 ≫ learned,
+Δ=0.263, CI excludes 0) is structural and survives this, but the *within-additive*
+ranking (v14 vs v19 at Δ=0.006, not significant) is inside the tuning noise.
+
+The remedy is an inner/outer split that mirrors the rolling protocol:
+
+- **Inner (tuning) seasons** (`INNER_TUNING_SEASONS = 2022,2023,2024`) — grid
+  search runs *only* here. The three tuning scripts now default to these.
+- **Confirmation window** (`CONFIRMATION_SEASONS = 2025`) — held back for a
+  single confirmatory look per *accepted* variant. Pointing a tuning script at
+  it prints a loud warning (`warn_on_confirmation_overlap`).
+
+This is a prerequisite for **#589** (tune the base `weighted_ppg`), which as
+originally written — "tune against the held-out harness" — would tune directly
+on the final window and burn it. #589 is **blocked on #595** and must run grid
+search on the inner folds, confirming once on 2025.
+
+*One-look re-check (deferred):* whether v14's current tuned params still beat
+their pre-tuning defaults on the confirmation window is itself a confirmation-
+window look. Rather than spend it on archaeology, it is folded into #589's single
+confirmatory evaluation when the base is next tuned under this protocol.
+
 ---
 
 ## 🟠 Finding 2: backtest overfitting / multiple comparisons

--- a/scripts/feature_projections/sweep_feature_combos.py
+++ b/scripts/feature_projections/sweep_feature_combos.py
@@ -4,8 +4,12 @@ Tests all 2^6 = 64 combinations of the 6 adjustment features on top of the
 base weighted_ppg feature. Computes in-memory projections and backtest metrics
 to rank every combination by weighted-average MAE across seasons.
 
+Tuning defaults to the **inner folds** (2022,2023,2024); the confirmation window
+(2025) is held back for a single confirmatory look per accepted variant (honest
+tuning protocol, GH #595).
+
 Usage:
-    python scripts/feature_projections/sweep_feature_combos.py [--seasons 2024,2025]
+    python scripts/feature_projections/sweep_feature_combos.py [--seasons 2022,2023,2024]
 """
 
 from __future__ import annotations
@@ -19,6 +23,10 @@ import pandas as pd
 
 from scripts.config import get_supabase_client, fetch_all_rows, POSITIONS, MIN_GAMES
 from scripts.analysis_utils import fetch_multi_season_stats, fetch_multi_season_nfl_stats
+from scripts.feature_projections.tuning_protocol import (
+    inner_tuning_seasons_str,
+    warn_on_confirmation_overlap,
+)
 from scripts.feature_projections.features import FEATURE_REGISTRY
 from scripts.feature_projections.features.base import ProjectionFeature
 from scripts.feature_projections.combiner import combine_features
@@ -223,8 +231,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Sweep all feature combinations")
     parser.add_argument(
         "--seasons",
-        default="2024,2025",
-        help="Comma-separated target seasons (default: 2024,2025)",
+        default=inner_tuning_seasons_str(),
+        help=f"Comma-separated target seasons (default: {inner_tuning_seasons_str()} — "
+             "the inner tuning folds; the confirmation window is excluded, GH #595)",
     )
     parser.add_argument(
         "--top",
@@ -239,6 +248,7 @@ def main() -> None:
     )
     args = parser.parse_args()
     seasons = [int(s.strip()) for s in args.seasons.split(",")]
+    warn_on_confirmation_overlap(seasons)
 
     combos = _generate_all_combos()
     print(f"Testing {len(combos)} feature combinations across seasons {seasons}\n")

--- a/scripts/feature_projections/sweep_recency_weights.py
+++ b/scripts/feature_projections/sweep_recency_weights.py
@@ -3,8 +3,13 @@
 Tests multiple weight configurations and reports MAE/R² across seasons
 to find the optimal recency weights.
 
+Tuning runs on the **inner folds** (default 2022,2023,2024) by design — the
+confirmation window (2025) is held back for a single confirmatory look per
+accepted variant (honest tuning protocol, GH #595). Pointing ``--seasons`` at
+the confirmation window prints a loud warning.
+
 Usage:
-    python scripts/feature_projections/sweep_recency_weights.py [--seasons 2022,2023,2024,2025]
+    python scripts/feature_projections/sweep_recency_weights.py [--seasons 2022,2023,2024]
 """
 
 from __future__ import annotations
@@ -17,6 +22,10 @@ import pandas as pd
 
 from scripts.config import get_supabase_client, fetch_all_rows, POSITIONS, MIN_GAMES
 from scripts.analysis_utils import fetch_multi_season_stats
+from scripts.feature_projections.tuning_protocol import (
+    inner_tuning_seasons_str,
+    warn_on_confirmation_overlap,
+)
 from scripts.feature_projections.features.weighted_ppg import WeightedPPGFeature
 
 # Weight variants to test (most recent season first)
@@ -159,11 +168,13 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Sweep recency weight variants")
     parser.add_argument(
         "--seasons",
-        default="2022,2023,2024,2025",
-        help="Comma-separated target seasons (default: 2022,2023,2024,2025)",
+        default=inner_tuning_seasons_str(),
+        help=f"Comma-separated target seasons (default: {inner_tuning_seasons_str()} — "
+             "the inner tuning folds; the confirmation window is excluded, GH #595)",
     )
     args = parser.parse_args()
     seasons = [int(s.strip()) for s in args.seasons.split(",")]
+    warn_on_confirmation_overlap(seasons)
 
     print(f"Testing {len(WEIGHT_VARIANTS)} weight variants across seasons {seasons}\n")
 

--- a/scripts/feature_projections/tune_age_curve.py
+++ b/scripts/feature_projections/tune_age_curve.py
@@ -4,13 +4,15 @@ Tests combinations of peak_age, decline_rate, growth_rate, and scale for each
 position. Computes in-memory projections (base weighted_ppg + age curve delta)
 and compares to actuals to find the optimal parameter set.
 
-**Overfitting caveat:** By default, the same seasons are used for both parameter
-search and evaluation. Results may overfit to historical data. Consider holding
-out one season (e.g., search on 2022-2024, evaluate on 2025) for more robust
-estimates of improvement.
+**Honest tuning protocol (GH #595):** the grid search now defaults to the
+**inner folds** (2022,2023,2024) and holds the confirmation window (2025) back
+for a single confirmatory look per accepted variant — so the search no longer
+sees the seasons used to crown the production model. Pointing ``--seasons`` at
+the confirmation window prints a loud warning. See
+``scripts/feature_projections/tuning_protocol.py``.
 
 Usage:
-    venv/bin/python scripts/feature_projections/tune_age_curve.py [--seasons 2022,2023,2024,2025]
+    venv/bin/python scripts/feature_projections/tune_age_curve.py [--seasons 2022,2023,2024]
     venv/bin/python scripts/feature_projections/tune_age_curve.py --positions QB,WR
 """
 
@@ -25,6 +27,10 @@ import pandas as pd
 
 from scripts.config import get_supabase_client, fetch_all_rows, POSITIONS, MIN_GAMES
 from scripts.analysis_utils import fetch_multi_season_stats
+from scripts.feature_projections.tuning_protocol import (
+    inner_tuning_seasons_str,
+    warn_on_confirmation_overlap,
+)
 from scripts.feature_projections.features.weighted_ppg import WeightedPPGFeature
 from scripts.feature_projections.features.age_curve import (
     AgeCurveFeature,
@@ -245,8 +251,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Tune age curve parameters via grid search")
     parser.add_argument(
         "--seasons",
-        default="2022,2023,2024,2025",
-        help="Comma-separated target seasons (default: 2022,2023,2024,2025)",
+        default=inner_tuning_seasons_str(),
+        help=f"Comma-separated target seasons (default: {inner_tuning_seasons_str()} — "
+             "the inner tuning folds; the confirmation window is excluded, GH #595)",
     )
     parser.add_argument(
         "--positions",
@@ -255,6 +262,7 @@ def main() -> None:
     )
     args = parser.parse_args()
     seasons = [int(s.strip()) for s in args.seasons.split(",")]
+    warn_on_confirmation_overlap(seasons)
     positions = [p.strip().upper() for p in args.positions.split(",")]
 
     print(f"Tuning age curve for positions: {positions}")

--- a/scripts/feature_projections/tuning_protocol.py
+++ b/scripts/feature_projections/tuning_protocol.py
@@ -1,0 +1,64 @@
+"""Honest hyperparameter-tuning protocol for the additive models (GH #595).
+
+The audit (Finding 1) caught the *learned* models training on the seasons they
+were scored on. The additive models have a milder version of the same problem:
+their hyperparameters — age-curve params (#272), recency weights (#271), the
+regression factor and backup-QB penalty embedded in ``v14`` — were chosen by
+grid search whose default ``--seasons`` *included the 2024–2025 holdout*. The
+within-additive ranking (e.g. v14 vs v19 at Δ=0.006) is then inside the tuning
+noise, and #589 as originally written ("tune the base against the held-out
+harness") would tune directly on the final holdout, burning it completely.
+
+The fix is an inner/outer split that mirrors the rolling-origin protocol (#594):
+
+- **Inner (tuning) seasons** — hyperparameter search runs *only* here. These are
+  the rolling-origin eval folds **excluding** the final confirmation window.
+- **Confirmation window** — the most recent season(s), reserved for a single
+  confirmatory look per *accepted* variant. Grid search must never touch it.
+
+Tuning scripts default ``--seasons`` to :data:`INNER_TUNING_SEASONS` and call
+:func:`warn_on_confirmation_overlap` so that pointing one at the confirmation
+window is loud and deliberate, not the silent default.
+"""
+
+from __future__ import annotations
+
+# The most recent held-out season(s) — reserved for confirmation only. When 2026
+# actuals land, roll this forward (and extend INNER_TUNING_SEASONS) rather than
+# tuning on 2026 directly.
+CONFIRMATION_SEASONS = (2025,)
+
+# Default inner folds for hyperparameter search: the rolling-origin eval seasons
+# minus the confirmation window. Keep in lockstep with the holdout protocol.
+INNER_TUNING_SEASONS = (2022, 2023, 2024)
+
+
+def inner_tuning_seasons_str() -> str:
+    """Comma-joined default for argparse ``--seasons`` defaults/help text."""
+    return ",".join(str(s) for s in INNER_TUNING_SEASONS)
+
+
+def warn_on_confirmation_overlap(seasons: list) -> bool:
+    """Print a loud warning if any requested season is in the confirmation window.
+
+    Returns True when an overlap was found (so callers can also gate behaviour on
+    it if they wish). Tuning on the confirmation window is leakage at the
+    hyperparameter level — the exact mechanism the inner/outer split exists to
+    prevent — so it must never be the silent path.
+    """
+    overlap = sorted(set(int(s) for s in seasons) & set(CONFIRMATION_SEASONS))
+    if overlap:
+        bar = "!" * 72
+        print(bar)
+        print(
+            "  WARNING: tuning seasons "
+            f"{overlap} overlap the CONFIRMATION window {list(CONFIRMATION_SEASONS)}."
+        )
+        print(
+            "  Hyperparameters selected with sight of the confirmation window are\n"
+            "  leakage at the hyperparameter level (GH #595). Tune on the inner folds\n"
+            f"  ({inner_tuning_seasons_str()}) and keep the confirmation window for a\n"
+            "  single confirmatory look per accepted variant."
+        )
+        print(bar)
+    return bool(overlap)

--- a/scripts/tests/test_tuning_protocol.py
+++ b/scripts/tests/test_tuning_protocol.py
@@ -1,0 +1,32 @@
+"""Tests for the honest hyperparameter-tuning protocol (GH #595)."""
+
+from scripts.feature_projections import tuning_protocol as tp
+
+
+class TestInnerVsConfirmation:
+    def test_inner_and_confirmation_disjoint(self):
+        assert not (set(tp.INNER_TUNING_SEASONS) & set(tp.CONFIRMATION_SEASONS))
+
+    def test_inner_precedes_confirmation(self):
+        # Inner folds must all come before the confirmation window.
+        assert max(tp.INNER_TUNING_SEASONS) < min(tp.CONFIRMATION_SEASONS)
+
+    def test_inner_seasons_str(self):
+        assert tp.inner_tuning_seasons_str() == ",".join(
+            str(s) for s in tp.INNER_TUNING_SEASONS
+        )
+
+
+class TestOverlapWarning:
+    def test_overlap_detected(self, capsys):
+        assert tp.warn_on_confirmation_overlap([2023, 2024, 2025]) is True
+        out = capsys.readouterr().out
+        assert "WARNING" in out and "2025" in out
+
+    def test_no_overlap_silent(self, capsys):
+        assert tp.warn_on_confirmation_overlap([2022, 2023, 2024]) is False
+        assert capsys.readouterr().out == ""
+
+    def test_accepts_string_seasons(self):
+        # argparse hands ints, but be defensive about str input.
+        assert tp.warn_on_confirmation_overlap(["2025"]) is True


### PR DESCRIPTION
Closes #595 (Wave 1 of the 2026-06 projection-system review). Prereq for #589.

## Problem (new finding, not in the original audit)
The audit established that learned models v20–v31 suffered train/test leakage (Finding 1). But the additive models have their own, milder leakage path: their hyperparameters were selected by grid search against the full 2022–2025 backtest — `tune_age_curve.py` (#272 age-curve params), `sweep_recency_weights.py` (#271 recency weights), and `sweep_feature_combos.py` all defaulted to `2022,2023,2024,2025`. The age-curve params, recency weights, regression factor and backup-QB penalty embedded in `v14` were all chosen with sight of the 2024–2025 eval window.

The headline conclusion (v14 ≫ learned, Δ=0.263, CI excludes 0) is structural and survives. But the *within-additive* ranking (v14 vs v19 at Δ=0.006, not significant) is inside the tuning noise — and #589 ("tune the base `weighted_ppg` against the held-out harness") as written would tune directly on the final holdout, burning it.

## Changes
- **`tuning_protocol.py`** (new) — `INNER_TUNING_SEASONS = (2022,2023,2024)` (the rolling-origin folds minus the confirmation window) and `CONFIRMATION_SEASONS = (2025,)`; `warn_on_confirmation_overlap()` prints a loud warning when a tuning run's `--seasons` touches the confirmation window.
- **`tune_age_curve.py` / `sweep_recency_weights.py` / `sweep_feature_combos.py`** — default `--seasons` to the inner folds; warn on overlap; docstring caveats replaced with the protocol.
- **Docs** — honest tuning protocol section in the methodology audit; #589 marked **blocked on #595** in the accuracy-improvement backlog with the inner-fold/confirm-once requirement.
- The one-look re-check of v14's current tuned params is folded into #589's single confirmatory evaluation rather than spent on archaeology (spending the confirmation look pre-emptively would itself be questionable).
- Tests for the inner/confirmation split and the overlap warning.

## Verification
`warn_on_confirmation_overlap([2023,2024,2025])` fires the warning; `[2022,2023,2024]` is silent. All three scripts import cleanly and default to `2022,2023,2024`. 26 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)