### PR TITLE
docs(eval): refresh model-iteration skills + CLAUDE.md gates to the honest workflow (#596)

### DIFF
--- a/.claude/commands/ablation.md
+++ b/.claude/commands/ablation.md
@@ -1,39 +1,53 @@
 ---
 description: Run feature ablation study to measure individual feature contributions
 ---
-Follow these steps to run a feature ablation study:
+Measure each feature's contribution **on the leakage-free held-out harness**.
+The old `hypothesis_test.py` flow is **in-sample only** (it scores over the same
+seasons the model trained on) and its 0.05/0.02 MAE thresholds are exactly the
+arbitrary-band decisions Finding 2 condemned — do not use it for verdicts.
 
 // turbo
 
-1. **Identify the target model** (default: the current best model, v20_learned_usage). If the user specifies a model in the arguments, use that instead.
+1. **Identify the target model** (default: production `v14_qb_starter`). If the
+   user specifies a model, use that.
 
-2. **List the model's features** by reading `scripts/feature_projections/model_config.py`. Identify the base feature (cannot be removed) and all adjustment features.
+2. **List the model's features** from `scripts/feature_projections/model_config.py`.
+   Identify the base feature (cannot be removed) and the adjustment features.
 
-3. **For each adjustment feature**, run a hypothesis test that removes it:
+3. **For each adjustment feature, define a temporary ablated variant** in
+   `model_config.py` (same model minus that one feature/interaction), with a clear
+   name like `MODEL_NAME_no_FEATURE`. Keep the edits staged but uncommitted.
+
+4. **Score the full model and every ablated variant on the held-out harness**
+   (rolling protocol; the cache makes the repeated runs fast):
    ```bash
-   source venv/bin/activate && python scripts/feature_projections/hypothesis_test.py \
-     --base-model MODEL_NAME --remove-feature FEATURE_NAME --seasons 2022,2023,2024,2025
+   just holdout-eval --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021 \
+     --models MODEL_NAME,MODEL_NAME_no_FEATURE_A,MODEL_NAME_no_FEATURE_B,...
+   ```
+   For each ablated variant, test whether removing the feature *significantly*
+   changes accuracy vs the full model:
+   ```bash
+   just significance MODEL_NAME MODEL_NAME_no_FEATURE_A --protocol rolling \
+     --eval-seasons 2023,2024,2025 --min-train-season 2021
    ```
 
-   If `hypothesis_test.py` is not available or errors, manually:
-   - Note the feature to remove
-   - Create a temporary model variant in model_config.py without that feature
-   - Run projections and backtest for the variant
-   - Record the results
-   - Revert the model_config.py change
-
-4. **Compile results into an ablation table:**
+5. **Compile the ablation table** from the held-out numbers + significance:
    ```
-   Feature Removed        | MAE Delta | R² Delta | Verdict
-   age_curve              | +0.15     | -0.04    | KEEP (significant)
-   regression_to_mean     | +0.02     | -0.01    | KEEP (marginal)
-   qb_backup_penalty      | +0.005   | -0.001   | DROP CANDIDATE
+   Feature Removed     | Held-out MAE Δ | 95% CI            | Significant? | Verdict
+   age_curve           | +0.15          | [+0.08, +0.22]    | Y            | KEEP (load-bearing)
+   regression_to_mean  | +0.02          | [-0.03, +0.07]    | N            | DROP CANDIDATE
+   qb_backup_penalty   | -0.01          | [-0.05, +0.03]    | N            | DROP CANDIDATE
    ```
 
-5. **Assign verdicts per feature:**
-   - **KEEP (significant)**: Removing increases MAE by >0.05
-   - **KEEP (marginal)**: Removing increases MAE by 0.02-0.05
-   - **DROP CANDIDATE**: Removing increases MAE by <0.02 or improves it
-   - **HARMFUL**: Removing actually decreases MAE (improves accuracy)
+6. **Assign verdicts from significance, not a fixed MAE band:**
+   - **KEEP (load-bearing)** — removing it *significantly* increases MAE (CI > 0).
+   - **DROP CANDIDATE** — removing it has no significant effect (CI spans 0). The
+     feature is not earning its complexity; prune it (Finding 4: prune, don't add).
+   - **HARMFUL** — removing it *significantly* decreases MAE (CI < 0). Remove it.
+   Check the per-position **Ranking quality** section too (#598): a feature can be
+   MAE-neutral but improve within-position ordering, which the decisions consume.
 
-6. **Summarize findings**: Which features are load-bearing? Which are deadweight? Are there any features that are actively harmful?
+7. **Revert the temporary `model_config.py` variants** once the table is recorded.
+
+8. **Summarize**: which features are load-bearing, which are deadweight, which are
+   actively harmful — all judged on the held-out, significance-tested numbers.

--- a/.claude/commands/compare-models.md
+++ b/.claude/commands/compare-models.md
@@ -1,42 +1,39 @@
 ---
 description: Side-by-side comparison of 2-3 projection models with per-player divergence
 ---
-Follow these steps to compare projection models side-by-side:
+Compare 2–3 projection models side by side, **leading with held-out (leakage-free)
+metrics**. The in-sample `accuracy-report` / `cli.py compare` tables score
+learned models on data they trained on (Findings 1 & 2) — use them only for
+per-player divergence inspection, never to declare a winner.
 
 // turbo
 
-1. **Parse model names from arguments.** The user should provide 2-3 model names separated by spaces (e.g., `v14 v20 v24`). Resolve partial names to full names from model_config.py (e.g., `v14` → `v14_qb_starter`).
+1. **Parse model names from arguments** (2–3 names, e.g. `v14 v20`). Resolve
+   partial names to full names from `model_config.py` (`v14` → `v14_qb_starter`).
 
-2. **Run the full accuracy report** (if not recently generated):
+2. **Held-out comparison (the verdict).** Score exactly the requested models
+   out-of-sample on the shared window:
    ```bash
-   source venv/bin/activate && python scripts/feature_projections/accuracy_report.py \
-     --seasons 2022,2023,2024,2025 --output docs/generated/projection-accuracy.md
+   just holdout-eval --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021 \
+     --models MODEL_A,MODEL_B[,MODEL_C]
    ```
-
-3. **Extract metrics** for ONLY the specified models from the report. Present a focused comparison table per position:
-   ```
-   Position | Metric | Model A    | Model B    | Model C    | Best
-   ALL      | MAE    | 2.515      | 2.412      | 2.469      | B
-   ALL      | R²     | 0.542      | 0.577      | 0.565      | B
-   ALL      | Bias   | +0.170     | -0.026     | -0.050     | B
-   QB       | MAE    | 3.801      | 3.650      | 3.700      | B
-   ...
-   ```
-
-4. **For the most recent season** (2025), identify top 10 players where the models diverge most. Fetch projections from DB:
+   Present the focused per-position table from the generated report, including the
+   **Ranking quality** rows (Spearman ρ + top-N hit, #598). Whenever two models
+   are close, confirm with the paired bootstrap rather than eyeballing MAE:
    ```bash
-   source venv/bin/activate && python -c "
-   from config import get_supabase_client
-   supabase = get_supabase_client()
-   # Fetch projections for the specified models and compare
-   "
+   just significance MODEL_A MODEL_B --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
    ```
+   State the winner as "significantly better" or "not separable", never as a bare
+   MAE delta.
 
-5. **Present the divergence table:**
+3. **Per-player divergence (diagnostic, most recent season).** Use `cli.py
+   compare` to see where the models disagree most — this is for understanding
+   *why* they differ, not for scoring:
+   ```bash
+   just compare MODEL_A,MODEL_B 2025
    ```
-   Player         | Pos | Model A | Model B | Max Diff
-   Patrick Mahomes| QB  | 18.5    | 20.1    | 1.6
-   ...
-   ```
+   Present the top ~10 players by absolute projection difference.
 
-6. **Summarize**: Which model wins overall? Where does each model have strengths/weaknesses? Are there position-specific recommendations?
+4. **Summarize**: which model is significantly better out-of-sample (level *and*
+   ordering), where each is strong/weak by position, and what drives the largest
+   per-player disagreements.

--- a/.claude/commands/diagnose-segment.md
+++ b/.claude/commands/diagnose-segment.md
@@ -1,52 +1,43 @@
 ---
 description: Deep-dive accuracy analysis for a specific player segment
 ---
-Follow these steps to diagnose projection accuracy for a specific player segment:
+Diagnose projection accuracy for a specific player segment. Segment analysis and
+per-player diagnostics are **descriptive** tools — they surface *where* error
+concentrates. Any model-change idea they motivate must still be validated on the
+held-out harness (`/experiment`), never on the in-sample segment numbers.
 
 // turbo
 
-1. **Parse the segment description from arguments.** Examples: "bench WR", "elite QB", "rookies", "age 30+", "high-usage RB". If no segment specified, ask the user.
+1. **Parse the segment** from arguments (e.g. "bench WR", "elite QB", "age 30+",
+   "high-usage RB"). If none given, ask the user.
 
-2. **Run segment analysis** to get accuracy broken down by segments:
+2. **Run segment analysis** across production + a learned reference + the naïve
+   baseline (use `venv/bin/python` directly — no `source venv/bin/activate`):
    ```bash
-   source venv/bin/activate && python scripts/feature_projections/cli.py segment-analysis \
-     --models v1_baseline_weighted_ppg,v14_qb_starter,v20_learned_usage \
+   venv/bin/python scripts/feature_projections/cli.py segment-analysis \
+     --models v14_qb_starter,v20_learned_usage,naive_prior_season_ppg \
      --seasons 2022,2023,2024,2025
    ```
 
-3. **Run per-player diagnostics** for detailed player-level view:
+3. **Run per-player diagnostics** for the player-level view:
    ```bash
-   source venv/bin/activate && python scripts/feature_projections/cli.py diagnostics \
-     --model v20_learned_usage --season 2025 --top 50 \
+   venv/bin/python scripts/feature_projections/cli.py diagnostics \
+     --model v14_qb_starter --season 2025 --top 50 \
      --output docs/generated/player-diagnostics.md
    ```
 
-4. **Read and filter** the generated reports to the requested segment. Look at:
-   - `docs/generated/segment-analysis.md` for segment-level metrics
-   - `docs/generated/player-diagnostics.md` for individual players
+4. **Read and filter** `docs/generated/segment-analysis.md` and
+   `docs/generated/player-diagnostics.md` to the requested segment.
 
-5. **Present segment-specific metrics:**
-   ```
-   Segment: Bench-tier WR (rank > 24)
-   Model              | MAE   | Bias    | R²    | N
-   v1_baseline        | 2.81  | -1.05   | 0.210 | 87
-   v14_qb_starter     | 2.78  | -1.27   | 0.220 | 87
-   v20_learned_usage  | 2.65  | -0.90   | 0.255 | 87
-   ```
+5. **Present segment metrics** (MAE, Bias, R², N per model) and **list the
+   players** with projected vs actual and an over/under-projection label.
 
-6. **List players in the segment** with their projected vs actual:
-   ```
-   Player         | Projected | Actual | Error  | Category
-   John Smith     | 4.50      | 2.10   | -2.40  | bust
-   Jane Doe       | 3.80      | 6.50   | +2.70  | breakout
-   ```
+6. **Identify systematic patterns** — is the segment consistently over/under-
+   projected? Are errors correlated with a feature (age, usage, depth role)? Note
+   that these are in-sample observations on the full history.
 
-7. **Identify systematic patterns:**
-   - Is the segment consistently over-projected or under-projected?
-   - Are errors correlated with specific features (e.g., age, usage share)?
-   - Are certain error categories dominant (breakout, bust, injury)?
-
-8. **Suggest potential improvements:**
-   - Which features might address the gap?
-   - Would a segment-specific weight adjustment help?
-   - Is this a data quality issue or a modeling issue?
+7. **Propose improvements as hypotheses, not conclusions.** For any proposed
+   feature or weight change, hand off to `/experiment` to get a held-out,
+   significance-tested verdict vs `v14_qb_starter` before trusting it. Be alert to
+   the level-vs-ordering split (#579/#598): a segment can be biased in level while
+   still ranked correctly, which changes whether a fix is even worth making.

--- a/.claude/commands/experiment.md
+++ b/.claude/commands/experiment.md
@@ -1,40 +1,68 @@
 ---
 description: Run a controlled experiment on a new/modified projection model variant
 ---
-Follow these steps to run a controlled experiment on a projection model:
+Run a controlled experiment on a projection model **on the leakage-free held-out
+harness** (GH #572/#573/#594). Do **not** use the in-sample `accuracy-report`
+flow to decide anything — it scores learned models on the data they trained on
+(methodology audit, Findings 1 & 2). A verdict is "significant or not", never a
+point-estimate delta.
 
 // turbo
 
-1. **Identify the model to test.** If no model is specified in the arguments, check `git diff` for changes to `model_config.py` to detect new/modified models. If nothing found, ask the user which model to test.
+1. **Identify the model to test.** If no model is given in the arguments, check
+   `git diff` for changes to `model_config.py`. If nothing is found, ask the user.
 
-2. **If the model uses `combiner_type="learned"`**, train it first:
+2. **Make the model's held-out projections available.**
+   - **Additive / external models are parameter-free** w.r.t. training seasons, so
+     `holdout-eval` reads their projections from the DB — generate them first:
+     ```bash
+     just project MODEL_NAME 2023,2024,2025
+     ```
+   - **Learned / residual models** are retrained out-of-sample inside the
+     `holdout-eval` sandbox automatically — no pre-training or pre-projection
+     needed (and never train on the eval seasons yourself).
+
+3. **Run the held-out re-rank** against production (`v14_qb_starter`) and the
+   naïve baselines (`naive_prior_season_ppg`, `position_mean_baseline`). Prefer
+   the rolling-origin protocol (#594); the cache (#597) makes re-runs fast:
    ```bash
-   source venv/bin/activate && python scripts/feature_projections/train_model.py --model MODEL_NAME --seasons 2022,2023,2024
+   just holdout-eval --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021 \
+     --models MODEL_NAME,v14_qb_starter,naive_prior_season_ppg,position_mean_baseline
    ```
+   Read the **Ranking quality** section too (per-position Spearman ρ + top-N hit
+   rate, #598) — the projections feed VORP/auction/keepers, which consume
+   *ordering*, not just PPG level.
 
-3. **Generate projections for ALL backtest seasons** (this is mandatory — do not skip any season):
+4. **Test significance vs the production model** (player-clustered paired
+   bootstrap, #594). This is the gate:
    ```bash
-   source venv/bin/activate && python scripts/feature_projections/cli.py run --model MODEL_NAME --seasons 2022,2023,2024,2025
+   just significance MODEL_NAME v14_qb_starter --protocol rolling \
+     --eval-seasons 2023,2024,2025 --min-train-season 2021
    ```
 
-4. **Run backtest and generate accuracy report:**
+5. **If the model touches availability / expected games**, additionally report
+   the availability budget (rate vs availability MAE, #574):
    ```bash
-   source venv/bin/activate && python scripts/feature_projections/accuracy_report.py --run-backtest --seasons 2022,2023,2024,2025 --output docs/generated/projection-accuracy.md
+   just availability-backtest --models MODEL_NAME,v14_qb_starter
    ```
 
-5. **Extract metrics** from the generated report for the new model, v1_baseline_weighted_ppg (baseline), and v20_learned_usage (current best). Present a compact verdict table:
-   ```
-   Model              | ALL MAE | ALL R² | QB MAE | RB MAE | WR MAE | TE MAE | Verdict
-   v1_baseline        | X.XXX   | 0.XXX  | X.XXX  | X.XXX  | X.XXX  | X.XXX  | baseline
-   v20_learned_usage  | X.XXX   | 0.XXX  | X.XXX  | X.XXX  | X.XXX  | X.XXX  | current best
-   NEW_MODEL          | X.XXX   | 0.XXX  | X.XXX  | X.XXX  | X.XXX  | X.XXX  | ???
-   ```
+6. **State the verdict** from the significance test, not an MAE band:
+   - **SIGNIFICANT WIN** — the 95% CI for MAE(NEW) − MAE(v14_qb_starter) lies
+     entirely below 0. Only this clears the bar to consider promotion.
+   - **NOT SIGNIFICANT** — CI spans 0. The gap is sampling noise; do not promote
+     on it, regardless of the point estimate.
+   - **SIGNIFICANT REGRESSION** — CI lies entirely above 0.
+   Also note whether the model out-*ranks* `v14` (Spearman/top-N) even at MAE
+   parity — that can justify a ranking-motivated bet (#590/#592).
 
-6. **State the verdict:**
-   - **IMPROVEMENT** if ALL MAE < v20's ALL MAE
-   - **REGRESSION** if ALL MAE > v20's ALL MAE
-   - **NEUTRAL** if ALL MAE within ±0.01 of v20
+7. **Append to the experiment log** (`docs/generated/experiment-log.md`) using the
+   held-out columns: date, model, change, **held-out ALL MAE**, **Δ vs
+   v14_qb_starter**, **95% CI**, **significant? (Y/N)**, protocol, PR. The
+   in-sample `accuracy-report` is a secondary diagnostic only.
 
-7. **Append to experiment log** at `docs/generated/experiment-log.md` with date, model name, change description, ALL MAE, ALL R², ALL Bias, verdict, and PR number (if known).
+8. **In the PR description**, lead with the held-out + significance result; the
+   in-sample accuracy table, if included, must be labelled "in-sample diagnostic".
 
-8. **Include the full accuracy table** in any PR description when creating a PR for this change.
+**Confirmation discipline (#594):** iterate against the rolling folds; the final
+window (2025, then 2026 actuals) is confirmation-only — one look per experiment.
+Promotion requires a *significant* held-out win over the active model.

--- a/.claude/commands/feature-importance.md
+++ b/.claude/commands/feature-importance.md
@@ -1,38 +1,39 @@
 ---
 description: Inspect learned model coefficients and feature importance
 ---
-Follow these steps to analyze feature importance for a learned model:
+Inspect a learned model's coefficients to understand *what it leans on*. This is
+a **diagnostic**, not a selection tool: coefficient magnitude is in-sample and
+says nothing about out-of-sample value. To decide whether a feature earns its
+place, cross-check with held-out ablation (`/ablation`, #588), not these numbers.
 
 // turbo
 
-1. **Identify the learned model** (default: v20_learned_usage). If the user specifies a model in the arguments, use that instead.
+1. **Identify the learned model** (default: `v20_learned_usage` — note this is a
+   learned reference model, not production; production is the additive
+   `v14_qb_starter`, which has no learned coefficients to inspect). Use the
+   user-specified model if given.
 
-2. **Try running the feature analysis script:**
+2. **Run the feature analysis script** (use `venv/bin/python` directly — no
+   `source venv/bin/activate`, which fails in worktrees):
    ```bash
-   source venv/bin/activate && python scripts/feature_projections/feature_analysis.py \
+   venv/bin/python scripts/feature_projections/feature_analysis.py \
      --model MODEL_NAME --seasons 2022,2023,2024
    ```
 
-3. **If the script succeeds**, present its output (correlation matrix, feature-target correlations, VIF, importance ranking).
+3. **If the script succeeds**, present its output (correlation matrix,
+   feature-target correlations, VIF, importance ranking).
 
-4. **If the script fails or doesn't exist**, manually analyze the trained model JSON:
-   - Read `scripts/feature_projections/trained_models/MODEL_NAME.json`
-   - For each feature, compute effective importance = |coefficient| × scaler_scale
-   - Rank features by effective importance
-   - Compute and flag VIF concerns (features with similar names/roles)
+4. **If the script fails or doesn't exist**, analyze the trained model JSON at
+   `scripts/feature_projections/trained_models/MODEL_NAME.json`: per feature,
+   effective importance = |coefficient| × scaler_scale; rank by it; flag likely
+   collinear feature pairs.
 
-5. **Present a ranked importance table:**
-   ```
-   Rank | Feature                         | Coefficient | Scale  | Importance | Notes
-   1    | weighted_ppg_no_qb_trajectory   | +1.170      | 4.867  | 5.694      | Base feature
-   2    | usage_share_raw*base_ppg        | +0.517      | 1.568  | 0.811      | Interaction
-   3    | age_curve                       | -0.342      | 1.203  | 0.411      | Adjustment
-   ...
-   ```
+5. **Present a ranked importance table** (Rank | Feature | Coefficient | Scale |
+   Importance | Notes).
 
-6. **Flag concerns:**
-   - Features with near-zero importance (candidates for removal via `/ablation`)
-   - Features with VIF > 5 (multicollinearity concern)
-   - Unexpected coefficient signs (e.g., positive age_curve for old players)
+6. **Flag concerns** — near-zero-importance features (ablation candidates),
+   VIF > 5 (multicollinearity), unexpected coefficient signs.
 
-7. **Summarize**: Which features drive the model? Are there redundant features? Any surprising coefficient directions?
+7. **Summarize**, and explicitly route any "this feature looks weak/redundant"
+   hunch to `/ablation` for a held-out, significance-tested decision — importance
+   here is only a hypothesis generator.

--- a/.claude/commands/projection-accuracy.md
+++ b/.claude/commands/projection-accuracy.md
@@ -1,20 +1,41 @@
 ---
 description: Run projection accuracy comparison across all models and generate a report table
 ---
-Follow these steps to generate a projection accuracy comparison table:
+Generate the model accuracy comparison. **Lead with the leakage-free held-out
+ranking**; the in-sample `accuracy-report` table is a secondary diagnostic only
+(it scores learned models on data they trained on — methodology audit, Findings
+1 & 2).
 
 // turbo
-1. **If a new model was just added**, first run it for ALL backtest seasons before running the report.
-   Missing seasons show as `—` in the table and corrupt the combined averages.
+
+1. **Held-out ranking (the honest comparison).** Re-rank every model
+   out-of-sample (learned models retrain in a sandbox; the cache makes re-runs
+   fast). Prefer the rolling-origin protocol (#594):
+   ```bash
+   just holdout-eval --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
    ```
-   source venv/bin/activate && python scripts/feature_projections/cli.py run --model <new_model> --seasons 2022,2023,2024,2025
+   Output: `docs/generated/projection-holdout-eval-rolling.md` (fixed-window:
+   `projection-holdout-eval.md`). This is the table to quote in any PR. It also
+   carries the **Ranking quality** section — per-position Spearman ρ + top-N hit
+   rate (#598), the metrics VORP/auction/keeper decisions actually consume.
+
+2. **Significance of any close call.** A point-estimate MAE gap is not a result;
+   confirm it with the player-clustered paired bootstrap:
+   ```bash
+   just significance MODEL_A MODEL_B --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
    ```
 
-2. Activate the virtual environment and run backtests for all models, then generate the report
-`source venv/bin/activate && python scripts/feature_projections/accuracy_report.py --run-backtest --seasons 2022,2023,2024,2025`
+3. **In-sample diagnostic (optional, label it as such).** Useful for spotting
+   per-season anomalies, never for picking a winner:
+   ```bash
+   just accuracy-report --run-backtest --seasons 2022,2023,2024,2025
+   ```
+   If you include this table anywhere, label it "in-sample diagnostic — not the
+   ranking" and pair it with the held-out table.
 
-3. The report is saved to `docs/generated/projection-accuracy.md` and printed to stdout.
-   Include the full markdown table in any task output or PR description when this relates to a projection model change.
-
-4. When comparing a specific pair of models (e.g., after adding a new model), you can also run:
-`source venv/bin/activate && python scripts/feature_projections/cli.py compare --models v1_baseline_weighted_ppg,<new_model> --season 2024`
+4. **If a new additive/external model was just added**, generate its held-out
+   projections first so it appears in the report (learned models need no
+   pre-projection — `holdout-eval` retrains them):
+   ```bash
+   just project <new_model> 2023,2024,2025
+   ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Comprehensive database and analytics platform for Ottoneu Fantasy Football Leagu
 - **Environment:** See [docs/references/environment-variables.md](docs/references/environment-variables.md) for `.env` setup
 - **Season cycle:** See [docs/exec-plans/season-cycle.md](docs/exec-plans/season-cycle.md) — the site rolls between Ottoneu seasons from the `league_calendar` table; the current season is resolved at runtime via `scripts/season.py` and `web/lib/season.ts`, not from static config
 - **Projection Accuracy Plan:** See [docs/exec-plans/projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md) for the 4-phase accuracy improvement roadmap (Issues #271-#285)
-- **Projection Accuracy:** Run `just accuracy-report` (or `python scripts/feature_projections/accuracy_report.py`) to generate a model comparison table. **Required when updating any projection code** — see Projection Model Update Requirements below.
+- **Projection Accuracy:** The gate for any projection change is the **leakage-free held-out harness** — `just holdout-eval` (#572/#594) + `just significance` (#573/#594), not the in-sample `just accuracy-report` (which is a secondary diagnostic only). See Projection Model Update Requirements below.
 - **Market Projections:** See [docs/exec-plans/market-projections.md](docs/exec-plans/market-projections.md) for the market-based projection system (DEFERRED)
 - **Experiment Log:** See [docs/generated/experiment-log.md](docs/generated/experiment-log.md) for history of all model iteration attempts.
 - **Build System Spec:** See [docs/superpowers/specs/2026-04-19-build-system-design.md](docs/superpowers/specs/2026-04-19-build-system-design.md) for the transition specification to `just` build runner
@@ -117,24 +117,22 @@ Run `just check-arch` to validate these rules locally.
 
 ## Projection Model Update Requirements
 
-When any task modifies the projection system — including `scripts/feature_projections/`, `scripts/projection_methods.py`, `scripts/update_projections.py`, or `model_config.py` — you MUST:
+When any task modifies the projection system — including `scripts/feature_projections/`, `scripts/projection_methods.py`, `scripts/update_projections.py`, or `model_config.py` — you MUST validate it on the **leakage-free held-out harness**. The in-sample `accuracy-report` scores learned models on the seasons they trained on (methodology audit, Findings 1 & 2); it is a **secondary diagnostic only** and must never be the gate or the basis for a promote decision. Use `/experiment` to run this flow.
 
-1. **Run the new model for ALL backtest seasons before calling `--run-backtest`.**
-   The accuracy report covers seasons 2022–2025. If a new model is missing any of those seasons in `model_projections`, that season will show `—` in the table and the combined averages will be wrong. Run:
+1. **Run the held-out re-rank** against production (`v14_qb_starter`) and the naïve baselines, on the rolling-origin protocol (#594). Learned models retrain out-of-sample inside the sandbox; additive/external models need their held-out projections generated first (`just project <name> 2023,2024,2025`). The cache (#597) makes re-runs fast.
    ```
-   just project <name> 2022,2023,2024,2025
+   just holdout-eval --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021 \
+     --models <name>,v14_qb_starter,naive_prior_season_ppg,position_mean_baseline
    ```
-   Then run the full report:
+2. **Test significance vs the active model** (player-clustered paired bootstrap). This is the gate — a point-estimate MAE delta is **not** a result:
    ```
-   just accuracy-report --run-backtest --seasons 2022,2023,2024,2025
+   just significance <name> v14_qb_starter --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
    ```
-2. **Include the full markdown table** (from `docs/generated/projection-accuracy.md`) in:
-   - The task output / conversation summary
-   - The PR description body under a `## Projection Accuracy` section
-3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Promote via `just promote <model>` (or `cli.py promote --model <name>`)** to switch which model the web app serves — `update_projections.py` now reads `projection_models.is_active` dynamically (no more hardcoded `ACTIVE_MODEL` constant). Methodology copy on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` is rendered live by `<ActiveModelCard>` (`web/components/ActiveModelCard.tsx`) from `fetchActiveProjectionModel()`, so do **not** hardcode model names or feature lists in page copy.
+   Availability-touching changes additionally run `just availability-backtest` and report **both** rate and availability MAE (#574).
+3. **In the PR description**, lead with the held-out ranking + significance verdict (and the per-position Ranking-quality rows, #598). Include the in-sample `accuracy-report` table only if labelled "in-sample diagnostic — not the ranking".
+4. **Promotion requires a *significant* held-out win over the active model** (CI excludes 0), never a point-estimate delta. Promote via `just promote <model>` (or `cli.py promote --model <name>`) — `update_projections.py` reads `projection_models.is_active` dynamically (no hardcoded `ACTIVE_MODEL`). Methodology copy on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` is rendered live by `<ActiveModelCard>` (`web/components/ActiveModelCard.tsx`) from `fetchActiveProjectionModel()`, so do **not** hardcode model names or feature lists in page copy.
 
-This ensures every projection change is empirically validated before merge.
+**Confirmation discipline (#594):** iterate against the rolling folds; the final window (2025, then 2026 actuals) is confirmation-only — one look per experiment. This ensures every projection change is empirically validated, out-of-sample, before merge.
 
 ### Feature changes require test updates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Comprehensive database and analytics platform for Ottoneu Fantasy Football Leagu
 - **Environment:** See [docs/references/environment-variables.md](docs/references/environment-variables.md) for `.env` setup
 - **Season cycle:** See [docs/exec-plans/season-cycle.md](docs/exec-plans/season-cycle.md) — the site rolls between Ottoneu seasons from the `league_calendar` table; the current season is resolved at runtime via `scripts/season.py` and `web/lib/season.ts`, not from static config
 - **Projection Accuracy Plan:** See [docs/exec-plans/projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md) for the 4-phase accuracy improvement roadmap (Issues #271-#285)
-- **Projection Accuracy:** Run `just accuracy-report` (or `python scripts/feature_projections/accuracy_report.py`) to generate a model comparison table. **Required when updating any projection code** — see Projection Model Update Requirements below.
+- **Projection Accuracy:** The gate for any projection change is the **leakage-free held-out harness** — `just holdout-eval` (#572/#594) + `just significance` (#573/#594), not the in-sample `just accuracy-report` (which is a secondary diagnostic only). See Projection Model Update Requirements below.
 - **Projection Iteration:** Use `/experiment` to run a full experiment loop (train → project → backtest → verdict). Use `/ablation` for feature ablation studies, `/feature-importance` for learned model inspection, `/compare-models` for side-by-side comparisons, `/diagnose-segment` for segment deep-dives.
 - **Market Projections:** See [docs/exec-plans/market-projections.md](docs/exec-plans/market-projections.md) for the market-based projection system (DEFERRED)
 - **Experiment Log:** See [docs/generated/experiment-log.md](docs/generated/experiment-log.md) for history of all model iteration attempts.
@@ -127,24 +127,22 @@ Run `just check-arch` to validate these rules locally.
 
 ## Projection Model Update Requirements
 
-When any task modifies the projection system — including `scripts/feature_projections/`, `scripts/projection_methods.py`, `scripts/update_projections.py`, or `model_config.py` — you MUST:
+When any task modifies the projection system — including `scripts/feature_projections/`, `scripts/projection_methods.py`, `scripts/update_projections.py`, or `model_config.py` — you MUST validate it on the **leakage-free held-out harness**. The in-sample `accuracy-report` scores learned models on the seasons they trained on (methodology audit, Findings 1 & 2); it is a **secondary diagnostic only** and must never be the gate or the basis for a promote decision. Use `/experiment` to run this flow.
 
-1. **Run the new model for ALL backtest seasons before calling `--run-backtest`.**
-   The accuracy report covers seasons 2022–2025. If a new model is missing any of those seasons in `model_projections`, that season will show `—` in the table and the combined averages will be wrong. Run:
+1. **Run the held-out re-rank** against production (`v14_qb_starter`) and the naïve baselines, on the rolling-origin protocol (#594). Learned models retrain out-of-sample inside the sandbox; additive/external models need their held-out projections generated first (`just project <name> 2023,2024,2025`). The cache (#597) makes re-runs fast.
    ```
-   just project <name> 2022,2023,2024,2025
+   just holdout-eval --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021 \
+     --models <name>,v14_qb_starter,naive_prior_season_ppg,position_mean_baseline
    ```
-   Then run the full report:
+2. **Test significance vs the active model** (player-clustered paired bootstrap). This is the gate — a point-estimate MAE delta is **not** a result:
    ```
-   just accuracy-report --run-backtest --seasons 2022,2023,2024,2025
+   just significance <name> v14_qb_starter --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
    ```
-2. **Include the full markdown table** (from `docs/generated/projection-accuracy.md`) in:
-   - The task output / conversation summary
-   - The PR description body under a `## Projection Accuracy` section
-3. **Highlight improvements** — call out which metrics improved vs the baseline (`v1_baseline_weighted_ppg`) in the PR description narrative above the table.
-4. **Promote via `just promote <model>` (or `cli.py promote --model <name>`)** to switch which model the web app serves — `update_projections.py` now reads `projection_models.is_active` dynamically (no more hardcoded `ACTIVE_MODEL` constant). Methodology copy on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` is rendered live by `<ActiveModelCard>` (`web/components/ActiveModelCard.tsx`) from `fetchActiveProjectionModel()`, so do **not** hardcode model names or feature lists in page copy.
+   Availability-touching changes additionally run `just availability-backtest` and report **both** rate and availability MAE (#574).
+3. **In the PR description**, lead with the held-out ranking + significance verdict (and the per-position Ranking-quality rows, #598). Include the in-sample `accuracy-report` table only if labelled "in-sample diagnostic — not the ranking".
+4. **Promotion requires a *significant* held-out win over the active model** (CI excludes 0), never a point-estimate delta. Promote via `just promote <model>` (or `cli.py promote --model <name>`) — `update_projections.py` reads `projection_models.is_active` dynamically (no hardcoded `ACTIVE_MODEL`). Methodology copy on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` is rendered live by `<ActiveModelCard>` (`web/components/ActiveModelCard.tsx`) from `fetchActiveProjectionModel()`, so do **not** hardcode model names or feature lists in page copy.
 
-This ensures every projection change is empirically validated before merge.
+**Confirmation discipline (#594):** iterate against the rolling folds; the final window (2025, then 2026 actuals) is confirmation-only — one look per experiment. See [docs/exec-plans/projection-methodology-audit.md](docs/exec-plans/projection-methodology-audit.md) for the protocol. This ensures every projection change is empirically validated, out-of-sample, before merge.
 
 ### Feature changes require test updates
 

--- a/docs/generated/experiment-log.md
+++ b/docs/generated/experiment-log.md
@@ -2,13 +2,31 @@
 
 _Tracks every model iteration attempt to prevent re-trying failed approaches._
 
-> ⚠️ **The `ALL MAE`/`R²` columns below are in-sample for the learned models
+> ⚠️ **The historical table at the bottom is in-sample for the learned models
 > (`v20`–`v31`) — they were trained on the seasons they're scored on. The
 > [methodology audit](../exec-plans/projection-methodology-audit.md) (2026-06-10)
 > re-ranked everything out-of-sample: the additive **`v14_qb_starter`** is the
 > honest best and is in production; the entire `v20`→`v31` "progression" was a
-> leakage artifact. Do not read the deltas below as real gains. New experiments
-> are validated via `just holdout-eval` + `just significance` (backlog: #587–#592).
+> leakage artifact. Do not read those deltas as real gains.**
+
+## Held-out experiments (post-audit protocol — #594+)
+
+New experiments are logged here with **leakage-free held-out** numbers, the gate
+being a *significant* win over the active model. Generate the row with
+`/experiment`: `just holdout-eval --protocol rolling …` for the MAE/CI and
+`just significance NEW v14_qb_starter --protocol rolling …` for the verdict. Δ
+and CI are for `MAE(model) − MAE(v14_qb_starter)` (negative ⇒ model better).
+Iterate on the rolling folds; the final window is confirmation-only (one look).
+
+| Date | Model | Change | Held-out ALL MAE | Δ vs v14 | 95% CI | Significant? | Protocol | PR |
+|------|-------|--------|------------------|----------|--------|--------------|----------|-----|
+| _—_ | _—_ | _first post-audit experiment lands here_ | _—_ | _—_ | _—_ | _—_ | _—_ | _—_ |
+
+## Historical (in-sample) log — pre-audit, deltas not reliable
+
+These rows predate the held-out harness; their `ALL MAE`/`R²` are in-sample for
+the learned models (see the warning above). Kept to prevent re-trying failed
+approaches, **not** as a ranking.
 
 | Date | Model | Change | ALL MAE | ALL R² | ALL Bias | Verdict | PR |
 |------|-------|--------|---------|--------|----------|---------|-----|


### PR DESCRIPTION
Closes #596 (Wave 1 of the 2026-06 projection-system review).

## Problem
The #579 re-plan mandated that "every new experiment must clear `just holdout-eval` + `just significance`" — but none of the agent tooling was updated, so any implementation agent following the documented workflow would reproduce the leaked evaluation: `/experiment` trained on 2022–2024, backtested **in-sample** on 2022–2025, and declared IMPROVEMENT/REGRESSION vs `v20_learned_usage` ("current best" — actually rank ~22 out-of-sample) on the ±0.01 band Finding 2 condemned. CLAUDE.md gated merges on the in-sample `accuracy-report`; the experiment-log had no held-out columns; the skills used `source venv/bin/activate && python` (which also fails in worktrees).

## Changes
- **`/experiment`** — train → `holdout-eval` (rolling) → `significance NEW v14_qb_starter` → verdict = *significant-or-not*; compares vs production `v14_qb_starter` + naïve baselines; availability experiments add `availability-backtest`; reads the Ranking-quality section (#598). Dropped the ±0.01 band and the v20 "current best" framing.
- **`/ablation`** — rebuilt around held-out + significance; flags `hypothesis_test.py` as in-sample-only, not for verdicts.
- **`/projection-accuracy`, `/compare-models`, `/feature-importance`, `/diagnose-segment`** — lead with held-out numbers; in-sample tables labelled diagnostics only.
- Replaced `source venv/bin/activate && python` with `just` recipes throughout (or bare `venv/bin/python` where no recipe exists).
- **CLAUDE.md + AGENTS.md** "Projection Model Update Requirements" — gate is now `holdout-eval` + `significance`; promotion requires a *significant* held-out win over the active model; `accuracy-report` demoted to secondary diagnostic.
- **experiment-log.md** — new "Held-out experiments" table (held-out MAE, Δ vs v14, 95% CI, significant?, protocol); legacy table relabelled "in-sample / not a ranking".

## DoD check
A fresh agent running `/experiment` on a dummy variant now produces a held-out, significance-tested verdict vs `v14_qb_starter` without touching the leaked flow. `just check-docs` + `just check-arch` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)