### PR TITLE
data(eval): backfill 2021–2023 player_stats — removes over-projection bias, reverses #579 (#599)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ docs/
 │   ├── [projection-accuracy.md](docs/generated/projection-accuracy.md)         # Projection model accuracy report (in-sample; see audit caveat)
 │   ├── [projection-holdout-eval.md](docs/generated/projection-holdout-eval.md)     # Held-out (leakage-free) model re-ranking — `just holdout-eval` (#572); naïve baselines (#575)
 │   ├── [projection-holdout-eval-matched.md](docs/generated/projection-holdout-eval-matched.md) # Held-out re-ranking on the common player set — apples-to-apples FantasyPros — `just holdout-eval --matched` (#575)
+│   ├── [projection-holdout-eval-rolling.md](docs/generated/projection-holdout-eval-rolling.md) # Held-out re-ranking, rolling-origin protocol — `just holdout-eval --protocol rolling` (#594)
 │   ├── [projection-availability-eval.md](docs/generated/projection-availability-eval.md) # Availability-inclusive backtest — rate vs availability budget — `just availability-backtest` (#574)
 │   ├── [coverage-analysis.md](docs/generated/coverage-analysis.md)            # Qualifying-population coverage: player_stats vs nflverse — `just coverage-report` (#599)
 │   ├── [rookie-backtest.md](docs/generated/rookie-backtest.md)             # Rookie (0-history) projection backtest — draft_capital vs baselines

--- a/docs/exec-plans/projection-accuracy-improvement.md
+++ b/docs/exec-plans/projection-accuracy-improvement.md
@@ -125,11 +125,18 @@ New data sources and learned models. Expected: MAE < 2.3, R² > 0.60.
 
 ### Priority 3 — Bounded recalibration / ranking experiments
 
+> **Re-scoped 2026-06-10 after the #599 backfill.** Fixing the 2021–2023 coverage
+> bug removed the learned models' over-projection bias and lifted the whole family
+> back to parity with `v14` out-of-sample (v31 #1 by 0.020 MAE, *not* significant).
+> So #590/#592 are now bets on a **calibrated, competitive** learned base rather
+> than a discredited one, and **#591 is moot** — the "level mismatch" it set out to
+> fix was the coverage artifact, now corrected.
+
 | # | Experiment | Why |
 |---|---|---|
-| [#590](https://github.com/alex-monroe/ottoneu-db/issues/590) | Delta-anchored learned model | Fixes the level-drift bias by anchoring to the per-player base; expected ceiling ≈ tie with `v14`. |
-| [#591](https://github.com/alex-monroe/ottoneu-db/issues/591) | Training-window recalibration (level-matched 2018–2020) | 2018–2020 PPG (~6.9) matches eval seasons (~7.0); wider training window may recalibrate the learned intercept. |
-| [#592](https://github.com/alex-monroe/ottoneu-db/issues/592) | QB-specific anchored model | QB is the one position where learned *beats* `v14` out-of-sample (Finding 1b). |
+| [#590](https://github.com/alex-monroe/ottoneu-db/issues/590) | Delta-anchored learned model | Anchor to the per-player base for robustness; now starting from a learned family that already ties `v14` post-backfill — aim for a *significant* held-out win. |
+| [#592](https://github.com/alex-monroe/ottoneu-db/issues/592) | QB-specific anchored model | QB is where learned has the clearest edge; per-position significance on the corrected population. |
+| ~~[#591](https://github.com/alex-monroe/ottoneu-db/issues/591)~~ **moot** | ~~Training-window recalibration (level-matched 2018–2020)~~ | The level mismatch was the #599 coverage bug (2021–2023 under-ingested), not a real scoring-environment shift. Now that all seasons are ~6.2 mean, a wider/level-matched window has no recalibration premise. |
 
 Deferred (not in the accuracy plan): uncertainty-aware/Bayesian intervals (a separate decision-quality value prop, not point-MAE).
 

--- a/docs/exec-plans/projection-methodology-audit.md
+++ b/docs/exec-plans/projection-methodology-audit.md
@@ -376,6 +376,14 @@ mix-driven illusion visible at a glance.
 
 ## 🔬 Modeling follow-up (#579): recalibration ties `v14` but doesn't beat it — NEGATIVE RESULT
 
+> ⚠️ **Superseded (2026-06-10).** The #599 backfill showed this negative result
+> was itself an artifact of the 2021–2023 coverage bug — the over-projection bias
+> below was caused by training on an inflated population, not by the models. With
+> coverage corrected the bias vanishes and the learned family returns to the top
+> of the honest ranking (still a tie with `v14`, not a significant win). See
+> [the backfill result](#backfill-result-2026-06-10-full-coverage-removes-the-bias-and-reverses-the-579-conclusion).
+> The diagnostic below is kept for the record; read its conclusion as overturned.
+
 Finding 1b left a 🔴 follow-up: the learned models over-project out-of-sample
 (bias −1.0 to −1.3) — recalibrate before re-promoting. A diagnostic settled it,
 and the answer is a **negative result**: recalibration alone cannot make a
@@ -483,14 +491,62 @@ mean-actual-PPG range from **4.08** (5.93→10.01 under the full population) to
 removes essentially all of the coverage-driven drift, confirming it was an
 artifact. Use `--population harmonized` for any cross-season comparison.
 
-**Backfill recommendation (warranted, follow-up).** The ~1,255 qualifying nflverse
-player-seasons missing from `player_stats` in 2021–2023 (409 / 466 / 380) can be
-backfilled from the same nflverse source already used for 2018–2020 and 2024–2025
-(`pull_player_stats` reads the full `stats_player` parquet with Ottoneu scoring;
-the 2018–2020 backfill set the precedent — GH #380). Because it changes the
-training population for every model, it must run the full held-out re-validation
-(`/experiment`) before any re-promotion — tracked as the #599 backfill follow-up,
-not bundled with this tooling change.
+### Backfill result (2026-06-10): full coverage removes the bias and **reverses the #579 conclusion**
+
+The 2021–2023 backfill was executed: `pull_player_stats` for 2021–2023 added
+**1,997** qualifying player-seasons from the same nflverse source used for the
+other years (the ~1,932 "unmatched" are defensive players / O-linemen not in the
+fantasy `players` table — correctly skipped). Coverage **29–40% → 82–84%**, mean
+PPG **8.0/10.0/9.6 → ~6.2** — now consistent with every other season. All 22
+additive models were re-projected on the corrected population and every learned
+model retrained out-of-sample (cache cleared — it is keyed on model definition,
+not data).
+
+The effect is decisive. Held-out (train 2021–2023, eval 2024–2025), apples-to-
+apples (N≈810–842):
+
+| Model | Before backfill | After backfill | Bias before → after |
+|---|---|---|---|
+| `v31_depth_chart` | rank 22, MAE 2.660 | **rank 1, MAE 2.269** | −1.4 → −0.107 |
+| `v25_draft_capital_residual` | bottom of table | rank 6, MAE 2.311 | — → −0.242 |
+| `v20_learned_usage` | MAE 2.683, bias −1.060 | MAE 2.325, **bias −0.032** | −1.060 → −0.032 |
+| `v27_vegas_full_refit` | MAE 2.707, bias −1.066 | MAE 2.345, bias −0.154 | −1.066 → −0.154 |
+| `v14_qb_starter` (production) | rank 1, MAE 2.450 | rank 3, MAE 2.297 | −0.149 → −0.278 |
+| `external_fantasypros_v1` | rank 3, MAE 2.462 | rank 30, MAE 2.424 (bias +0.96) | — |
+
+**The learned models' −1.0 to −1.3 over-projection bias was the coverage
+artifact, full stop.** Training on the inflated ~9.6-mean 2021–2023 baked in a
+level that didn't transfer to the true ~6.0 eval seasons (#579's exact mechanism).
+With consistent coverage the bias collapses to ≈0 and the whole learned family
+climbs back to the top of the honest ranking — `v31_depth_chart` is again #1, but
+now **without leakage** (retrained on a clean window, scored out-of-sample).
+
+**So #579 ("learned models can't beat `v14`, even with an oracle de-bias") was
+itself an artifact of the data bug, not a property of the models.** The corrected
+result depends on which protocol — and the fairer one **overturns** the production
+choice:
+
+- **Fixed window (train 2021–2023 → 2024–2025)** — `v31` leads `v14` by 0.020 MAE
+  but the paired player-clustered bootstrap is **not significant** (95% CI
+  [−0.113, +0.078], p=0.68): a tie. (This protocol still hands the learned models
+  only 3 training seasons vs the 5 production would use.)
+- **Rolling-origin (#594, the fair protocol — expanding to 5 training seasons)** —
+  `v31` beats `v14` by **0.091 MAE, and it is SIGNIFICANT**: 95% CI
+  [−0.163, −0.020], p=0.014, clustered over 617 players (N=1,216). `v27` is second
+  (2.298). The learned family clearly leads once it gets a time-honest training
+  window on clean data.
+
+**This clears the promotion gate** ("a *significant* held-out win over the active
+model"): under the standing rolling protocol, the demoted-by-#579 `v31_depth_chart`
+is now the honest, well-calibrated (bias −0.16) out-of-sample leader. Promotion is
+a production decision left to the operator, but `v31` (or a #590/#592 successor) is
+now the live candidate. This also **re-opens #590 (delta-anchored) and #592
+(QB-specific)** as bets on a competitive base and makes **#591 (level-matched
+window) moot** — the level mismatch *was* the coverage bug, now fixed.
+
+*Production note:* the active model's current-season (2026) projections were
+computed on pre-backfill history and should be regenerated (`just analyze`) so the
+web app is consistent with the corrected data; no automatic promotion was made.
 
 ---
 

--- a/docs/generated/coverage-analysis.md
+++ b/docs/generated/coverage-analysis.md
@@ -1,6 +1,6 @@
 # Qualifying-Population Coverage Analysis (GH #599)
 
-_Generated: 2026-06-10 13:43_
+_Generated: 2026-06-10 14:19_
 
 Coverage of the Ottoneu `player_stats` qualifying population (games ≥ 4) against the stable nflverse `nfl_stats` denominator (same scoring). **Coverage %** = player_stats qualifiers ÷ nfl_stats qualifiers. **Missing** = qualifying nflverse player-seasons absent from `player_stats`.
 
@@ -19,9 +19,9 @@ Coverage of the Ottoneu `player_stats` qualifying population (games ≥ 4) again
 | 2018 | 633 | 524 | 6.51 | 654 | 80% | 130 |
 | 2019 | 636 | 513 | 6.48 | 635 | 81% | 122 |
 | 2020 | 678 | 547 | 6.54 | 672 | 81% | 125 |
-| 2021 | 331 | 275 | 8.03 | 684 | 40% | 409 |
-| 2022 | 201 | 189 | 10.01 | 655 | 29% | 466 |
-| 2023 | 248 | 234 | 9.60 | 614 | 38% | 380 |
+| 2021 | 706 | 561 | 6.24 | 684 | 82% | 123 |
+| 2022 | 667 | 536 | 6.13 | 655 | 82% | 119 |
+| 2023 | 632 | 517 | 6.23 | 614 | 84% | 97 |
 | 2024 | 651 | 537 | 6.15 | 622 | 86% | 85 |
 | 2025 | 1252 | 516 | 5.93 | 638 | 81% | 152 |
 
@@ -42,9 +42,9 @@ _If the level drift were football, both columns would move together. They don't:
 | 2018 | 6.51 | 6.39 | 80% |
 | 2019 | 6.48 | 6.22 | 81% |
 | 2020 | 6.54 | 6.32 | 81% |
-| 2021 | 8.03 | 5.99 | 40% |
-| 2022 | 10.01 | 5.74 | 29% |
-| 2023 | 9.60 | 5.77 | 38% |
+| 2021 | 6.24 | 5.99 | 82% |
+| 2022 | 6.13 | 5.74 | 82% |
+| 2023 | 6.23 | 5.77 | 84% |
 | 2024 | 6.15 | 5.68 | 86% |
 | 2025 | 5.93 | 5.46 | 81% |
 
@@ -63,8 +63,8 @@ _If the level drift were football, both columns would move together. They don't:
 | 2018 | 55 | 141 | 194 | 98 | 36 |
 | 2019 | 49 | 135 | 196 | 95 | 38 |
 | 2020 | 57 | 151 | 205 | 96 | 38 |
-| 2021 | 42 | 53 | 88 | 62 | 30 |
-| 2022 | 40 | 38 | 43 | 43 | 25 |
-| 2023 | 47 | 47 | 55 | 56 | 29 |
+| 2021 | 59 | 145 | 211 | 107 | 39 |
+| 2022 | 59 | 145 | 197 | 100 | 35 |
+| 2023 | 61 | 130 | 191 | 99 | 36 |
 | 2024 | 58 | 129 | 202 | 106 | 42 |
 | 2025 | 65 | 119 | 182 | 112 | 38 |

--- a/docs/generated/experiment-log.md
+++ b/docs/generated/experiment-log.md
@@ -20,7 +20,9 @@ Iterate on the rolling folds; the final window is confirmation-only (one look).
 
 | Date | Model | Change | Held-out ALL MAE | Δ vs v14 | 95% CI | Significant? | Protocol | PR |
 |------|-------|--------|------------------|----------|--------|--------------|----------|-----|
-| _—_ | _—_ | _first post-audit experiment lands here_ | _—_ | _—_ | _—_ | _—_ | _—_ | _—_ |
+| 2026-06-10 | v31_depth_chart | #599 backfill of 2021–2023 player_stats (coverage 29–40%→82–84%); all models re-projected/retrained on the corrected population | 2.232 | **−0.091** | [−0.163, −0.020] | **Y** (p=0.014, 617 clusters) | rolling 2023–2025 | #599 backfill |
+| 2026-06-10 | v31_depth_chart | same — fixed window (3-season train handicap) | 2.269 | −0.020 | [−0.113, +0.078] | N (p=0.68) | fixed 2021–23→24–25 | #599 backfill |
+| 2026-06-10 | v20_learned_usage | same backfill — over-projection bias check | 2.325 | — | bias −1.060→**−0.032** | bias artifact removed | fixed | #599 backfill |
 
 ## Historical (in-sample) log — pre-audit, deltas not reliable
 

--- a/docs/generated/projection-availability-eval.md
+++ b/docs/generated/projection-availability-eval.md
@@ -1,6 +1,6 @@
 # Projection Availability-Inclusive Evaluation (GH #574)
 
-_Generated: 2026-06-10 13:09_
+_Generated: 2026-06-10 14:19_
 
 Standard backtests score only players with ≥4 games, hiding injured/benched/bust seasons. This evaluation keeps everyone with ≥1 game (non-rookie) and scores each PPG projection against two targets: **Rate** = actual PPG, and **Avail** = availability-inclusive production per scheduled game (`ppg × min(games,17) / 17`, missed games = 0). The gap **avail-MAE − rate-MAE** is the *availability error budget* — error from playing-time loss that no current rate feature addresses. Default models are parameter-free (additive + external), whose stored projections are leakage-free; learned models (if included) use in-sample projections (see #571). Seasons: 2022,2023,2024,2025. See [docs/exec-plans/projection-methodology-audit.md](../exec-plans/projection-methodology-audit.md) (Finding 3).
 
@@ -10,29 +10,29 @@ _**Avail MAE** is pooled over players; **Bal Avail MAE** is the position-balance
 
 | Model | N | Mean games | Rate MAE | Avail MAE | Bal Avail MAE | Availability budget | Avail bias |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 703 | 13.1 | 2.598 | 2.489 | 2.510 | -0.109 | -0.455 |
-| `v7_regression_to_mean` | 1069 | 12.6 | 2.652 | 3.096 | 3.312 | +0.444 | -1.530 |
-| `v4_availability_adjusted` | 1069 | 12.6 | 2.673 | 3.106 | 3.317 | +0.433 | -1.527 |
-| `v5_team_context` | 1069 | 12.6 | 2.679 | 3.117 | 3.330 | +0.437 | -1.550 |
-| `v21_tiered_regression` | 1069 | 12.6 | 2.599 | 3.120 | 3.348 | +0.521 | -1.536 |
-| `v6_usage_share` | 1069 | 12.6 | 2.703 | 3.179 | 3.396 | +0.475 | -1.697 |
-| `v14_qb_starter` | 1069 | 12.6 | 2.555 | 3.188 | 3.431 | +0.633 | -1.747 |
-| `v16_snap_trend_full` | 1069 | 12.6 | 2.570 | 3.216 | 3.468 | +0.646 | -1.781 |
-| `v19_usage_level_full` | 1069 | 12.6 | 2.560 | 3.247 | 3.495 | +0.687 | -1.894 |
-| `v12_no_qb_trajectory` | 1069 | 12.6 | 2.568 | 3.252 | 3.512 | +0.684 | -1.815 |
-| `v17_rookie_growth` | 1069 | 12.6 | 2.610 | 3.252 | 3.501 | +0.642 | -1.817 |
-| `v10_stat_efficiency_v2` | 1069 | 12.6 | 2.577 | 3.257 | 3.509 | +0.681 | -1.835 |
-| `v8_age_regression` | 1069 | 12.6 | 2.579 | 3.265 | 3.519 | +0.686 | -1.843 |
-| `v9_pos_specific` | 1069 | 12.6 | 2.579 | 3.265 | 3.519 | +0.686 | -1.843 |
-| `v13_qb_starter` | 1069 | 12.6 | 2.578 | 3.268 | 3.523 | +0.691 | -1.842 |
-| `v11_team_context_v2` | 1069 | 12.6 | 2.585 | 3.270 | 3.524 | +0.685 | -1.869 |
-| `v3_stat_weighted` | 1069 | 12.6 | 2.615 | 3.334 | 3.590 | +0.720 | -1.996 |
-| `v2_age_adjusted` | 1069 | 12.6 | 2.617 | 3.343 | 3.601 | +0.726 | -2.010 |
-| `v15_snap_trend` | 1069 | 12.6 | 2.649 | 3.375 | 3.642 | +0.725 | -2.044 |
-| `v18_usage_level` | 1069 | 12.6 | 2.658 | 3.414 | 3.677 | +0.756 | -2.157 |
-| `naive_prior_season_ppg` | 1098 | 12.4 | 2.819 | 3.476 | 3.754 | +0.657 | -1.979 |
-| `v1_baseline_weighted_ppg` | 1069 | 12.6 | 2.693 | 3.510 | 3.788 | +0.817 | -2.242 |
-| `position_mean_baseline` | 1098 | 12.4 | 4.078 | 4.312 | 4.717 | +0.234 | -0.700 |
+| `external_fantasypros_v1` | 761 | 12.7 | 2.513 | 2.389 | 2.412 | -0.124 | -0.461 |
+| `v4_availability_adjusted` | 1731 | 11.1 | 2.369 | 2.758 | 3.002 | +0.389 | -1.623 |
+| `v5_team_context` | 1731 | 11.1 | 2.393 | 2.783 | 3.031 | +0.389 | -1.644 |
+| `v7_regression_to_mean` | 1731 | 11.1 | 2.385 | 2.791 | 3.036 | +0.406 | -1.630 |
+| `v6_usage_share` | 1731 | 11.1 | 2.416 | 2.829 | 3.073 | +0.413 | -1.746 |
+| `v21_tiered_regression` | 1731 | 11.1 | 2.445 | 2.917 | 3.196 | +0.473 | -1.809 |
+| `v14_qb_starter` | 1731 | 11.1 | 2.398 | 2.986 | 3.291 | +0.589 | -1.946 |
+| `v16_snap_trend_full` | 1731 | 11.1 | 2.404 | 3.004 | 3.318 | +0.600 | -1.968 |
+| `v17_rookie_growth` | 1731 | 11.1 | 2.421 | 3.022 | 3.325 | +0.601 | -1.994 |
+| `v19_usage_level_full` | 1731 | 11.1 | 2.407 | 3.035 | 3.337 | +0.628 | -2.053 |
+| `v12_no_qb_trajectory` | 1731 | 11.1 | 2.415 | 3.039 | 3.383 | +0.624 | -2.001 |
+| `v10_stat_efficiency_v2` | 1731 | 11.1 | 2.419 | 3.041 | 3.380 | +0.621 | -2.010 |
+| `v8_age_regression` | 1731 | 11.1 | 2.421 | 3.047 | 3.389 | +0.625 | -2.019 |
+| `v9_pos_specific` | 1731 | 11.1 | 2.421 | 3.047 | 3.389 | +0.625 | -2.019 |
+| `v13_qb_starter` | 1731 | 11.1 | 2.421 | 3.049 | 3.392 | +0.627 | -2.017 |
+| `v11_team_context_v2` | 1731 | 11.1 | 2.439 | 3.057 | 3.400 | +0.618 | -2.031 |
+| `v3_stat_weighted` | 1731 | 11.1 | 2.440 | 3.083 | 3.423 | +0.642 | -2.136 |
+| `v2_age_adjusted` | 1731 | 11.1 | 2.441 | 3.085 | 3.426 | +0.644 | -2.141 |
+| `v15_snap_trend` | 1731 | 11.1 | 2.460 | 3.107 | 3.457 | +0.646 | -2.163 |
+| `naive_prior_season_ppg` | 1972 | 10.8 | 2.594 | 3.116 | 3.451 | +0.522 | -2.050 |
+| `v18_usage_level` | 1731 | 11.1 | 2.478 | 3.145 | 3.481 | +0.666 | -2.248 |
+| `v1_baseline_weighted_ppg` | 1731 | 11.1 | 2.487 | 3.188 | 3.551 | +0.701 | -2.284 |
+| `position_mean_baseline` | 1972 | 10.8 | 3.816 | 4.102 | 4.571 | +0.286 | -1.423 |
 
 ## Availability-inclusive metrics by position
 
@@ -40,168 +40,168 @@ _**Avail MAE** is pooled over players; **Bal Avail MAE** is the position-balance
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 2.489 | -0.455 | 0.594 | 3.539 | 703 |
-| `v7_regression_to_mean` | 3.096 | -1.530 | 0.349 | 4.234 | 1069 |
-| `v4_availability_adjusted` | 3.106 | -1.527 | 0.322 | 4.324 | 1069 |
-| `v5_team_context` | 3.117 | -1.550 | 0.315 | 4.344 | 1069 |
-| `v21_tiered_regression` | 3.120 | -1.536 | 0.309 | 4.363 | 1069 |
-| `v6_usage_share` | 3.179 | -1.697 | 0.292 | 4.417 | 1069 |
-| `v14_qb_starter` | 3.188 | -1.747 | 0.312 | 4.355 | 1069 |
-| `v16_snap_trend_full` | 3.216 | -1.781 | 0.296 | 4.404 | 1069 |
-| `v19_usage_level_full` | 3.247 | -1.894 | 0.293 | 4.412 | 1069 |
-| `v12_no_qb_trajectory` | 3.252 | -1.815 | 0.273 | 4.475 | 1069 |
-| `v17_rookie_growth` | 3.252 | -1.817 | 0.300 | 4.392 | 1069 |
-| `v10_stat_efficiency_v2` | 3.257 | -1.835 | 0.259 | 4.518 | 1069 |
-| `v8_age_regression` | 3.265 | -1.843 | 0.256 | 4.527 | 1069 |
-| `v9_pos_specific` | 3.265 | -1.843 | 0.256 | 4.527 | 1069 |
-| `v13_qb_starter` | 3.268 | -1.842 | 0.255 | 4.531 | 1069 |
-| `v11_team_context_v2` | 3.270 | -1.869 | 0.252 | 4.540 | 1069 |
-| `v3_stat_weighted` | 3.334 | -1.996 | 0.210 | 4.665 | 1069 |
-| `v2_age_adjusted` | 3.343 | -2.010 | 0.205 | 4.681 | 1069 |
-| `v15_snap_trend` | 3.375 | -2.044 | 0.186 | 4.735 | 1069 |
-| `v18_usage_level` | 3.414 | -2.157 | 0.178 | 4.759 | 1069 |
-| `naive_prior_season_ppg` | 3.476 | -1.979 | 0.130 | 4.919 | 1098 |
-| `v1_baseline_weighted_ppg` | 3.510 | -2.242 | 0.134 | 4.885 | 1069 |
-| `position_mean_baseline` | 4.312 | -0.700 | -0.064 | 5.439 | 1098 |
+| `external_fantasypros_v1` | 2.389 | -0.461 | 0.622 | 3.441 | 761 |
+| `v4_availability_adjusted` | 2.758 | -1.623 | 0.383 | 3.889 | 1731 |
+| `v5_team_context` | 2.783 | -1.644 | 0.373 | 3.919 | 1731 |
+| `v7_regression_to_mean` | 2.791 | -1.630 | 0.407 | 3.813 | 1731 |
+| `v6_usage_share` | 2.829 | -1.746 | 0.353 | 3.981 | 1731 |
+| `v21_tiered_regression` | 2.917 | -1.809 | 0.310 | 4.110 | 1731 |
+| `v14_qb_starter` | 2.986 | -1.946 | 0.344 | 4.011 | 1731 |
+| `v16_snap_trend_full` | 3.004 | -1.968 | 0.332 | 4.045 | 1731 |
+| `v17_rookie_growth` | 3.022 | -1.994 | 0.337 | 4.031 | 1731 |
+| `v19_usage_level_full` | 3.035 | -2.053 | 0.325 | 4.068 | 1731 |
+| `v12_no_qb_trajectory` | 3.039 | -2.001 | 0.309 | 4.113 | 1731 |
+| `v10_stat_efficiency_v2` | 3.041 | -2.010 | 0.301 | 4.138 | 1731 |
+| `v8_age_regression` | 3.047 | -2.019 | 0.298 | 4.148 | 1731 |
+| `v9_pos_specific` | 3.047 | -2.019 | 0.298 | 4.148 | 1731 |
+| `v13_qb_starter` | 3.049 | -2.017 | 0.297 | 4.149 | 1731 |
+| `v11_team_context_v2` | 3.057 | -2.031 | 0.293 | 4.163 | 1731 |
+| `v3_stat_weighted` | 3.083 | -2.136 | 0.247 | 4.296 | 1731 |
+| `v2_age_adjusted` | 3.085 | -2.141 | 0.245 | 4.302 | 1731 |
+| `v15_snap_trend` | 3.107 | -2.163 | 0.231 | 4.342 | 1731 |
+| `naive_prior_season_ppg` | 3.116 | -2.050 | 0.151 | 4.447 | 1972 |
+| `v18_usage_level` | 3.145 | -2.248 | 0.218 | 4.377 | 1731 |
+| `v1_baseline_weighted_ppg` | 3.188 | -2.284 | 0.196 | 4.440 | 1731 |
+| `position_mean_baseline` | 4.102 | -1.423 | -0.078 | 5.011 | 1972 |
 
 ### QB
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 3.299 | -0.964 | 0.575 | 4.768 | 174 |
-| `v4_availability_adjusted` | 5.054 | -3.283 | 0.148 | 6.563 | 211 |
-| `v7_regression_to_mean` | 5.078 | -3.265 | 0.183 | 6.429 | 211 |
-| `v5_team_context` | 5.115 | -3.330 | 0.135 | 6.613 | 211 |
-| `v6_usage_share` | 5.115 | -3.330 | 0.135 | 6.613 | 211 |
-| `v21_tiered_regression` | 5.411 | -3.736 | 0.074 | 6.842 | 211 |
-| `v14_qb_starter` | 5.707 | -4.258 | 0.043 | 6.958 | 211 |
-| `v17_rookie_growth` | 5.707 | -4.258 | 0.043 | 6.958 | 211 |
-| `v19_usage_level_full` | 5.707 | -4.258 | 0.043 | 6.958 | 211 |
-| `v16_snap_trend_full` | 5.787 | -4.329 | 0.017 | 7.053 | 211 |
-| `v12_no_qb_trajectory` | 6.031 | -4.602 | -0.064 | 7.335 | 211 |
-| `v3_stat_weighted` | 6.047 | -4.759 | -0.132 | 7.566 | 211 |
-| `v10_stat_efficiency_v2` | 6.048 | -4.704 | -0.098 | 7.453 | 211 |
-| `v8_age_regression` | 6.058 | -4.726 | -0.104 | 7.471 | 211 |
-| `v9_pos_specific` | 6.058 | -4.726 | -0.104 | 7.471 | 211 |
-| `v11_team_context_v2` | 6.064 | -4.779 | -0.109 | 7.489 | 211 |
-| `v2_age_adjusted` | 6.069 | -4.791 | -0.143 | 7.602 | 211 |
-| `v18_usage_level` | 6.069 | -4.791 | -0.143 | 7.602 | 211 |
-| `v13_qb_starter` | 6.074 | -4.721 | -0.107 | 7.484 | 211 |
-| `v15_snap_trend` | 6.162 | -4.862 | -0.173 | 7.704 | 211 |
-| `naive_prior_season_ppg` | 6.338 | -4.546 | -0.268 | 8.007 | 211 |
-| `v1_baseline_weighted_ppg` | 6.355 | -5.165 | -0.229 | 7.882 | 211 |
-| `position_mean_baseline` | 7.314 | -4.264 | -0.373 | 8.333 | 211 |
+| `external_fantasypros_v1` | 3.195 | -0.928 | 0.595 | 4.677 | 181 |
+| `v4_availability_adjusted` | 4.919 | -3.367 | 0.166 | 6.440 | 249 |
+| `v7_regression_to_mean` | 4.941 | -3.286 | 0.214 | 6.251 | 249 |
+| `v6_usage_share` | 4.971 | -3.403 | 0.157 | 6.472 | 249 |
+| `v5_team_context` | 4.987 | -3.403 | 0.157 | 6.473 | 249 |
+| `v21_tiered_regression` | 5.339 | -3.868 | 0.063 | 6.824 | 249 |
+| `v14_qb_starter` | 5.579 | -4.272 | 0.065 | 6.819 | 249 |
+| `v17_rookie_growth` | 5.579 | -4.272 | 0.065 | 6.819 | 249 |
+| `v19_usage_level_full` | 5.579 | -4.272 | 0.065 | 6.819 | 249 |
+| `v16_snap_trend_full` | 5.640 | -4.324 | 0.043 | 6.897 | 249 |
+| `v12_no_qb_trajectory` | 5.947 | -4.657 | -0.052 | 7.231 | 249 |
+| `v10_stat_efficiency_v2` | 5.947 | -4.739 | -0.077 | 7.317 | 249 |
+| `v8_age_regression` | 5.968 | -4.763 | -0.085 | 7.346 | 249 |
+| `v9_pos_specific` | 5.968 | -4.763 | -0.085 | 7.346 | 249 |
+| `v11_team_context_v2` | 5.980 | -4.796 | -0.086 | 7.348 | 249 |
+| `v13_qb_starter` | 5.981 | -4.753 | -0.087 | 7.352 | 249 |
+| `naive_prior_season_ppg` | 5.983 | -4.529 | -0.201 | 7.660 | 272 |
+| `v3_stat_weighted` | 5.996 | -4.859 | -0.136 | 7.516 | 249 |
+| `v2_age_adjusted` | 5.998 | -4.880 | -0.141 | 7.530 | 249 |
+| `v18_usage_level` | 5.998 | -4.880 | -0.141 | 7.530 | 249 |
+| `v15_snap_trend` | 6.069 | -4.931 | -0.167 | 7.617 | 249 |
+| `v1_baseline_weighted_ppg` | 6.240 | -5.196 | -0.214 | 7.770 | 249 |
+| `position_mean_baseline` | 7.466 | -4.450 | -0.408 | 8.294 | 272 |
 
 ### RB
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 2.825 | -0.112 | 0.524 | 3.765 | 153 |
-| `v10_stat_efficiency_v2` | 3.378 | -1.221 | 0.427 | 4.295 | 217 |
-| `v11_team_context_v2` | 3.393 | -1.272 | 0.420 | 4.320 | 217 |
-| `v21_tiered_regression` | 3.399 | -1.033 | 0.394 | 4.417 | 217 |
-| `v8_age_regression` | 3.404 | -1.230 | 0.422 | 4.313 | 217 |
-| `v9_pos_specific` | 3.404 | -1.230 | 0.422 | 4.313 | 217 |
-| `v12_no_qb_trajectory` | 3.404 | -1.230 | 0.422 | 4.313 | 217 |
-| `v13_qb_starter` | 3.404 | -1.230 | 0.422 | 4.313 | 217 |
-| `v14_qb_starter` | 3.404 | -1.230 | 0.422 | 4.313 | 217 |
-| `v5_team_context` | 3.450 | -1.148 | 0.382 | 4.459 | 217 |
-| `v7_regression_to_mean` | 3.458 | -1.138 | 0.402 | 4.388 | 217 |
-| `v16_snap_trend_full` | 3.461 | -1.305 | 0.403 | 4.382 | 217 |
-| `v4_availability_adjusted` | 3.481 | -1.127 | 0.382 | 4.458 | 217 |
-| `v19_usage_level_full` | 3.529 | -1.500 | 0.389 | 4.433 | 217 |
-| `v3_stat_weighted` | 3.530 | -1.485 | 0.368 | 4.508 | 217 |
-| `v17_rookie_growth` | 3.540 | -1.385 | 0.388 | 4.437 | 217 |
-| `v2_age_adjusted` | 3.541 | -1.510 | 0.364 | 4.522 | 217 |
-| `v6_usage_share` | 3.548 | -1.417 | 0.346 | 4.588 | 217 |
-| `v15_snap_trend` | 3.585 | -1.584 | 0.342 | 4.602 | 217 |
-| `naive_prior_season_ppg` | 3.589 | -1.517 | 0.292 | 4.825 | 227 |
-| `v1_baseline_weighted_ppg` | 3.667 | -1.810 | 0.294 | 4.766 | 217 |
-| `v18_usage_level` | 3.671 | -1.779 | 0.317 | 4.689 | 217 |
-| `position_mean_baseline` | 4.959 | +0.541 | -0.027 | 5.815 | 227 |
+| `external_fantasypros_v1` | 2.703 | -0.140 | 0.570 | 3.663 | 166 |
+| `v4_availability_adjusted` | 2.865 | -1.446 | 0.443 | 3.919 | 413 |
+| `v5_team_context` | 2.870 | -1.458 | 0.433 | 3.954 | 413 |
+| `v7_regression_to_mean` | 2.928 | -1.464 | 0.451 | 3.890 | 413 |
+| `v6_usage_share` | 2.945 | -1.630 | 0.403 | 4.056 | 413 |
+| `v21_tiered_regression` | 2.999 | -1.602 | 0.373 | 4.155 | 413 |
+| `v10_stat_efficiency_v2` | 3.061 | -1.737 | 0.430 | 3.961 | 413 |
+| `v8_age_regression` | 3.071 | -1.751 | 0.428 | 3.971 | 413 |
+| `v9_pos_specific` | 3.071 | -1.751 | 0.428 | 3.971 | 413 |
+| `v12_no_qb_trajectory` | 3.071 | -1.751 | 0.428 | 3.971 | 413 |
+| `v13_qb_starter` | 3.071 | -1.751 | 0.428 | 3.971 | 413 |
+| `v14_qb_starter` | 3.071 | -1.751 | 0.428 | 3.971 | 413 |
+| `v11_team_context_v2` | 3.071 | -1.756 | 0.420 | 3.996 | 413 |
+| `v3_stat_weighted` | 3.101 | -1.903 | 0.376 | 4.148 | 413 |
+| `v2_age_adjusted` | 3.107 | -1.909 | 0.373 | 4.155 | 413 |
+| `v16_snap_trend_full` | 3.114 | -1.799 | 0.411 | 4.028 | 413 |
+| `v17_rookie_growth` | 3.134 | -1.842 | 0.408 | 4.038 | 413 |
+| `v15_snap_trend` | 3.147 | -1.957 | 0.354 | 4.220 | 413 |
+| `v19_usage_level_full` | 3.159 | -1.925 | 0.396 | 4.081 | 413 |
+| `naive_prior_season_ppg` | 3.165 | -1.907 | 0.239 | 4.427 | 481 |
+| `v1_baseline_weighted_ppg` | 3.173 | -2.067 | 0.330 | 4.296 | 413 |
+| `v18_usage_level` | 3.204 | -2.083 | 0.329 | 4.300 | 413 |
+| `position_mean_baseline` | 4.481 | -0.973 | -0.040 | 5.177 | 481 |
 
 ### WR
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 2.433 | -0.695 | 0.451 | 3.175 | 196 |
-| `v21_tiered_regression` | 2.784 | -1.279 | 0.366 | 3.763 | 291 |
-| `v8_age_regression` | 2.814 | -1.296 | 0.402 | 3.656 | 291 |
-| `v9_pos_specific` | 2.814 | -1.296 | 0.402 | 3.656 | 291 |
-| `v12_no_qb_trajectory` | 2.814 | -1.296 | 0.402 | 3.656 | 291 |
-| `v13_qb_starter` | 2.814 | -1.296 | 0.402 | 3.656 | 291 |
-| `v14_qb_starter` | 2.814 | -1.296 | 0.402 | 3.656 | 291 |
-| `v11_team_context_v2` | 2.815 | -1.313 | 0.397 | 3.672 | 291 |
-| `v10_stat_efficiency_v2` | 2.818 | -1.293 | 0.401 | 3.658 | 291 |
-| `v16_snap_trend_full` | 2.827 | -1.345 | 0.392 | 3.686 | 291 |
-| `v7_regression_to_mean` | 2.876 | -1.427 | 0.362 | 3.777 | 291 |
-| `v4_availability_adjusted` | 2.881 | -1.422 | 0.327 | 3.878 | 291 |
-| `v5_team_context` | 2.889 | -1.445 | 0.320 | 3.898 | 291 |
-| `v19_usage_level_full` | 2.894 | -1.548 | 0.365 | 3.767 | 291 |
-| `v3_stat_weighted` | 2.903 | -1.556 | 0.324 | 3.887 | 291 |
-| `v17_rookie_growth` | 2.906 | -1.396 | 0.392 | 3.686 | 291 |
-| `v2_age_adjusted` | 2.908 | -1.564 | 0.322 | 3.892 | 291 |
-| `v15_snap_trend` | 2.934 | -1.612 | 0.310 | 3.926 | 291 |
-| `v6_usage_share` | 2.998 | -1.696 | 0.270 | 4.040 | 291 |
-| `v18_usage_level` | 3.019 | -1.816 | 0.268 | 4.043 | 291 |
-| `naive_prior_season_ppg` | 3.064 | -1.655 | 0.270 | 4.091 | 302 |
-| `v1_baseline_weighted_ppg` | 3.106 | -1.754 | 0.247 | 4.101 | 291 |
-| `position_mean_baseline` | 4.034 | +0.552 | -0.007 | 4.804 | 302 |
+| `external_fantasypros_v1` | 2.329 | -0.717 | 0.549 | 3.078 | 223 |
+| `v4_availability_adjusted` | 2.518 | -1.528 | 0.413 | 3.346 | 591 |
+| `v5_team_context` | 2.556 | -1.561 | 0.397 | 3.394 | 591 |
+| `v7_regression_to_mean` | 2.572 | -1.561 | 0.431 | 3.295 | 591 |
+| `v6_usage_share` | 2.619 | -1.694 | 0.362 | 3.491 | 591 |
+| `v21_tiered_regression` | 2.678 | -1.703 | 0.335 | 3.564 | 591 |
+| `v10_stat_efficiency_v2` | 2.688 | -1.696 | 0.408 | 3.363 | 591 |
+| `v8_age_regression` | 2.690 | -1.702 | 0.407 | 3.365 | 591 |
+| `v9_pos_specific` | 2.690 | -1.702 | 0.407 | 3.365 | 591 |
+| `v12_no_qb_trajectory` | 2.690 | -1.702 | 0.407 | 3.365 | 591 |
+| `v13_qb_starter` | 2.690 | -1.702 | 0.407 | 3.365 | 591 |
+| `v14_qb_starter` | 2.690 | -1.702 | 0.407 | 3.365 | 591 |
+| `v16_snap_trend_full` | 2.695 | -1.730 | 0.402 | 3.379 | 591 |
+| `v11_team_context_v2` | 2.704 | -1.715 | 0.398 | 3.390 | 591 |
+| `v17_rookie_growth` | 2.733 | -1.761 | 0.404 | 3.373 | 591 |
+| `v2_age_adjusted` | 2.733 | -1.850 | 0.339 | 3.552 | 591 |
+| `v3_stat_weighted` | 2.734 | -1.850 | 0.340 | 3.551 | 591 |
+| `v15_snap_trend` | 2.746 | -1.879 | 0.333 | 3.568 | 591 |
+| `v19_usage_level_full` | 2.750 | -1.849 | 0.375 | 3.455 | 591 |
+| `naive_prior_season_ppg` | 2.804 | -1.795 | 0.208 | 3.756 | 698 |
+| `v18_usage_level` | 2.814 | -1.998 | 0.294 | 3.672 | 591 |
+| `v1_baseline_weighted_ppg` | 2.831 | -1.944 | 0.296 | 3.666 | 591 |
+| `position_mean_baseline` | 3.698 | -0.901 | -0.048 | 4.319 | 698 |
 
 ### TE
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 1.482 | +0.007 | 0.582 | 1.978 | 180 |
-| `v10_stat_efficiency_v2` | 1.794 | -0.756 | 0.439 | 2.298 | 235 |
-| `v16_snap_trend_full` | 1.799 | -0.767 | 0.438 | 2.300 | 235 |
-| `v8_age_regression` | 1.799 | -0.760 | 0.436 | 2.304 | 235 |
-| `v9_pos_specific` | 1.799 | -0.760 | 0.436 | 2.304 | 235 |
-| `v12_no_qb_trajectory` | 1.799 | -0.760 | 0.436 | 2.304 | 235 |
-| `v13_qb_starter` | 1.799 | -0.760 | 0.436 | 2.304 | 235 |
-| `v14_qb_starter` | 1.799 | -0.760 | 0.436 | 2.304 | 235 |
-| `v21_tiered_regression` | 1.799 | -0.532 | 0.429 | 2.318 | 235 |
-| `v11_team_context_v2` | 1.824 | -0.770 | 0.428 | 2.322 | 235 |
-| `v7_regression_to_mean` | 1.833 | -0.673 | 0.407 | 2.364 | 235 |
-| `v19_usage_level_full` | 1.851 | -0.870 | 0.402 | 2.372 | 235 |
-| `v17_rookie_growth` | 1.852 | -0.815 | 0.415 | 2.348 | 235 |
-| `v4_availability_adjusted` | 1.853 | -0.648 | 0.380 | 2.416 | 235 |
-| `v5_team_context` | 1.865 | -0.663 | 0.376 | 2.425 | 235 |
-| `v3_stat_weighted` | 1.879 | -0.857 | 0.370 | 2.435 | 235 |
-| `v2_age_adjusted` | 1.884 | -0.859 | 0.371 | 2.434 | 235 |
-| `v15_snap_trend` | 1.887 | -0.866 | 0.373 | 2.430 | 235 |
-| `v6_usage_share` | 1.923 | -0.773 | 0.329 | 2.514 | 235 |
-| `v18_usage_level` | 1.948 | -0.969 | 0.321 | 2.529 | 235 |
-| `naive_prior_season_ppg` | 2.024 | -0.977 | 0.268 | 2.640 | 243 |
-| `v1_baseline_weighted_ppg` | 2.025 | -1.115 | 0.275 | 2.612 | 235 |
-| `position_mean_baseline` | 2.562 | -0.167 | 0.003 | 3.081 | 243 |
+| `external_fantasypros_v1` | 1.422 | +0.001 | 0.612 | 1.926 | 191 |
+| `v7_regression_to_mean` | 1.700 | -0.842 | 0.467 | 2.184 | 348 |
+| `v4_availability_adjusted` | 1.706 | -0.818 | 0.441 | 2.237 | 348 |
+| `v5_team_context` | 1.710 | -0.826 | 0.441 | 2.237 | 348 |
+| `v6_usage_share` | 1.756 | -0.901 | 0.403 | 2.311 | 348 |
+| `v21_tiered_regression` | 1.770 | -0.881 | 0.413 | 2.292 | 348 |
+| `v16_snap_trend_full` | 1.823 | -1.059 | 0.413 | 2.291 | 348 |
+| `v10_stat_efficiency_v2` | 1.825 | -1.055 | 0.413 | 2.292 | 348 |
+| `v8_age_regression` | 1.827 | -1.057 | 0.413 | 2.292 | 348 |
+| `v9_pos_specific` | 1.827 | -1.057 | 0.413 | 2.292 | 348 |
+| `v12_no_qb_trajectory` | 1.827 | -1.057 | 0.413 | 2.292 | 348 |
+| `v13_qb_starter` | 1.827 | -1.057 | 0.413 | 2.292 | 348 |
+| `v14_qb_starter` | 1.827 | -1.057 | 0.413 | 2.292 | 348 |
+| `v11_team_context_v2` | 1.845 | -1.064 | 0.403 | 2.311 | 348 |
+| `v17_rookie_growth` | 1.854 | -1.086 | 0.405 | 2.308 | 348 |
+| `naive_prior_season_ppg` | 1.854 | -1.131 | 0.302 | 2.446 | 385 |
+| `v19_usage_level_full` | 1.859 | -1.132 | 0.389 | 2.338 | 348 |
+| `v3_stat_weighted` | 1.861 | -1.126 | 0.363 | 2.387 | 348 |
+| `v15_snap_trend` | 1.865 | -1.129 | 0.362 | 2.389 | 348 |
+| `v2_age_adjusted` | 1.866 | -1.128 | 0.362 | 2.390 | 348 |
+| `v18_usage_level` | 1.909 | -1.203 | 0.325 | 2.458 | 348 |
+| `v1_baseline_weighted_ppg` | 1.961 | -1.300 | 0.294 | 2.514 | 348 |
+| `position_mean_baseline` | 2.640 | -0.832 | -0.082 | 3.047 | 385 |
 
 ### K
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `v7_regression_to_mean` | 1.913 | -1.097 | -0.078 | 2.638 | 115 |
-| `v16_snap_trend_full` | 1.916 | -1.181 | -0.176 | 2.755 | 115 |
-| `v21_tiered_regression` | 1.938 | -1.155 | -0.155 | 2.731 | 115 |
-| `v12_no_qb_trajectory` | 1.945 | -1.269 | -0.187 | 2.768 | 115 |
-| `v14_qb_starter` | 1.945 | -1.269 | -0.187 | 2.768 | 115 |
-| `v17_rookie_growth` | 1.945 | -1.269 | -0.187 | 2.768 | 115 |
-| `v19_usage_level_full` | 1.945 | -1.269 | -0.187 | 2.768 | 115 |
-| `v4_availability_adjusted` | 1.954 | -1.119 | -0.119 | 2.688 | 115 |
-| `v5_team_context` | 1.954 | -1.119 | -0.119 | 2.688 | 115 |
-| `v6_usage_share` | 1.954 | -1.119 | -0.119 | 2.688 | 115 |
-| `position_mean_baseline` | 1.955 | -1.026 | -0.187 | 2.769 | 115 |
-| `v8_age_regression` | 2.013 | -1.307 | -0.293 | 2.889 | 115 |
-| `v9_pos_specific` | 2.013 | -1.307 | -0.293 | 2.889 | 115 |
-| `v10_stat_efficiency_v2` | 2.013 | -1.307 | -0.293 | 2.889 | 115 |
-| `v11_team_context_v2` | 2.013 | -1.307 | -0.293 | 2.889 | 115 |
-| `v13_qb_starter` | 2.013 | -1.307 | -0.293 | 2.889 | 115 |
-| `v15_snap_trend` | 2.020 | -1.242 | -0.322 | 2.921 | 115 |
-| `v1_baseline_weighted_ppg` | 2.047 | -1.234 | -0.304 | 2.902 | 115 |
-| `v2_age_adjusted` | 2.051 | -1.330 | -0.333 | 2.933 | 115 |
-| `v3_stat_weighted` | 2.051 | -1.330 | -0.333 | 2.933 | 115 |
-| `v18_usage_level` | 2.051 | -1.330 | -0.333 | 2.933 | 115 |
-| `naive_prior_season_ppg` | 2.153 | -1.148 | -0.359 | 2.962 | 115 |
+| `v7_regression_to_mean` | 2.150 | -1.401 | -0.078 | 2.925 | 130 |
+| `v16_snap_trend_full` | 2.177 | -1.502 | -0.171 | 3.048 | 130 |
+| `v21_tiered_regression` | 2.178 | -1.485 | -0.152 | 3.023 | 130 |
+| `v4_availability_adjusted` | 2.186 | -1.433 | -0.111 | 2.968 | 130 |
+| `v5_team_context` | 2.186 | -1.433 | -0.111 | 2.968 | 130 |
+| `v6_usage_share` | 2.186 | -1.433 | -0.111 | 2.968 | 130 |
+| `v12_no_qb_trajectory` | 2.207 | -1.595 | -0.196 | 3.080 | 130 |
+| `v14_qb_starter` | 2.207 | -1.595 | -0.196 | 3.080 | 130 |
+| `v17_rookie_growth` | 2.207 | -1.595 | -0.196 | 3.080 | 130 |
+| `v19_usage_level_full` | 2.207 | -1.595 | -0.196 | 3.080 | 130 |
+| `position_mean_baseline` | 2.244 | -1.319 | -0.224 | 3.118 | 136 |
+| `v8_age_regression` | 2.267 | -1.629 | -0.273 | 3.178 | 130 |
+| `v9_pos_specific` | 2.267 | -1.629 | -0.273 | 3.178 | 130 |
+| `v10_stat_efficiency_v2` | 2.267 | -1.629 | -0.273 | 3.178 | 130 |
+| `v11_team_context_v2` | 2.267 | -1.629 | -0.273 | 3.178 | 130 |
+| `v13_qb_starter` | 2.267 | -1.629 | -0.273 | 3.178 | 130 |
+| `v15_snap_trend` | 2.268 | -1.568 | -0.277 | 3.183 | 130 |
+| `v1_baseline_weighted_ppg` | 2.298 | -1.577 | -0.283 | 3.190 | 130 |
+| `v2_age_adjusted` | 2.301 | -1.661 | -0.303 | 3.215 | 130 |
+| `v3_stat_weighted` | 2.301 | -1.661 | -0.303 | 3.215 | 130 |
+| `v18_usage_level` | 2.301 | -1.661 | -0.303 | 3.215 | 130 |
+| `naive_prior_season_ppg` | 2.381 | -1.506 | -0.355 | 3.281 | 136 |
 
 ## Ranking quality — per-position ordering (GH #598)
 
@@ -211,110 +211,110 @@ _Spearman ρ and top-N hit rate against the **availability-inclusive** actuals (
 
 | Model | Spearman ρ | Top-N hit | N |
 | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 0.788 | 0.500 | 174 |
-| `v14_qb_starter` | 0.647 | 0.417 | 211 |
-| `v17_rookie_growth` | 0.647 | 0.417 | 211 |
-| `v19_usage_level_full` | 0.647 | 0.417 | 211 |
-| `v4_availability_adjusted` | 0.644 | 0.333 | 211 |
-| `v7_regression_to_mean` | 0.642 | 0.417 | 211 |
-| `v21_tiered_regression` | 0.641 | 0.417 | 211 |
-| `v5_team_context` | 0.640 | 0.417 | 211 |
-| `v6_usage_share` | 0.640 | 0.417 | 211 |
-| `v16_snap_trend_full` | 0.638 | 0.500 | 211 |
-| `v12_no_qb_trajectory` | 0.614 | 0.417 | 211 |
-| `v3_stat_weighted` | 0.612 | 0.333 | 211 |
-| `v10_stat_efficiency_v2` | 0.610 | 0.333 | 211 |
-| `v2_age_adjusted` | 0.607 | 0.417 | 211 |
-| `v18_usage_level` | 0.607 | 0.417 | 211 |
-| `v8_age_regression` | 0.606 | 0.417 | 211 |
-| `v9_pos_specific` | 0.606 | 0.417 | 211 |
-| `v11_team_context_v2` | 0.605 | 0.417 | 211 |
-| `v13_qb_starter` | 0.603 | 0.417 | 211 |
-| `v1_baseline_weighted_ppg` | 0.600 | 0.417 | 211 |
-| `v15_snap_trend` | 0.592 | 0.500 | 211 |
-| `naive_prior_season_ppg` | 0.541 | 0.417 | 211 |
-| `position_mean_baseline` | -0.131 | 0.000 | 211 |
+| `external_fantasypros_v1` | 0.796 | 0.500 | 181 |
+| `v14_qb_starter` | 0.674 | 0.417 | 249 |
+| `v17_rookie_growth` | 0.674 | 0.417 | 249 |
+| `v19_usage_level_full` | 0.674 | 0.417 | 249 |
+| `v4_availability_adjusted` | 0.668 | 0.333 | 249 |
+| `v16_snap_trend_full` | 0.666 | 0.500 | 249 |
+| `v6_usage_share` | 0.666 | 0.417 | 249 |
+| `v5_team_context` | 0.666 | 0.417 | 249 |
+| `v7_regression_to_mean` | 0.666 | 0.417 | 249 |
+| `v21_tiered_regression` | 0.665 | 0.417 | 249 |
+| `v10_stat_efficiency_v2` | 0.643 | 0.417 | 249 |
+| `v12_no_qb_trajectory` | 0.642 | 0.417 | 249 |
+| `v3_stat_weighted` | 0.641 | 0.333 | 249 |
+| `v2_age_adjusted` | 0.638 | 0.417 | 249 |
+| `v18_usage_level` | 0.638 | 0.417 | 249 |
+| `v1_baseline_weighted_ppg` | 0.637 | 0.417 | 249 |
+| `v8_age_regression` | 0.637 | 0.417 | 249 |
+| `v9_pos_specific` | 0.637 | 0.417 | 249 |
+| `v11_team_context_v2` | 0.634 | 0.417 | 249 |
+| `v13_qb_starter` | 0.633 | 0.417 | 249 |
+| `v15_snap_trend` | 0.624 | 0.500 | 249 |
+| `naive_prior_season_ppg` | 0.608 | 0.417 | 272 |
+| `position_mean_baseline` | 0.001 | 0.000 | 272 |
 
 ### RB (top-24)
 
 | Model | Spearman ρ | Top-N hit | N |
 | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 0.728 | 0.500 | 153 |
-| `v19_usage_level_full` | 0.706 | 0.458 | 217 |
-| `v10_stat_efficiency_v2` | 0.705 | 0.417 | 217 |
-| `v18_usage_level` | 0.705 | 0.458 | 217 |
-| `v11_team_context_v2` | 0.704 | 0.458 | 217 |
-| `v15_snap_trend` | 0.703 | 0.417 | 217 |
-| `v16_snap_trend_full` | 0.703 | 0.417 | 217 |
-| `naive_prior_season_ppg` | 0.703 | 0.375 | 227 |
-| `v8_age_regression` | 0.702 | 0.458 | 217 |
-| `v9_pos_specific` | 0.702 | 0.458 | 217 |
-| `v12_no_qb_trajectory` | 0.702 | 0.458 | 217 |
-| `v13_qb_starter` | 0.702 | 0.458 | 217 |
-| `v14_qb_starter` | 0.702 | 0.458 | 217 |
-| `v3_stat_weighted` | 0.702 | 0.458 | 217 |
-| `v2_age_adjusted` | 0.701 | 0.458 | 217 |
-| `v6_usage_share` | 0.697 | 0.417 | 217 |
-| `v5_team_context` | 0.695 | 0.375 | 217 |
-| `v21_tiered_regression` | 0.694 | 0.458 | 217 |
-| `v7_regression_to_mean` | 0.694 | 0.417 | 217 |
-| `v4_availability_adjusted` | 0.692 | 0.375 | 217 |
-| `v1_baseline_weighted_ppg` | 0.687 | 0.500 | 217 |
-| `v17_rookie_growth` | 0.681 | 0.458 | 217 |
-| `position_mean_baseline` | 0.077 | 0.000 | 227 |
+| `external_fantasypros_v1` | 0.765 | 0.500 | 166 |
+| `v4_availability_adjusted` | 0.749 | 0.375 | 413 |
+| `v5_team_context` | 0.742 | 0.375 | 413 |
+| `v15_snap_trend` | 0.742 | 0.417 | 413 |
+| `v6_usage_share` | 0.741 | 0.375 | 413 |
+| `v16_snap_trend_full` | 0.741 | 0.417 | 413 |
+| `v7_regression_to_mean` | 0.739 | 0.375 | 413 |
+| `v3_stat_weighted` | 0.739 | 0.417 | 413 |
+| `v2_age_adjusted` | 0.739 | 0.458 | 413 |
+| `v18_usage_level` | 0.739 | 0.458 | 413 |
+| `v19_usage_level_full` | 0.737 | 0.417 | 413 |
+| `v1_baseline_weighted_ppg` | 0.737 | 0.500 | 413 |
+| `v8_age_regression` | 0.737 | 0.458 | 413 |
+| `v9_pos_specific` | 0.737 | 0.458 | 413 |
+| `v12_no_qb_trajectory` | 0.737 | 0.458 | 413 |
+| `v13_qb_starter` | 0.737 | 0.458 | 413 |
+| `v14_qb_starter` | 0.737 | 0.458 | 413 |
+| `v10_stat_efficiency_v2` | 0.737 | 0.458 | 413 |
+| `v21_tiered_regression` | 0.733 | 0.458 | 413 |
+| `v11_team_context_v2` | 0.729 | 0.458 | 413 |
+| `v17_rookie_growth` | 0.728 | 0.458 | 413 |
+| `naive_prior_season_ppg` | 0.702 | 0.375 | 481 |
+| `position_mean_baseline` | -0.009 | 0.042 | 481 |
 
 ### WR (top-24)
 
 | Model | Spearman ρ | Top-N hit | N |
 | --- | --- | --- | --- |
-| `naive_prior_season_ppg` | 0.722 | 0.375 | 302 |
-| `v19_usage_level_full` | 0.720 | 0.333 | 291 |
-| `v18_usage_level` | 0.716 | 0.333 | 291 |
-| `v8_age_regression` | 0.713 | 0.333 | 291 |
-| `v9_pos_specific` | 0.713 | 0.333 | 291 |
-| `v12_no_qb_trajectory` | 0.713 | 0.333 | 291 |
-| `v13_qb_starter` | 0.713 | 0.333 | 291 |
-| `v14_qb_starter` | 0.713 | 0.333 | 291 |
-| `v3_stat_weighted` | 0.713 | 0.333 | 291 |
-| `v10_stat_efficiency_v2` | 0.713 | 0.333 | 291 |
-| `v16_snap_trend_full` | 0.712 | 0.292 | 291 |
-| `v11_team_context_v2` | 0.711 | 0.333 | 291 |
-| `v7_regression_to_mean` | 0.711 | 0.333 | 291 |
-| `v2_age_adjusted` | 0.711 | 0.292 | 291 |
-| `v15_snap_trend` | 0.710 | 0.292 | 291 |
-| `v21_tiered_regression` | 0.709 | 0.333 | 291 |
-| `v6_usage_share` | 0.708 | 0.333 | 291 |
-| `v17_rookie_growth` | 0.706 | 0.333 | 291 |
-| `v5_team_context` | 0.703 | 0.333 | 291 |
-| `v4_availability_adjusted` | 0.702 | 0.333 | 291 |
-| `v1_baseline_weighted_ppg` | 0.695 | 0.292 | 291 |
-| `external_fantasypros_v1` | 0.672 | 0.458 | 196 |
-| `position_mean_baseline` | 0.310 | 0.042 | 302 |
+| `v4_availability_adjusted` | 0.785 | 0.333 | 591 |
+| `v7_regression_to_mean` | 0.782 | 0.292 | 591 |
+| `v6_usage_share` | 0.782 | 0.333 | 591 |
+| `v5_team_context` | 0.780 | 0.292 | 591 |
+| `v15_snap_trend` | 0.776 | 0.292 | 591 |
+| `v16_snap_trend_full` | 0.776 | 0.292 | 591 |
+| `v19_usage_level_full` | 0.775 | 0.333 | 591 |
+| `v18_usage_level` | 0.775 | 0.333 | 591 |
+| `v3_stat_weighted` | 0.774 | 0.333 | 591 |
+| `v2_age_adjusted` | 0.774 | 0.292 | 591 |
+| `v10_stat_efficiency_v2` | 0.774 | 0.333 | 591 |
+| `v8_age_regression` | 0.774 | 0.333 | 591 |
+| `v9_pos_specific` | 0.774 | 0.333 | 591 |
+| `v12_no_qb_trajectory` | 0.774 | 0.333 | 591 |
+| `v13_qb_starter` | 0.774 | 0.333 | 591 |
+| `v14_qb_starter` | 0.774 | 0.333 | 591 |
+| `v1_baseline_weighted_ppg` | 0.769 | 0.292 | 591 |
+| `v11_team_context_v2` | 0.769 | 0.333 | 591 |
+| `v21_tiered_regression` | 0.769 | 0.333 | 591 |
+| `v17_rookie_growth` | 0.768 | 0.333 | 591 |
+| `external_fantasypros_v1` | 0.751 | 0.458 | 223 |
+| `naive_prior_season_ppg` | 0.730 | 0.375 | 698 |
+| `position_mean_baseline` | 0.008 | 0.042 | 698 |
 
 ### TE (top-12)
 
 | Model | Spearman ρ | Top-N hit | N |
 | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 0.786 | 0.500 | 180 |
-| `v19_usage_level_full` | 0.723 | 0.333 | 235 |
-| `v18_usage_level` | 0.720 | 0.333 | 235 |
-| `v10_stat_efficiency_v2` | 0.718 | 0.333 | 235 |
-| `v1_baseline_weighted_ppg` | 0.718 | 0.333 | 235 |
-| `v15_snap_trend` | 0.718 | 0.333 | 235 |
-| `v8_age_regression` | 0.718 | 0.333 | 235 |
-| `v9_pos_specific` | 0.718 | 0.333 | 235 |
-| `v12_no_qb_trajectory` | 0.718 | 0.333 | 235 |
-| `v13_qb_starter` | 0.718 | 0.333 | 235 |
-| `v14_qb_starter` | 0.718 | 0.333 | 235 |
-| `v3_stat_weighted` | 0.717 | 0.333 | 235 |
-| `v16_snap_trend_full` | 0.717 | 0.333 | 235 |
-| `v2_age_adjusted` | 0.717 | 0.333 | 235 |
-| `v11_team_context_v2` | 0.717 | 0.333 | 235 |
-| `v21_tiered_regression` | 0.717 | 0.333 | 235 |
-| `v6_usage_share` | 0.710 | 0.333 | 235 |
-| `v7_regression_to_mean` | 0.709 | 0.250 | 235 |
-| `naive_prior_season_ppg` | 0.707 | 0.417 | 243 |
-| `v5_team_context` | 0.706 | 0.250 | 235 |
-| `v4_availability_adjusted` | 0.705 | 0.250 | 235 |
-| `v17_rookie_growth` | 0.702 | 0.333 | 235 |
-| `position_mean_baseline` | 0.131 | 0.167 | 243 |
+| `external_fantasypros_v1` | 0.805 | 0.500 | 191 |
+| `v7_regression_to_mean` | 0.730 | 0.333 | 348 |
+| `v5_team_context` | 0.725 | 0.250 | 348 |
+| `naive_prior_season_ppg` | 0.725 | 0.417 | 385 |
+| `v6_usage_share` | 0.724 | 0.333 | 348 |
+| `v4_availability_adjusted` | 0.724 | 0.250 | 348 |
+| `v1_baseline_weighted_ppg` | 0.715 | 0.333 | 348 |
+| `v19_usage_level_full` | 0.706 | 0.333 | 348 |
+| `v18_usage_level` | 0.706 | 0.333 | 348 |
+| `v3_stat_weighted` | 0.705 | 0.333 | 348 |
+| `v2_age_adjusted` | 0.705 | 0.333 | 348 |
+| `v10_stat_efficiency_v2` | 0.705 | 0.333 | 348 |
+| `v8_age_regression` | 0.704 | 0.333 | 348 |
+| `v9_pos_specific` | 0.704 | 0.333 | 348 |
+| `v12_no_qb_trajectory` | 0.704 | 0.333 | 348 |
+| `v13_qb_starter` | 0.704 | 0.333 | 348 |
+| `v14_qb_starter` | 0.704 | 0.333 | 348 |
+| `v15_snap_trend` | 0.703 | 0.333 | 348 |
+| `v21_tiered_regression` | 0.702 | 0.333 | 348 |
+| `v11_team_context_v2` | 0.701 | 0.333 | 348 |
+| `v16_snap_trend_full` | 0.701 | 0.333 | 348 |
+| `v17_rookie_growth` | 0.700 | 0.333 | 348 |
+| `position_mean_baseline` | 0.034 | 0.000 | 385 |

--- a/docs/generated/projection-holdout-eval-matched.md
+++ b/docs/generated/projection-holdout-eval-matched.md
@@ -1,6 +1,6 @@
 # Projection Held-Out Evaluation (GH #572) — matched-sample (common players only)
 
-_Generated: 2026-06-10 09:35_
+_Generated: 2026-06-10 14:19_
 
 **Matched-sample mode (Finding 4):** every model is scored on the *same* players — the intersection of players all evaluated models projected, per season. This makes the FantasyPros comparison apples-to-apples (FP projects a smaller, more-available set), at the cost of a smaller N. Run without `--matched` for the full-coverage report.
 
@@ -12,39 +12,39 @@ _**MAE** is the pooled-over-players ALL error. **Bal MAE** is the position-balan
 
 | Rank | Model | MAE | Bal MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | `v14_qb_starter` | **2.494** | **2.564** | +0.161 | 0.650 | 3.283 | 416 |
-| 2 | `v19_usage_level_full` | 2.501 | 2.569 | -0.040 | 0.652 | 3.275 | 416 |
-| 3 | `external_fantasypros_v1` | 2.502 | 2.595 | +1.022 | 0.625 | 3.400 | 416 |
-| 4 | `v10_stat_efficiency_v2` | 2.521 | 2.598 | +0.071 | 0.627 | 3.389 | 416 |
-| 5 | `v17_rookie_growth` | 2.522 | 2.590 | +0.119 | 0.647 | 3.299 | 416 |
-| 6 | `v12_no_qb_trajectory` | 2.523 | 2.601 | +0.094 | 0.627 | 3.390 | 416 |
-| 7 | `v16_snap_trend_full` | 2.523 | 2.600 | +0.098 | 0.641 | 3.326 | 416 |
-| 8 | `v11_team_context_v2` | 2.525 | 2.602 | +0.033 | 0.621 | 3.419 | 416 |
-| 9 | `v8_age_regression` | 2.526 | 2.603 | +0.069 | 0.625 | 3.398 | 416 |
-| 10 | `v9_pos_specific` | 2.526 | 2.603 | +0.069 | 0.625 | 3.398 | 416 |
-| 11 | `v13_qb_starter` | 2.527 | 2.604 | +0.070 | 0.624 | 3.403 | 416 |
-| 12 | `v21_tiered_regression` | 2.551 | 2.628 | +0.233 | 0.628 | 3.387 | 416 |
-| 13 | `v7_regression_to_mean` | 2.571 | 2.645 | +0.304 | 0.624 | 3.405 | 416 |
-| 14 | `v3_stat_weighted` | 2.585 | 2.665 | -0.183 | 0.608 | 3.475 | 416 |
-| 15 | `v2_age_adjusted` | 2.587 | 2.667 | -0.197 | 0.607 | 3.480 | 416 |
-| 16 | `v5_team_context` | 2.623 | 2.703 | +0.238 | 0.600 | 3.511 | 416 |
-| 17 | `v15_snap_trend` | 2.624 | 2.711 | -0.259 | 0.595 | 3.532 | 416 |
-| 18 | `v4_availability_adjusted` | 2.628 | 2.707 | +0.272 | 0.604 | 3.494 | 416 |
-| 19 | `v18_usage_level` | 2.633 | 2.709 | -0.397 | 0.598 | 3.519 | 416 |
-| 20 | `v6_usage_share` | 2.646 | 2.722 | +0.038 | 0.595 | 3.531 | 416 |
-| 21 | `v20_learned_usage` | 2.647 | 2.707 | -0.627 | 0.636 | 3.347 | 416 |
-| 22 | `v31_depth_chart` | 2.656 | 2.711 | -0.908 | 0.625 | 3.399 | 416 |
-| 23 | `v28_reliability_weighting` | 2.663 | 2.719 | -0.786 | 0.633 | 3.362 | 416 |
-| 24 | `v26_vegas_residual` | 2.663 | 2.718 | -0.827 | 0.627 | 3.388 | 416 |
-| 25 | `v22_advanced_receiving` | 2.664 | 2.717 | -0.566 | 0.630 | 3.376 | 416 |
-| 26 | `v27_vegas_full_refit` | 2.674 | 2.734 | -0.872 | 0.624 | 3.403 | 416 |
-| 27 | `v30_reliability_full_refit` | 2.675 | 2.736 | -0.877 | 0.623 | 3.409 | 416 |
-| 28 | `v25_draft_capital_residual` | 2.693 | 2.751 | -0.779 | 0.623 | 3.408 | 416 |
-| 29 | `v29_reliability_residual` | 2.693 | 2.752 | -0.964 | 0.626 | 3.396 | 416 |
-| 30 | `v1_baseline_weighted_ppg` | 2.700 | 2.775 | -0.429 | 0.578 | 3.605 | 416 |
-| 31 | `v23_draft_capital` | 2.742 | 2.805 | -0.652 | 0.606 | 3.486 | 416 |
-| 32 | `naive_prior_season_ppg` | 2.890 | 2.992 | -0.281 | 0.494 | 3.949 | 416 |
-| 33 | `position_mean_baseline` | 4.080 | 4.150 | +1.757 | 0.131 | 5.173 | 416 |
+| 1 | `external_fantasypros_v1` | **2.466** | 2.563 | +1.004 | 0.641 | 3.364 | 434 |
+| 2 | `v19_usage_level_full` | 2.474 | **2.549** | +0.079 | 0.663 | 3.258 | 434 |
+| 3 | `v14_qb_starter` | 2.480 | 2.555 | +0.270 | 0.659 | 3.277 | 434 |
+| 4 | `v21_tiered_regression` | 2.494 | 2.579 | +0.121 | 0.650 | 3.323 | 434 |
+| 5 | `v17_rookie_growth` | 2.499 | 2.574 | +0.238 | 0.658 | 3.284 | 434 |
+| 6 | `v16_snap_trend_full` | 2.502 | 2.584 | +0.210 | 0.651 | 3.315 | 434 |
+| 7 | `v11_team_context_v2` | 2.508 | 2.591 | +0.147 | 0.634 | 3.395 | 434 |
+| 8 | `v12_no_qb_trajectory` | 2.509 | 2.592 | +0.205 | 0.638 | 3.379 | 434 |
+| 9 | `v8_age_regression` | 2.511 | 2.595 | +0.181 | 0.636 | 3.385 | 434 |
+| 10 | `v9_pos_specific` | 2.511 | 2.595 | +0.181 | 0.636 | 3.385 | 434 |
+| 11 | `v10_stat_efficiency_v2` | 2.514 | 2.598 | +0.194 | 0.637 | 3.384 | 434 |
+| 12 | `v13_qb_starter` | 2.515 | 2.600 | +0.182 | 0.635 | 3.390 | 434 |
+| 13 | `v26_vegas_residual` | 2.516 | 2.594 | +0.245 | 0.661 | 3.268 | 434 |
+| 14 | `v31_depth_chart` | 2.525 | 2.591 | +0.251 | 0.661 | 3.269 | 434 |
+| 15 | `v3_stat_weighted` | 2.548 | 2.635 | -0.214 | 0.626 | 3.433 | 434 |
+| 16 | `v2_age_adjusted` | 2.557 | 2.645 | -0.215 | 0.624 | 3.442 | 434 |
+| 17 | `v25_draft_capital_residual` | 2.561 | 2.633 | +0.271 | 0.656 | 3.293 | 434 |
+| 18 | `v7_regression_to_mean` | 2.562 | 2.647 | +0.431 | 0.630 | 3.414 | 434 |
+| 19 | `v5_team_context` | 2.575 | 2.664 | +0.237 | 0.619 | 3.466 | 434 |
+| 20 | `v29_reliability_residual` | 2.577 | 2.645 | +0.267 | 0.649 | 3.327 | 434 |
+| 21 | `v4_availability_adjusted` | 2.577 | 2.664 | +0.261 | 0.623 | 3.445 | 434 |
+| 22 | `v15_snap_trend` | 2.592 | 2.687 | -0.276 | 0.613 | 3.493 | 434 |
+| 23 | `v6_usage_share` | 2.594 | 2.680 | +0.041 | 0.616 | 3.480 | 434 |
+| 24 | `v18_usage_level` | 2.600 | 2.684 | -0.406 | 0.616 | 3.480 | 434 |
+| 25 | `v30_reliability_full_refit` | 2.606 | 2.674 | +0.323 | 0.638 | 3.376 | 434 |
+| 26 | `v20_learned_usage` | 2.610 | 2.669 | +0.654 | 0.635 | 3.391 | 434 |
+| 27 | `v22_advanced_receiving` | 2.621 | 2.681 | +0.603 | 0.639 | 3.373 | 434 |
+| 28 | `v28_reliability_weighting` | 2.625 | 2.685 | +0.568 | 0.633 | 3.402 | 434 |
+| 29 | `v27_vegas_full_refit` | 2.626 | 2.699 | +0.336 | 0.635 | 3.392 | 434 |
+| 30 | `v23_draft_capital` | 2.634 | 2.704 | +0.344 | 0.633 | 3.401 | 434 |
+| 31 | `v1_baseline_weighted_ppg` | 2.665 | 2.748 | -0.438 | 0.597 | 3.563 | 434 |
+| 32 | `naive_prior_season_ppg` | 2.820 | 2.933 | -0.240 | 0.522 | 3.882 | 434 |
+| 33 | `position_mean_baseline` | 4.616 | 4.663 | +2.841 | -0.072 | 5.813 | 434 |
 
 ## Combined across eval seasons — by position
 
@@ -52,269 +52,425 @@ _**MAE** is the pooled-over-players ALL error. **Bal MAE** is the position-balan
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `v14_qb_starter` | 2.494 | +0.161 | 0.650 | 3.283 | 416 |
-| `v19_usage_level_full` | 2.501 | -0.040 | 0.652 | 3.275 | 416 |
-| `external_fantasypros_v1` | 2.502 | +1.022 | 0.625 | 3.400 | 416 |
-| `v10_stat_efficiency_v2` | 2.521 | +0.071 | 0.627 | 3.389 | 416 |
-| `v17_rookie_growth` | 2.522 | +0.119 | 0.647 | 3.299 | 416 |
-| `v12_no_qb_trajectory` | 2.523 | +0.094 | 0.627 | 3.390 | 416 |
-| `v16_snap_trend_full` | 2.523 | +0.098 | 0.641 | 3.326 | 416 |
-| `v11_team_context_v2` | 2.525 | +0.033 | 0.621 | 3.419 | 416 |
-| `v8_age_regression` | 2.526 | +0.069 | 0.625 | 3.398 | 416 |
-| `v9_pos_specific` | 2.526 | +0.069 | 0.625 | 3.398 | 416 |
-| `v13_qb_starter` | 2.527 | +0.070 | 0.624 | 3.403 | 416 |
-| `v21_tiered_regression` | 2.551 | +0.233 | 0.628 | 3.387 | 416 |
-| `v7_regression_to_mean` | 2.571 | +0.304 | 0.624 | 3.405 | 416 |
-| `v3_stat_weighted` | 2.585 | -0.183 | 0.608 | 3.475 | 416 |
-| `v2_age_adjusted` | 2.587 | -0.197 | 0.607 | 3.480 | 416 |
-| `v5_team_context` | 2.623 | +0.238 | 0.600 | 3.511 | 416 |
-| `v15_snap_trend` | 2.624 | -0.259 | 0.595 | 3.532 | 416 |
-| `v4_availability_adjusted` | 2.628 | +0.272 | 0.604 | 3.494 | 416 |
-| `v18_usage_level` | 2.633 | -0.397 | 0.598 | 3.519 | 416 |
-| `v6_usage_share` | 2.646 | +0.038 | 0.595 | 3.531 | 416 |
-| `v20_learned_usage` | 2.647 | -0.627 | 0.636 | 3.347 | 416 |
-| `v31_depth_chart` | 2.656 | -0.908 | 0.625 | 3.399 | 416 |
-| `v28_reliability_weighting` | 2.663 | -0.786 | 0.633 | 3.362 | 416 |
-| `v26_vegas_residual` | 2.663 | -0.827 | 0.627 | 3.388 | 416 |
-| `v22_advanced_receiving` | 2.664 | -0.566 | 0.630 | 3.376 | 416 |
-| `v27_vegas_full_refit` | 2.674 | -0.872 | 0.624 | 3.403 | 416 |
-| `v30_reliability_full_refit` | 2.675 | -0.877 | 0.623 | 3.409 | 416 |
-| `v25_draft_capital_residual` | 2.693 | -0.779 | 0.623 | 3.408 | 416 |
-| `v29_reliability_residual` | 2.693 | -0.964 | 0.626 | 3.396 | 416 |
-| `v1_baseline_weighted_ppg` | 2.700 | -0.429 | 0.578 | 3.605 | 416 |
-| `v23_draft_capital` | 2.742 | -0.652 | 0.606 | 3.486 | 416 |
-| `naive_prior_season_ppg` | 2.890 | -0.281 | 0.494 | 3.949 | 416 |
-| `position_mean_baseline` | 4.080 | +1.757 | 0.131 | 5.173 | 416 |
+| `external_fantasypros_v1` | 2.466 | +1.004 | 0.641 | 3.364 | 434 |
+| `v19_usage_level_full` | 2.474 | +0.079 | 0.663 | 3.258 | 434 |
+| `v14_qb_starter` | 2.480 | +0.270 | 0.659 | 3.277 | 434 |
+| `v21_tiered_regression` | 2.494 | +0.121 | 0.650 | 3.323 | 434 |
+| `v17_rookie_growth` | 2.499 | +0.238 | 0.658 | 3.284 | 434 |
+| `v16_snap_trend_full` | 2.502 | +0.210 | 0.651 | 3.315 | 434 |
+| `v11_team_context_v2` | 2.508 | +0.147 | 0.634 | 3.395 | 434 |
+| `v12_no_qb_trajectory` | 2.509 | +0.205 | 0.638 | 3.379 | 434 |
+| `v8_age_regression` | 2.511 | +0.181 | 0.636 | 3.385 | 434 |
+| `v9_pos_specific` | 2.511 | +0.181 | 0.636 | 3.385 | 434 |
+| `v10_stat_efficiency_v2` | 2.514 | +0.194 | 0.637 | 3.384 | 434 |
+| `v13_qb_starter` | 2.515 | +0.182 | 0.635 | 3.390 | 434 |
+| `v26_vegas_residual` | 2.516 | +0.245 | 0.661 | 3.268 | 434 |
+| `v31_depth_chart` | 2.525 | +0.251 | 0.661 | 3.269 | 434 |
+| `v3_stat_weighted` | 2.548 | -0.214 | 0.626 | 3.433 | 434 |
+| `v2_age_adjusted` | 2.557 | -0.215 | 0.624 | 3.442 | 434 |
+| `v25_draft_capital_residual` | 2.561 | +0.271 | 0.656 | 3.293 | 434 |
+| `v7_regression_to_mean` | 2.562 | +0.431 | 0.630 | 3.414 | 434 |
+| `v5_team_context` | 2.575 | +0.237 | 0.619 | 3.466 | 434 |
+| `v29_reliability_residual` | 2.577 | +0.267 | 0.649 | 3.327 | 434 |
+| `v4_availability_adjusted` | 2.577 | +0.261 | 0.623 | 3.445 | 434 |
+| `v15_snap_trend` | 2.592 | -0.276 | 0.613 | 3.493 | 434 |
+| `v6_usage_share` | 2.594 | +0.041 | 0.616 | 3.480 | 434 |
+| `v18_usage_level` | 2.600 | -0.406 | 0.616 | 3.480 | 434 |
+| `v30_reliability_full_refit` | 2.606 | +0.323 | 0.638 | 3.376 | 434 |
+| `v20_learned_usage` | 2.610 | +0.654 | 0.635 | 3.391 | 434 |
+| `v22_advanced_receiving` | 2.621 | +0.603 | 0.639 | 3.373 | 434 |
+| `v28_reliability_weighting` | 2.625 | +0.568 | 0.633 | 3.402 | 434 |
+| `v27_vegas_full_refit` | 2.626 | +0.336 | 0.635 | 3.392 | 434 |
+| `v23_draft_capital` | 2.634 | +0.344 | 0.633 | 3.401 | 434 |
+| `v1_baseline_weighted_ppg` | 2.665 | -0.438 | 0.597 | 3.563 | 434 |
+| `naive_prior_season_ppg` | 2.820 | -0.240 | 0.522 | 3.882 | 434 |
+| `position_mean_baseline` | 4.616 | +2.841 | -0.072 | 5.813 | 434 |
 
 ### QB
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `v22_advanced_receiving` | 3.447 | -0.678 | 0.482 | 4.470 | 84 |
-| `v31_depth_chart` | 3.455 | -1.347 | 0.484 | 4.460 | 84 |
-| `v20_learned_usage` | 3.486 | -1.200 | 0.477 | 4.491 | 84 |
-| `v28_reliability_weighting` | 3.492 | -1.252 | 0.472 | 4.511 | 84 |
-| `v26_vegas_residual` | 3.497 | -1.067 | 0.460 | 4.564 | 84 |
-| `v27_vegas_full_refit` | 3.539 | -1.240 | 0.444 | 4.631 | 84 |
-| `v30_reliability_full_refit` | 3.549 | -1.274 | 0.437 | 4.658 | 84 |
-| `v14_qb_starter` | 3.558 | -0.397 | 0.446 | 4.622 | 84 |
-| `v17_rookie_growth` | 3.558 | -0.397 | 0.446 | 4.622 | 84 |
-| `v19_usage_level_full` | 3.558 | -0.397 | 0.446 | 4.622 | 84 |
-| `v25_draft_capital_residual` | 3.563 | -1.036 | 0.448 | 4.612 | 84 |
-| `v29_reliability_residual` | 3.592 | -1.513 | 0.442 | 4.639 | 84 |
-| `v16_snap_trend_full` | 3.637 | -0.420 | 0.433 | 4.676 | 84 |
-| `v23_draft_capital` | 3.666 | -0.712 | 0.425 | 4.710 | 84 |
-| `v21_tiered_regression` | 3.670 | -0.023 | 0.412 | 4.759 | 84 |
-| `v7_regression_to_mean` | 3.703 | +0.480 | 0.388 | 4.857 | 84 |
-| `v12_no_qb_trajectory` | 3.706 | -0.726 | 0.354 | 4.990 | 84 |
-| `v8_age_regression` | 3.715 | -0.850 | 0.347 | 5.018 | 84 |
-| `v9_pos_specific` | 3.715 | -0.850 | 0.347 | 5.018 | 84 |
-| `v13_qb_starter` | 3.721 | -0.845 | 0.342 | 5.035 | 84 |
-| `v10_stat_efficiency_v2` | 3.724 | -0.853 | 0.348 | 5.012 | 84 |
-| `v11_team_context_v2` | 3.739 | -0.917 | 0.332 | 5.075 | 84 |
-| `v4_availability_adjusted` | 3.810 | +0.352 | 0.347 | 5.018 | 84 |
-| `external_fantasypros_v1` | 3.835 | +2.254 | 0.301 | 5.189 | 84 |
-| `v3_stat_weighted` | 3.848 | -1.038 | 0.308 | 5.164 | 84 |
-| `v2_age_adjusted` | 3.851 | -1.038 | 0.307 | 5.168 | 84 |
-| `v18_usage_level` | 3.851 | -1.038 | 0.307 | 5.168 | 84 |
-| `v5_team_context` | 3.862 | +0.292 | 0.333 | 5.070 | 84 |
-| `v6_usage_share` | 3.862 | +0.292 | 0.333 | 5.070 | 84 |
-| `v15_snap_trend` | 3.928 | -1.060 | 0.291 | 5.229 | 84 |
-| `v1_baseline_weighted_ppg` | 3.949 | -1.288 | 0.287 | 5.242 | 84 |
-| `naive_prior_season_ppg` | 4.478 | -0.552 | 0.101 | 5.886 | 84 |
-| `position_mean_baseline` | 5.022 | +0.133 | 0.000 | 6.208 | 84 |
+| `v28_reliability_weighting` | 3.379 | -0.296 | 0.554 | 4.211 | 85 |
+| `v31_depth_chart` | 3.402 | -0.456 | 0.556 | 4.202 | 85 |
+| `v22_advanced_receiving` | 3.433 | -0.001 | 0.542 | 4.271 | 85 |
+| `v29_reliability_residual` | 3.447 | -0.556 | 0.537 | 4.294 | 85 |
+| `v20_learned_usage` | 3.453 | -0.049 | 0.535 | 4.302 | 85 |
+| `v30_reliability_full_refit` | 3.468 | -0.409 | 0.527 | 4.340 | 85 |
+| `v26_vegas_residual` | 3.470 | -0.351 | 0.528 | 4.332 | 85 |
+| `v25_draft_capital_residual` | 3.508 | -0.326 | 0.523 | 4.356 | 85 |
+| `v14_qb_starter` | 3.554 | -0.253 | 0.467 | 4.607 | 85 |
+| `v17_rookie_growth` | 3.554 | -0.253 | 0.467 | 4.607 | 85 |
+| `v19_usage_level_full` | 3.554 | -0.253 | 0.467 | 4.607 | 85 |
+| `v23_draft_capital` | 3.557 | -0.333 | 0.518 | 4.381 | 85 |
+| `v27_vegas_full_refit` | 3.588 | -0.146 | 0.504 | 4.442 | 85 |
+| `v16_snap_trend_full` | 3.628 | -0.270 | 0.456 | 4.655 | 85 |
+| `v21_tiered_regression` | 3.629 | -0.154 | 0.445 | 4.702 | 85 |
+| `v12_no_qb_trajectory` | 3.700 | -0.587 | 0.380 | 4.969 | 85 |
+| `v8_age_regression` | 3.711 | -0.709 | 0.374 | 4.992 | 85 |
+| `v9_pos_specific` | 3.711 | -0.709 | 0.374 | 4.992 | 85 |
+| `v11_team_context_v2` | 3.724 | -0.777 | 0.365 | 5.027 | 85 |
+| `v10_stat_efficiency_v2` | 3.726 | -0.710 | 0.376 | 4.985 | 85 |
+| `v13_qb_starter` | 3.733 | -0.705 | 0.370 | 5.009 | 85 |
+| `v7_regression_to_mean` | 3.756 | +0.615 | 0.396 | 4.902 | 85 |
+| `external_fantasypros_v1` | 3.794 | +2.231 | 0.332 | 5.158 | 85 |
+| `v4_availability_adjusted` | 3.795 | +0.334 | 0.373 | 4.997 | 85 |
+| `v6_usage_share` | 3.851 | +0.254 | 0.359 | 5.050 | 85 |
+| `v3_stat_weighted` | 3.853 | -1.082 | 0.332 | 5.156 | 85 |
+| `v2_age_adjusted` | 3.858 | -1.078 | 0.331 | 5.161 | 85 |
+| `v18_usage_level` | 3.858 | -1.078 | 0.331 | 5.161 | 85 |
+| `v5_team_context` | 3.889 | +0.251 | 0.355 | 5.068 | 85 |
+| `v15_snap_trend` | 3.929 | -1.095 | 0.317 | 5.216 | 85 |
+| `v1_baseline_weighted_ppg` | 3.955 | -1.326 | 0.312 | 5.234 | 85 |
+| `naive_prior_season_ppg` | 4.433 | -0.537 | 0.140 | 5.852 | 85 |
+| `position_mean_baseline` | 5.425 | +1.620 | -0.068 | 6.521 | 85 |
 
 ### RB
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `v11_team_context_v2` | 2.615 | +0.725 | 0.609 | 3.368 | 97 |
-| `v10_stat_efficiency_v2` | 2.637 | +0.790 | 0.610 | 3.365 | 97 |
-| `v19_usage_level_full` | 2.656 | +0.438 | 0.613 | 3.349 | 97 |
-| `v8_age_regression` | 2.664 | +0.770 | 0.603 | 3.392 | 97 |
-| `v9_pos_specific` | 2.664 | +0.770 | 0.603 | 3.392 | 97 |
-| `v12_no_qb_trajectory` | 2.664 | +0.770 | 0.603 | 3.392 | 97 |
-| `v13_qb_starter` | 2.664 | +0.770 | 0.603 | 3.392 | 97 |
-| `v14_qb_starter` | 2.664 | +0.770 | 0.603 | 3.392 | 97 |
-| `v3_stat_weighted` | 2.683 | +0.483 | 0.607 | 3.378 | 97 |
-| `v2_age_adjusted` | 2.685 | +0.429 | 0.604 | 3.387 | 97 |
-| `v17_rookie_growth` | 2.727 | +0.659 | 0.595 | 3.429 | 97 |
-| `v18_usage_level` | 2.732 | +0.098 | 0.594 | 3.430 | 97 |
-| `v7_regression_to_mean` | 2.746 | +0.786 | 0.579 | 3.494 | 97 |
-| `v16_snap_trend_full` | 2.753 | +0.579 | 0.579 | 3.493 | 97 |
-| `external_fantasypros_v1` | 2.760 | +1.107 | 0.606 | 3.382 | 97 |
-| `v6_usage_share` | 2.761 | +0.446 | 0.575 | 3.510 | 97 |
-| `v1_baseline_weighted_ppg` | 2.774 | +0.086 | 0.553 | 3.601 | 97 |
-| `v5_team_context` | 2.780 | +0.777 | 0.569 | 3.535 | 97 |
-| `v15_snap_trend` | 2.788 | +0.238 | 0.573 | 3.521 | 97 |
-| `v21_tiered_regression` | 2.797 | +0.862 | 0.563 | 3.558 | 97 |
-| `v4_availability_adjusted` | 2.839 | +0.807 | 0.565 | 3.553 | 97 |
-| `v20_learned_usage` | 2.848 | -0.133 | 0.569 | 3.537 | 97 |
-| `v26_vegas_residual` | 2.853 | -0.351 | 0.567 | 3.545 | 97 |
-| `v29_reliability_residual` | 2.873 | -0.485 | 0.579 | 3.496 | 97 |
-| `v28_reliability_weighting` | 2.881 | -0.330 | 0.573 | 3.519 | 97 |
-| `v30_reliability_full_refit` | 2.906 | -0.543 | 0.553 | 3.602 | 97 |
-| `v27_vegas_full_refit` | 2.909 | -0.543 | 0.552 | 3.603 | 97 |
-| `v25_draft_capital_residual` | 2.910 | -0.325 | 0.559 | 3.574 | 97 |
-| `v31_depth_chart` | 2.915 | -0.609 | 0.541 | 3.649 | 97 |
-| `v22_advanced_receiving` | 2.922 | -0.174 | 0.552 | 3.602 | 97 |
-| `v23_draft_capital` | 2.991 | -0.282 | 0.516 | 3.745 | 97 |
-| `naive_prior_season_ppg` | 2.999 | -0.058 | 0.426 | 4.080 | 97 |
-| `position_mean_baseline` | 4.790 | +2.922 | -0.228 | 5.967 | 97 |
+| `v3_stat_weighted` | 2.568 | +0.387 | 0.644 | 3.292 | 102 |
+| `v11_team_context_v2` | 2.593 | +0.840 | 0.624 | 3.383 | 102 |
+| `v19_usage_level_full` | 2.594 | +0.557 | 0.633 | 3.342 | 102 |
+| `v2_age_adjusted` | 2.598 | +0.368 | 0.637 | 3.323 | 102 |
+| `v5_team_context` | 2.623 | +0.764 | 0.608 | 3.456 | 102 |
+| `v8_age_regression` | 2.624 | +0.871 | 0.619 | 3.404 | 102 |
+| `v9_pos_specific` | 2.624 | +0.871 | 0.619 | 3.404 | 102 |
+| `v12_no_qb_trajectory` | 2.624 | +0.871 | 0.619 | 3.404 | 102 |
+| `v13_qb_starter` | 2.624 | +0.871 | 0.619 | 3.404 | 102 |
+| `v14_qb_starter` | 2.624 | +0.871 | 0.619 | 3.404 | 102 |
+| `v10_stat_efficiency_v2` | 2.626 | +0.922 | 0.618 | 3.409 | 102 |
+| `v18_usage_level` | 2.643 | +0.053 | 0.628 | 3.364 | 102 |
+| `v6_usage_share` | 2.651 | +0.409 | 0.612 | 3.437 | 102 |
+| `external_fantasypros_v1` | 2.672 | +1.093 | 0.639 | 3.313 | 102 |
+| `v17_rookie_growth` | 2.676 | +0.811 | 0.613 | 3.434 | 102 |
+| `v1_baseline_weighted_ppg` | 2.682 | +0.042 | 0.590 | 3.531 | 102 |
+| `v16_snap_trend_full` | 2.685 | +0.689 | 0.600 | 3.487 | 102 |
+| `v21_tiered_regression` | 2.688 | +0.760 | 0.609 | 3.449 | 102 |
+| `v15_snap_trend` | 2.693 | +0.185 | 0.609 | 3.450 | 102 |
+| `v7_regression_to_mean` | 2.720 | +0.939 | 0.586 | 3.547 | 102 |
+| `v4_availability_adjusted` | 2.723 | +0.731 | 0.602 | 3.478 | 102 |
+| `v31_depth_chart` | 2.885 | +1.036 | 0.544 | 3.723 | 102 |
+| `naive_prior_season_ppg` | 2.885 | -0.057 | 0.479 | 3.983 | 102 |
+| `v25_draft_capital_residual` | 2.919 | +1.109 | 0.551 | 3.696 | 102 |
+| `v26_vegas_residual` | 2.920 | +1.105 | 0.550 | 3.700 | 102 |
+| `v20_learned_usage` | 2.960 | +1.258 | 0.523 | 3.809 | 102 |
+| `v29_reliability_residual` | 2.989 | +1.331 | 0.531 | 3.777 | 102 |
+| `v22_advanced_receiving` | 3.005 | +1.337 | 0.519 | 3.827 | 102 |
+| `v27_vegas_full_refit` | 3.010 | +1.141 | 0.504 | 3.883 | 102 |
+| `v30_reliability_full_refit` | 3.030 | +1.277 | 0.501 | 3.894 | 102 |
+| `v23_draft_capital` | 3.045 | +1.204 | 0.493 | 3.928 | 102 |
+| `v28_reliability_weighting` | 3.106 | +1.622 | 0.486 | 3.956 | 102 |
+| `position_mean_baseline` | 5.540 | +4.237 | -0.580 | 6.933 | 102 |
 
 ### WR
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 2.217 | +0.448 | 0.585 | 2.791 | 127 |
-| `v16_snap_trend_full` | 2.315 | +0.114 | 0.542 | 2.934 | 127 |
-| `v8_age_regression` | 2.345 | +0.161 | 0.545 | 2.922 | 127 |
-| `v9_pos_specific` | 2.345 | +0.161 | 0.545 | 2.922 | 127 |
-| `v12_no_qb_trajectory` | 2.345 | +0.161 | 0.545 | 2.922 | 127 |
-| `v13_qb_starter` | 2.345 | +0.161 | 0.545 | 2.922 | 127 |
-| `v14_qb_starter` | 2.345 | +0.161 | 0.545 | 2.922 | 127 |
-| `v10_stat_efficiency_v2` | 2.350 | +0.159 | 0.545 | 2.922 | 127 |
-| `v11_team_context_v2` | 2.359 | +0.138 | 0.536 | 2.951 | 127 |
-| `v19_usage_level_full` | 2.359 | -0.160 | 0.544 | 2.927 | 127 |
-| `v21_tiered_regression` | 2.362 | -0.048 | 0.523 | 2.993 | 127 |
-| `v17_rookie_growth` | 2.387 | +0.109 | 0.537 | 2.949 | 127 |
-| `v15_snap_trend` | 2.409 | -0.263 | 0.499 | 3.068 | 127 |
-| `v7_regression_to_mean` | 2.416 | -0.001 | 0.518 | 3.007 | 127 |
-| `v2_age_adjusted` | 2.427 | -0.216 | 0.503 | 3.054 | 127 |
-| `v3_stat_weighted` | 2.428 | -0.204 | 0.504 | 3.052 | 127 |
-| `v4_availability_adjusted` | 2.446 | -0.031 | 0.488 | 3.101 | 127 |
-| `v5_team_context` | 2.453 | -0.057 | 0.481 | 3.122 | 127 |
-| `v20_learned_usage` | 2.462 | -0.316 | 0.528 | 2.978 | 127 |
-| `v6_usage_share` | 2.503 | -0.378 | 0.459 | 3.187 | 127 |
-| `v18_usage_level` | 2.514 | -0.536 | 0.476 | 3.136 | 127 |
-| `v30_reliability_full_refit` | 2.532 | -1.042 | 0.507 | 3.044 | 127 |
-| `v27_vegas_full_refit` | 2.536 | -1.048 | 0.505 | 3.048 | 127 |
-| `v28_reliability_weighting` | 2.567 | -0.950 | 0.488 | 3.100 | 127 |
-| `v31_depth_chart` | 2.578 | -1.106 | 0.458 | 3.189 | 127 |
-| `v26_vegas_residual` | 2.579 | -1.201 | 0.487 | 3.104 | 127 |
-| `v22_advanced_receiving` | 2.581 | -0.808 | 0.488 | 3.102 | 127 |
-| `v29_reliability_residual` | 2.602 | -1.194 | 0.484 | 3.114 | 127 |
-| `v25_draft_capital_residual` | 2.603 | -1.110 | 0.486 | 3.106 | 127 |
-| `v1_baseline_weighted_ppg` | 2.615 | -0.355 | 0.451 | 3.211 | 127 |
-| `v23_draft_capital` | 2.618 | -0.935 | 0.481 | 3.122 | 127 |
-| `naive_prior_season_ppg` | 2.647 | -0.357 | 0.410 | 3.329 | 127 |
-| `position_mean_baseline` | 4.085 | +2.780 | -0.336 | 5.009 | 127 |
+| `external_fantasypros_v1` | 2.201 | +0.417 | 0.627 | 2.787 | 136 |
+| `v21_tiered_regression` | 2.244 | -0.197 | 0.599 | 2.890 | 136 |
+| `v26_vegas_residual` | 2.264 | +0.142 | 0.609 | 2.852 | 136 |
+| `v16_snap_trend_full` | 2.289 | +0.209 | 0.591 | 2.919 | 136 |
+| `v19_usage_level_full` | 2.308 | -0.039 | 0.600 | 2.887 | 136 |
+| `v8_age_regression` | 2.319 | +0.259 | 0.595 | 2.903 | 136 |
+| `v9_pos_specific` | 2.319 | +0.259 | 0.595 | 2.903 | 136 |
+| `v12_no_qb_trajectory` | 2.319 | +0.259 | 0.595 | 2.903 | 136 |
+| `v13_qb_starter` | 2.319 | +0.259 | 0.595 | 2.903 | 136 |
+| `v14_qb_starter` | 2.319 | +0.259 | 0.595 | 2.903 | 136 |
+| `v10_stat_efficiency_v2` | 2.321 | +0.269 | 0.594 | 2.906 | 136 |
+| `v11_team_context_v2` | 2.322 | +0.236 | 0.591 | 2.917 | 136 |
+| `v17_rookie_growth` | 2.341 | +0.201 | 0.595 | 2.904 | 136 |
+| `v15_snap_trend` | 2.349 | -0.285 | 0.566 | 3.004 | 136 |
+| `v4_availability_adjusted` | 2.349 | -0.008 | 0.566 | 3.007 | 136 |
+| `v2_age_adjusted` | 2.361 | -0.235 | 0.572 | 2.983 | 136 |
+| `v3_stat_weighted` | 2.363 | -0.237 | 0.572 | 2.984 | 136 |
+| `v7_regression_to_mean` | 2.364 | +0.161 | 0.581 | 2.954 | 136 |
+| `v5_team_context` | 2.375 | -0.037 | 0.555 | 3.043 | 136 |
+| `v25_draft_capital_residual` | 2.381 | +0.217 | 0.583 | 2.944 | 136 |
+| `v31_depth_chart` | 2.397 | +0.175 | 0.566 | 3.006 | 136 |
+| `v6_usage_share` | 2.403 | -0.326 | 0.541 | 3.091 | 136 |
+| `v29_reliability_residual` | 2.417 | +0.095 | 0.555 | 3.042 | 136 |
+| `v18_usage_level` | 2.440 | -0.533 | 0.549 | 3.062 | 136 |
+| `v30_reliability_full_refit` | 2.443 | +0.219 | 0.552 | 3.054 | 136 |
+| `v27_vegas_full_refit` | 2.463 | +0.270 | 0.558 | 3.033 | 136 |
+| `v23_draft_capital` | 2.499 | +0.298 | 0.545 | 3.077 | 136 |
+| `naive_prior_season_ppg` | 2.513 | -0.259 | 0.503 | 3.216 | 136 |
+| `v28_reliability_weighting` | 2.525 | +0.563 | 0.512 | 3.185 | 136 |
+| `v1_baseline_weighted_ppg` | 2.536 | -0.366 | 0.528 | 3.134 | 136 |
+| `v22_advanced_receiving` | 2.549 | +0.758 | 0.523 | 3.150 | 136 |
+| `v20_learned_usage` | 2.565 | +0.898 | 0.512 | 3.186 | 136 |
+| `position_mean_baseline` | 4.953 | +3.754 | -0.672 | 5.899 | 136 |
 
 ### TE
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 1.569 | +0.661 | 0.620 | 2.041 | 108 |
-| `v21_tiered_regression` | 1.681 | +0.195 | 0.573 | 2.162 | 108 |
-| `v10_stat_efficiency_v2` | 1.683 | +0.041 | 0.591 | 2.117 | 108 |
-| `v8_age_regression` | 1.688 | +0.048 | 0.588 | 2.126 | 108 |
-| `v9_pos_specific` | 1.688 | +0.048 | 0.588 | 2.126 | 108 |
-| `v12_no_qb_trajectory` | 1.688 | +0.048 | 0.588 | 2.126 | 108 |
-| `v13_qb_starter` | 1.688 | +0.048 | 0.588 | 2.126 | 108 |
-| `v14_qb_starter` | 1.688 | +0.048 | 0.588 | 2.126 | 108 |
-| `v17_rookie_growth` | 1.689 | +0.047 | 0.588 | 2.124 | 108 |
-| `v11_team_context_v2` | 1.694 | +0.028 | 0.584 | 2.134 | 108 |
-| `v16_snap_trend_full` | 1.697 | +0.050 | 0.586 | 2.129 | 108 |
-| `v3_stat_weighted` | 1.700 | -0.091 | 0.581 | 2.141 | 108 |
-| `v2_age_adjusted` | 1.703 | -0.082 | 0.580 | 2.145 | 108 |
-| `v19_usage_level_full` | 1.705 | -0.049 | 0.584 | 2.134 | 108 |
-| `v7_regression_to_mean` | 1.713 | +0.094 | 0.568 | 2.175 | 108 |
-| `v15_snap_trend` | 1.718 | -0.080 | 0.581 | 2.141 | 108 |
-| `v5_team_context` | 1.719 | +0.061 | 0.560 | 2.194 | 108 |
-| `v4_availability_adjusted` | 1.733 | +0.085 | 0.562 | 2.191 | 108 |
-| `v18_usage_level` | 1.738 | -0.178 | 0.562 | 2.190 | 108 |
-| `v1_baseline_weighted_ppg` | 1.761 | -0.310 | 0.553 | 2.213 | 108 |
-| `v6_usage_share` | 1.763 | -0.036 | 0.542 | 2.239 | 108 |
-| `naive_prior_season_ppg` | 1.843 | -0.181 | 0.530 | 2.269 | 108 |
-| `v31_depth_chart` | 1.895 | -0.601 | 0.533 | 2.262 | 108 |
-| `v22_advanced_receiving` | 1.920 | -0.546 | 0.508 | 2.321 | 108 |
-| `v25_draft_capital_residual` | 1.926 | -0.599 | 0.509 | 2.318 | 108 |
-| `v28_reliability_weighting` | 1.935 | -0.641 | 0.517 | 2.300 | 108 |
-| `v29_reliability_residual` | 1.940 | -0.698 | 0.517 | 2.301 | 108 |
-| `v23_draft_capital` | 1.943 | -0.604 | 0.499 | 2.343 | 108 |
-| `v26_vegas_residual` | 1.944 | -0.629 | 0.508 | 2.320 | 108 |
-| `v27_vegas_full_refit` | 1.951 | -0.674 | 0.513 | 2.310 | 108 |
-| `v30_reliability_full_refit` | 1.954 | -0.675 | 0.512 | 2.312 | 108 |
-| `v20_learned_usage` | 2.033 | -0.992 | 0.469 | 2.411 | 108 |
-| `position_mean_baseline` | 2.704 | +0.770 | -0.063 | 3.412 | 108 |
+| `external_fantasypros_v1` | 1.585 | +0.701 | 0.608 | 2.064 | 111 |
+| `v31_depth_chart` | 1.681 | +0.165 | 0.590 | 2.110 | 111 |
+| `v20_learned_usage` | 1.699 | +0.340 | 0.538 | 2.241 | 111 |
+| `v23_draft_capital` | 1.714 | +0.130 | 0.561 | 2.183 | 111 |
+| `v10_stat_efficiency_v2` | 1.720 | +0.124 | 0.565 | 2.174 | 111 |
+| `v26_vegas_residual` | 1.723 | +0.038 | 0.556 | 2.196 | 111 |
+| `v17_rookie_growth` | 1.724 | +0.133 | 0.562 | 2.180 | 111 |
+| `v8_age_regression` | 1.724 | +0.133 | 0.562 | 2.180 | 111 |
+| `v9_pos_specific` | 1.724 | +0.133 | 0.562 | 2.180 | 111 |
+| `v12_no_qb_trajectory` | 1.724 | +0.133 | 0.562 | 2.180 | 111 |
+| `v13_qb_starter` | 1.724 | +0.133 | 0.562 | 2.180 | 111 |
+| `v14_qb_starter` | 1.724 | +0.133 | 0.562 | 2.180 | 111 |
+| `v11_team_context_v2` | 1.726 | +0.109 | 0.561 | 2.184 | 111 |
+| `v25_draft_capital_residual` | 1.726 | +0.026 | 0.568 | 2.165 | 111 |
+| `v29_reliability_residual` | 1.726 | +0.130 | 0.565 | 2.173 | 111 |
+| `v28_reliability_weighting` | 1.728 | +0.268 | 0.553 | 2.203 | 111 |
+| `v16_snap_trend_full` | 1.733 | +0.136 | 0.561 | 2.183 | 111 |
+| `v22_advanced_receiving` | 1.736 | +0.200 | 0.549 | 2.214 | 111 |
+| `v27_vegas_full_refit` | 1.737 | +0.049 | 0.562 | 2.180 | 111 |
+| `v19_usage_level_full` | 1.741 | +0.040 | 0.561 | 2.184 | 111 |
+| `v7_regression_to_mean` | 1.747 | +0.153 | 0.548 | 2.214 | 111 |
+| `v21_tiered_regression` | 1.754 | +0.133 | 0.533 | 2.253 | 111 |
+| `v3_stat_weighted` | 1.757 | -0.072 | 0.553 | 2.202 | 111 |
+| `v30_reliability_full_refit` | 1.757 | +0.134 | 0.561 | 2.183 | 111 |
+| `v2_age_adjusted` | 1.762 | -0.066 | 0.550 | 2.209 | 111 |
+| `v5_team_context` | 1.770 | +0.077 | 0.542 | 2.231 | 111 |
+| `v15_snap_trend` | 1.775 | -0.063 | 0.552 | 2.206 | 111 |
+| `v4_availability_adjusted` | 1.791 | +0.102 | 0.531 | 2.257 | 111 |
+| `v18_usage_level` | 1.796 | -0.160 | 0.533 | 2.251 | 111 |
+| `v6_usage_share` | 1.813 | -0.012 | 0.516 | 2.291 | 111 |
+| `v1_baseline_weighted_ppg` | 1.818 | -0.288 | 0.524 | 2.274 | 111 |
+| `naive_prior_season_ppg` | 1.901 | -0.158 | 0.499 | 2.333 | 111 |
+| `position_mean_baseline` | 2.736 | +1.373 | -0.172 | 3.568 | 111 |
 
 ### K
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
 
+## Ranking quality — per-position ordering (GH #598)
+
+_The projections feed VORP, surplus value, auction pricing and keeper calls, which depend on within-position **ordering** and getting the top tier right — not absolute PPG level. **Spearman ρ** is the rank correlation between projected and actual PPG (1.0 = perfect order). **Top-N hit** is the share of each model's predicted top-N (≈ the starter pool: 12 for QB/TE, 24 for RB/WR) that actually finished top-N. A model can win MAE while losing here (#579) — these are the metrics the downstream decisions actually care about._
+
+### QB (top-12)
+
+| Model | Spearman ρ | Top-N hit | N |
+| --- | --- | --- | --- |
+| `external_fantasypros_v1` | **0.796** | 0.417 | 85 |
+| `v31_depth_chart` | 0.759 | 0.333 | 85 |
+| `v28_reliability_weighting` | 0.753 | 0.417 | 85 |
+| `v22_advanced_receiving` | 0.751 | 0.417 | 85 |
+| `v26_vegas_residual` | 0.749 | 0.333 | 85 |
+| `v20_learned_usage` | 0.746 | 0.417 | 85 |
+| `v30_reliability_full_refit` | 0.742 | 0.333 | 85 |
+| `v29_reliability_residual` | 0.741 | 0.333 | 85 |
+| `v25_draft_capital_residual` | 0.740 | 0.333 | 85 |
+| `v23_draft_capital` | 0.735 | 0.250 | 85 |
+| `v27_vegas_full_refit` | 0.731 | 0.250 | 85 |
+| `v16_snap_trend_full` | 0.705 | 0.417 | 85 |
+| `v14_qb_starter` | 0.703 | 0.333 | 85 |
+| `v17_rookie_growth` | 0.703 | 0.333 | 85 |
+| `v19_usage_level_full` | 0.703 | 0.333 | 85 |
+| `v4_availability_adjusted` | 0.702 | 0.417 | 85 |
+| `v21_tiered_regression` | 0.701 | 0.333 | 85 |
+| `v6_usage_share` | 0.700 | 0.417 | 85 |
+| `v7_regression_to_mean` | 0.699 | 0.417 | 85 |
+| `v5_team_context` | 0.696 | 0.417 | 85 |
+| `v15_snap_trend` | 0.677 | 0.417 | 85 |
+| `v3_stat_weighted` | 0.672 | 0.417 | 85 |
+| `v8_age_regression` | 0.671 | 0.417 | 85 |
+| `v9_pos_specific` | 0.671 | 0.417 | 85 |
+| `v11_team_context_v2` | 0.671 | 0.417 | 85 |
+| `v2_age_adjusted` | 0.670 | 0.417 | 85 |
+| `v18_usage_level` | 0.670 | 0.417 | 85 |
+| `v10_stat_efficiency_v2` | 0.670 | 0.417 | 85 |
+| `v1_baseline_weighted_ppg` | 0.666 | 0.417 | 85 |
+| `v13_qb_starter` | 0.664 | 0.417 | 85 |
+| `v12_no_qb_trajectory` | 0.661 | 0.333 | 85 |
+| `naive_prior_season_ppg` | 0.610 | 0.333 | 85 |
+| `position_mean_baseline` | -0.007 | 0.167 | 85 |
+
+### RB (top-24)
+
+| Model | Spearman ρ | Top-N hit | N |
+| --- | --- | --- | --- |
+| `external_fantasypros_v1` | **0.836** | 0.667 | 102 |
+| `v3_stat_weighted` | 0.822 | 0.625 | 102 |
+| `v11_team_context_v2` | 0.821 | 0.667 | 102 |
+| `v8_age_regression` | 0.819 | 0.625 | 102 |
+| `v9_pos_specific` | 0.819 | 0.625 | 102 |
+| `v12_no_qb_trajectory` | 0.819 | 0.625 | 102 |
+| `v13_qb_starter` | 0.819 | 0.625 | 102 |
+| `v14_qb_starter` | 0.819 | 0.625 | 102 |
+| `v10_stat_efficiency_v2` | 0.818 | 0.625 | 102 |
+| `v19_usage_level_full` | 0.817 | 0.583 | 102 |
+| `v2_age_adjusted` | 0.816 | 0.625 | 102 |
+| `v21_tiered_regression` | 0.816 | 0.583 | 102 |
+| `v6_usage_share` | 0.815 | 0.625 | 102 |
+| `v17_rookie_growth` | 0.815 | 0.625 | 102 |
+| `v18_usage_level` | 0.815 | 0.583 | 102 |
+| `v5_team_context` | 0.813 | 0.625 | 102 |
+| `v7_regression_to_mean` | 0.806 | 0.583 | 102 |
+| `v4_availability_adjusted` | 0.805 | 0.625 | 102 |
+| `v15_snap_trend` | 0.804 | 0.625 | 102 |
+| `v16_snap_trend_full` | 0.801 | 0.583 | 102 |
+| `v1_baseline_weighted_ppg` | 0.790 | 0.667 | 102 |
+| `v29_reliability_residual` | 0.790 | 0.667 | 102 |
+| `v25_draft_capital_residual` | 0.783 | 0.667 | 102 |
+| `v26_vegas_residual` | 0.783 | 0.667 | 102 |
+| `v28_reliability_weighting` | 0.782 | 0.667 | 102 |
+| `v22_advanced_receiving` | 0.780 | 0.667 | 102 |
+| `v20_learned_usage` | 0.770 | 0.667 | 102 |
+| `v31_depth_chart` | 0.755 | 0.542 | 102 |
+| `v30_reliability_full_refit` | 0.753 | 0.583 | 102 |
+| `v27_vegas_full_refit` | 0.751 | 0.625 | 102 |
+| `naive_prior_season_ppg` | 0.750 | 0.583 | 102 |
+| `v23_draft_capital` | 0.744 | 0.583 | 102 |
+| `position_mean_baseline` | 0.208 | 0.375 | 102 |
+
+### WR (top-24)
+
+| Model | Spearman ρ | Top-N hit | N |
+| --- | --- | --- | --- |
+| `external_fantasypros_v1` | **0.767** | 0.500 | 136 |
+| `v26_vegas_residual` | 0.759 | 0.583 | 136 |
+| `v29_reliability_residual` | 0.747 | 0.542 | 136 |
+| `v19_usage_level_full` | 0.747 | 0.417 | 136 |
+| `v18_usage_level` | 0.747 | 0.417 | 136 |
+| `v3_stat_weighted` | 0.745 | 0.417 | 136 |
+| `v17_rookie_growth` | 0.744 | 0.417 | 136 |
+| `v15_snap_trend` | 0.744 | 0.458 | 136 |
+| `v7_regression_to_mean` | 0.744 | 0.458 | 136 |
+| `v2_age_adjusted` | 0.743 | 0.417 | 136 |
+| `v10_stat_efficiency_v2` | 0.743 | 0.417 | 136 |
+| `v11_team_context_v2` | 0.743 | 0.458 | 136 |
+| `v21_tiered_regression` | 0.743 | 0.542 | 136 |
+| `v6_usage_share` | 0.743 | 0.458 | 136 |
+| `v25_draft_capital_residual` | 0.743 | 0.500 | 136 |
+| `v30_reliability_full_refit` | 0.743 | 0.500 | 136 |
+| `v8_age_regression` | 0.742 | 0.417 | 136 |
+| `v9_pos_specific` | 0.742 | 0.417 | 136 |
+| `v12_no_qb_trajectory` | 0.742 | 0.417 | 136 |
+| `v13_qb_starter` | 0.742 | 0.417 | 136 |
+| `v14_qb_starter` | 0.742 | 0.417 | 136 |
+| `v31_depth_chart` | 0.742 | 0.500 | 136 |
+| `v16_snap_trend_full` | 0.741 | 0.458 | 136 |
+| `v4_availability_adjusted` | 0.739 | 0.500 | 136 |
+| `v5_team_context` | 0.734 | 0.542 | 136 |
+| `v28_reliability_weighting` | 0.733 | 0.583 | 136 |
+| `v27_vegas_full_refit` | 0.730 | 0.500 | 136 |
+| `v22_advanced_receiving` | 0.724 | 0.500 | 136 |
+| `v23_draft_capital` | 0.721 | 0.417 | 136 |
+| `naive_prior_season_ppg` | 0.720 | 0.500 | 136 |
+| `v1_baseline_weighted_ppg` | 0.717 | 0.542 | 136 |
+| `v20_learned_usage` | 0.706 | 0.542 | 136 |
+| `position_mean_baseline` | 0.185 | 0.250 | 136 |
+
+### TE (top-12)
+
+| Model | Spearman ρ | Top-N hit | N |
+| --- | --- | --- | --- |
+| `external_fantasypros_v1` | **0.780** | 0.750 | 111 |
+| `v31_depth_chart` | 0.759 | 0.667 | 111 |
+| `v26_vegas_residual` | 0.738 | 0.667 | 111 |
+| `v29_reliability_residual` | 0.738 | 0.667 | 111 |
+| `v28_reliability_weighting` | 0.737 | 0.667 | 111 |
+| `v5_team_context` | 0.733 | 0.667 | 111 |
+| `v25_draft_capital_residual` | 0.733 | 0.667 | 111 |
+| `v23_draft_capital` | 0.733 | 0.583 | 111 |
+| `v22_advanced_receiving` | 0.733 | 0.583 | 111 |
+| `v6_usage_share` | 0.732 | 0.667 | 111 |
+| `v30_reliability_full_refit` | 0.732 | 0.667 | 111 |
+| `v3_stat_weighted` | 0.731 | 0.667 | 111 |
+| `v27_vegas_full_refit` | 0.731 | 0.667 | 111 |
+| `v1_baseline_weighted_ppg` | 0.730 | 0.667 | 111 |
+| `v10_stat_efficiency_v2` | 0.729 | 0.667 | 111 |
+| `v11_team_context_v2` | 0.729 | 0.667 | 111 |
+| `v4_availability_adjusted` | 0.729 | 0.667 | 111 |
+| `v19_usage_level_full` | 0.729 | 0.667 | 111 |
+| `v18_usage_level` | 0.728 | 0.667 | 111 |
+| `v7_regression_to_mean` | 0.728 | 0.667 | 111 |
+| `v20_learned_usage` | 0.727 | 0.667 | 111 |
+| `v2_age_adjusted` | 0.727 | 0.667 | 111 |
+| `v17_rookie_growth` | 0.724 | 0.667 | 111 |
+| `v8_age_regression` | 0.724 | 0.667 | 111 |
+| `v9_pos_specific` | 0.724 | 0.667 | 111 |
+| `v12_no_qb_trajectory` | 0.724 | 0.667 | 111 |
+| `v13_qb_starter` | 0.724 | 0.667 | 111 |
+| `v14_qb_starter` | 0.724 | 0.667 | 111 |
+| `v15_snap_trend` | 0.714 | 0.667 | 111 |
+| `v16_snap_trend_full` | 0.712 | 0.667 | 111 |
+| `v21_tiered_regression` | 0.707 | 0.667 | 111 |
+| `naive_prior_season_ppg` | 0.682 | 0.667 | 111 |
+| `position_mean_baseline` | 0.091 | 0.083 | 111 |
+
 ## Season 2024 — ALL (held-out)
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `v19_usage_level_full` | 2.594 | +0.282 | 0.621 | 3.311 | 185 |
-| `v12_no_qb_trajectory` | 2.598 | +0.453 | 0.612 | 3.352 | 185 |
-| `v14_qb_starter` | 2.599 | +0.507 | 0.616 | 3.334 | 185 |
-| `v22_advanced_receiving` | 2.599 | -0.186 | 0.616 | 3.335 | 185 |
-| `v13_qb_starter` | 2.601 | +0.445 | 0.610 | 3.361 | 185 |
-| `v17_rookie_growth` | 2.603 | +0.480 | 0.615 | 3.339 | 185 |
-| `v11_team_context_v2` | 2.604 | +0.425 | 0.606 | 3.379 | 185 |
-| `v31_depth_chart` | 2.608 | -0.808 | 0.616 | 3.333 | 185 |
-| `v8_age_regression` | 2.614 | +0.458 | 0.609 | 3.366 | 185 |
-| `v9_pos_specific` | 2.614 | +0.458 | 0.609 | 3.366 | 185 |
-| `v10_stat_efficiency_v2` | 2.616 | +0.453 | 0.611 | 3.357 | 185 |
-| `v26_vegas_residual` | 2.637 | -0.460 | 0.607 | 3.373 | 185 |
-| `v16_snap_trend_full` | 2.647 | +0.444 | 0.595 | 3.422 | 185 |
-| `v20_learned_usage` | 2.648 | -0.350 | 0.607 | 3.372 | 185 |
-| `v25_draft_capital_residual` | 2.648 | -0.415 | 0.602 | 3.394 | 185 |
-| `v3_stat_weighted` | 2.660 | +0.282 | 0.601 | 3.398 | 185 |
-| `v28_reliability_weighting` | 2.661 | -0.635 | 0.602 | 3.393 | 185 |
-| `v2_age_adjusted` | 2.663 | +0.272 | 0.599 | 3.405 | 185 |
-| `v27_vegas_full_refit` | 2.675 | -0.678 | 0.591 | 3.443 | 185 |
-| `external_fantasypros_v1` | 2.679 | +1.456 | 0.572 | 3.520 | 185 |
-| `v23_draft_capital` | 2.679 | -0.231 | 0.582 | 3.477 | 185 |
-| `v21_tiered_regression` | 2.681 | +0.711 | 0.584 | 3.471 | 185 |
-| `v30_reliability_full_refit` | 2.687 | -0.682 | 0.586 | 3.463 | 185 |
-| `v1_baseline_weighted_ppg` | 2.695 | +0.091 | 0.577 | 3.499 | 185 |
-| `v18_usage_level` | 2.696 | +0.047 | 0.595 | 3.425 | 185 |
-| `v29_reliability_residual` | 2.712 | -0.826 | 0.588 | 3.455 | 185 |
-| `v7_regression_to_mean` | 2.722 | +0.721 | 0.585 | 3.467 | 185 |
-| `v15_snap_trend` | 2.738 | +0.209 | 0.576 | 3.502 | 185 |
-| `v4_availability_adjusted` | 2.769 | +0.792 | 0.569 | 3.533 | 185 |
-| `v5_team_context` | 2.777 | +0.759 | 0.562 | 3.560 | 185 |
-| `v6_usage_share` | 2.784 | +0.534 | 0.563 | 3.555 | 185 |
-| `naive_prior_season_ppg` | 2.881 | +0.310 | 0.468 | 3.924 | 185 |
-| `position_mean_baseline` | 3.868 | +1.645 | 0.168 | 4.909 | 185 |
+| `v19_usage_level_full` | 2.506 | +0.489 | 0.652 | 3.268 | 198 |
+| `v17_rookie_growth` | 2.527 | +0.686 | 0.645 | 3.298 | 198 |
+| `v12_no_qb_trajectory` | 2.533 | +0.648 | 0.640 | 3.323 | 198 |
+| `v14_qb_starter` | 2.536 | +0.698 | 0.643 | 3.311 | 198 |
+| `v13_qb_starter` | 2.544 | +0.640 | 0.638 | 3.331 | 198 |
+| `v8_age_regression` | 2.550 | +0.653 | 0.637 | 3.337 | 198 |
+| `v9_pos_specific` | 2.550 | +0.653 | 0.637 | 3.337 | 198 |
+| `v11_team_context_v2` | 2.551 | +0.622 | 0.634 | 3.350 | 198 |
+| `v10_stat_efficiency_v2` | 2.555 | +0.662 | 0.638 | 3.334 | 198 |
+| `v21_tiered_regression` | 2.557 | +0.556 | 0.637 | 3.336 | 198 |
+| `v3_stat_weighted` | 2.563 | +0.251 | 0.644 | 3.305 | 198 |
+| `v2_age_adjusted` | 2.567 | +0.257 | 0.642 | 3.314 | 198 |
+| `v16_snap_trend_full` | 2.576 | +0.631 | 0.625 | 3.393 | 198 |
+| `v18_usage_level` | 2.596 | +0.048 | 0.638 | 3.332 | 198 |
+| `v1_baseline_weighted_ppg` | 2.597 | +0.088 | 0.622 | 3.404 | 198 |
+| `external_fantasypros_v1` | 2.614 | +1.390 | 0.610 | 3.459 | 198 |
+| `v4_availability_adjusted` | 2.638 | +0.762 | 0.619 | 3.416 | 198 |
+| `v15_snap_trend` | 2.644 | +0.190 | 0.620 | 3.413 | 198 |
+| `v6_usage_share` | 2.652 | +0.538 | 0.613 | 3.444 | 198 |
+| `v31_depth_chart` | 2.654 | +0.635 | 0.619 | 3.418 | 198 |
+| `v26_vegas_residual` | 2.659 | +0.694 | 0.612 | 3.449 | 198 |
+| `v5_team_context` | 2.665 | +0.734 | 0.606 | 3.478 | 198 |
+| `v7_regression_to_mean` | 2.679 | +0.920 | 0.605 | 3.481 | 198 |
+| `v25_draft_capital_residual` | 2.708 | +0.733 | 0.606 | 3.476 | 198 |
+| `naive_prior_season_ppg` | 2.745 | +0.342 | 0.529 | 3.799 | 198 |
+| `v29_reliability_residual` | 2.747 | +0.713 | 0.595 | 3.525 | 198 |
+| `v20_learned_usage` | 2.749 | +1.143 | 0.587 | 3.558 | 198 |
+| `v22_advanced_receiving` | 2.778 | +1.085 | 0.587 | 3.561 | 198 |
+| `v30_reliability_full_refit` | 2.797 | +0.802 | 0.580 | 3.590 | 198 |
+| `v27_vegas_full_refit` | 2.804 | +0.834 | 0.580 | 3.588 | 198 |
+| `v23_draft_capital` | 2.809 | +0.821 | 0.575 | 3.611 | 198 |
+| `v28_reliability_weighting` | 2.813 | +1.034 | 0.575 | 3.611 | 198 |
+| `position_mean_baseline` | 4.812 | +3.388 | -0.188 | 6.037 | 198 |
 
 ## Season 2025 — ALL (held-out)
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 2.361 | +0.673 | 0.652 | 3.301 | 231 |
-| `v14_qb_starter` | 2.410 | -0.117 | 0.664 | 3.241 | 231 |
-| `v16_snap_trend_full` | 2.425 | -0.179 | 0.663 | 3.248 | 231 |
-| `v19_usage_level_full` | 2.426 | -0.297 | 0.663 | 3.246 | 231 |
-| `v10_stat_efficiency_v2` | 2.445 | -0.234 | 0.627 | 3.414 | 231 |
-| `v21_tiered_regression` | 2.447 | -0.151 | 0.648 | 3.319 | 231 |
-| `v7_regression_to_mean` | 2.449 | -0.029 | 0.640 | 3.356 | 231 |
-| `v8_age_regression` | 2.455 | -0.242 | 0.625 | 3.423 | 231 |
-| `v9_pos_specific` | 2.455 | -0.242 | 0.625 | 3.423 | 231 |
-| `v17_rookie_growth` | 2.456 | -0.170 | 0.659 | 3.267 | 231 |
-| `v11_team_context_v2` | 2.461 | -0.281 | 0.619 | 3.450 | 231 |
-| `v12_no_qb_trajectory` | 2.464 | -0.193 | 0.626 | 3.420 | 231 |
-| `v13_qb_starter` | 2.467 | -0.230 | 0.622 | 3.437 | 231 |
-| `v5_team_context` | 2.500 | -0.178 | 0.615 | 3.472 | 231 |
-| `v4_availability_adjusted` | 2.515 | -0.144 | 0.617 | 3.463 | 231 |
-| `v3_stat_weighted` | 2.525 | -0.555 | 0.600 | 3.537 | 231 |
-| `v2_age_adjusted` | 2.526 | -0.572 | 0.600 | 3.538 | 231 |
-| `v15_snap_trend` | 2.534 | -0.634 | 0.596 | 3.555 | 231 |
-| `v6_usage_share` | 2.535 | -0.359 | 0.606 | 3.511 | 231 |
-| `v18_usage_level` | 2.583 | -0.752 | 0.587 | 3.593 | 231 |
-| `v20_learned_usage` | 2.647 | -0.850 | 0.646 | 3.328 | 231 |
-| `v28_reliability_weighting` | 2.664 | -0.907 | 0.644 | 3.338 | 231 |
-| `v30_reliability_full_refit` | 2.665 | -1.034 | 0.638 | 3.365 | 231 |
-| `v27_vegas_full_refit` | 2.673 | -1.027 | 0.637 | 3.370 | 231 |
-| `v29_reliability_residual` | 2.679 | -1.075 | 0.642 | 3.347 | 231 |
-| `v26_vegas_residual` | 2.684 | -1.122 | 0.631 | 3.399 | 231 |
-| `v31_depth_chart` | 2.695 | -0.987 | 0.619 | 3.451 | 231 |
-| `v1_baseline_weighted_ppg` | 2.703 | -0.845 | 0.565 | 3.687 | 231 |
-| `v22_advanced_receiving` | 2.716 | -0.870 | 0.629 | 3.408 | 231 |
-| `v25_draft_capital_residual` | 2.729 | -1.071 | 0.626 | 3.419 | 231 |
-| `v23_draft_capital` | 2.792 | -0.989 | 0.610 | 3.493 | 231 |
-| `naive_prior_season_ppg` | 2.897 | -0.754 | 0.496 | 3.970 | 231 |
-| `position_mean_baseline` | 4.250 | +1.846 | 0.076 | 5.376 | 231 |
+| `external_fantasypros_v1` | 2.342 | +0.680 | 0.659 | 3.281 | 236 |
+| `v26_vegas_residual` | 2.396 | -0.131 | 0.694 | 3.107 | 236 |
+| `v31_depth_chart` | 2.417 | -0.071 | 0.688 | 3.139 | 236 |
+| `v29_reliability_residual` | 2.434 | -0.107 | 0.686 | 3.152 | 236 |
+| `v14_qb_starter` | 2.434 | -0.088 | 0.666 | 3.248 | 236 |
+| `v25_draft_capital_residual` | 2.437 | -0.116 | 0.690 | 3.131 | 236 |
+| `v16_snap_trend_full` | 2.440 | -0.144 | 0.666 | 3.248 | 236 |
+| `v21_tiered_regression` | 2.442 | -0.245 | 0.653 | 3.312 | 236 |
+| `v30_reliability_full_refit` | 2.446 | -0.079 | 0.679 | 3.184 | 236 |
+| `v19_usage_level_full` | 2.447 | -0.265 | 0.666 | 3.249 | 236 |
+| `v7_regression_to_mean` | 2.465 | +0.020 | 0.643 | 3.356 | 236 |
+| `v28_reliability_weighting` | 2.467 | +0.177 | 0.673 | 3.216 | 236 |
+| `v11_team_context_v2` | 2.471 | -0.251 | 0.627 | 3.433 | 236 |
+| `v17_rookie_growth` | 2.476 | -0.138 | 0.661 | 3.272 | 236 |
+| `v27_vegas_full_refit` | 2.477 | -0.081 | 0.672 | 3.219 | 236 |
+| `v8_age_regression` | 2.478 | -0.215 | 0.629 | 3.425 | 236 |
+| `v9_pos_specific` | 2.478 | -0.215 | 0.629 | 3.425 | 236 |
+| `v10_stat_efficiency_v2` | 2.480 | -0.199 | 0.628 | 3.426 | 236 |
+| `v23_draft_capital` | 2.487 | -0.056 | 0.673 | 3.215 | 236 |
+| `v12_no_qb_trajectory` | 2.489 | -0.167 | 0.629 | 3.425 | 236 |
+| `v22_advanced_receiving` | 2.490 | +0.198 | 0.675 | 3.206 | 236 |
+| `v13_qb_starter` | 2.491 | -0.203 | 0.626 | 3.439 | 236 |
+| `v20_learned_usage` | 2.494 | +0.244 | 0.667 | 3.244 | 236 |
+| `v5_team_context` | 2.500 | -0.180 | 0.622 | 3.456 | 236 |
+| `v4_availability_adjusted` | 2.526 | -0.160 | 0.619 | 3.470 | 236 |
+| `v3_stat_weighted` | 2.535 | -0.604 | 0.604 | 3.537 | 236 |
+| `v6_usage_share` | 2.545 | -0.377 | 0.610 | 3.509 | 236 |
+| `v2_age_adjusted` | 2.548 | -0.612 | 0.602 | 3.546 | 236 |
+| `v15_snap_trend` | 2.549 | -0.667 | 0.600 | 3.558 | 236 |
+| `v18_usage_level` | 2.604 | -0.788 | 0.590 | 3.599 | 236 |
+| `v1_baseline_weighted_ppg` | 2.721 | -0.880 | 0.569 | 3.692 | 236 |
+| `naive_prior_season_ppg` | 2.883 | -0.728 | 0.506 | 3.950 | 236 |
+| `position_mean_baseline` | 4.452 | +2.382 | 0.001 | 5.618 | 236 |

--- a/docs/generated/projection-holdout-eval-rolling.md
+++ b/docs/generated/projection-holdout-eval-rolling.md
@@ -1,0 +1,544 @@
+# Projection Held-Out Evaluation (GH #572) — rolling-origin
+
+_Generated: 2026-06-10 14:17_
+
+**Rolling-origin protocol (GH #594).** Each eval season is scored by models that trained on an *expanding window of only the seasons before it* — train 2021,2022 → eval 2023; train 2021,2022,2023 → eval 2024; train 2021,2022,2023,2024 → eval 2025. This guards the single fixed holdout against decay (no one window drives every accept/reject decision) and removes the fixed protocol's 3-vs-5 training-season handicap on learned models. The combined rows below pool every fold's player-seasons; the per-season tables are the individual folds. See [docs/exec-plans/projection-methodology-audit.md](../exec-plans/projection-methodology-audit.md) (rolling-origin protocol).
+
+## Ranking — combined held-out ALL (lower MAE = better)
+
+_**MAE** is the pooled-over-players ALL error. **Bal MAE** is the position-balanced MAE — the unweighted mean of the per-position MAEs over a fixed set (QB/RB/WR/TE; K excluded as essentially random and not projected by every model) — which neutralises the drifting position mix of the qualifier pool (GH #577). They can disagree: a model can win the pooled MAE while losing the balanced one if it's strong only where players are easy/plentiful._
+
+| Rank | Model | MAE | Bal MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `v31_depth_chart` | **2.232** | 2.450 | -0.161 | 0.668 | 2.983 | 1216 |
+| 2 | `v27_vegas_full_refit` | 2.298 | 2.527 | -0.159 | 0.649 | 3.065 | 1216 |
+| 3 | `v30_reliability_full_refit` | 2.300 | 2.531 | -0.175 | 0.649 | 3.067 | 1216 |
+| 4 | `v29_reliability_residual` | 2.306 | 2.538 | -0.271 | 0.648 | 3.070 | 1216 |
+| 5 | `v28_reliability_weighting` | 2.307 | 2.535 | -0.088 | 0.643 | 3.090 | 1216 |
+| 6 | `v23_draft_capital` | 2.315 | 2.541 | -0.182 | 0.646 | 3.078 | 1216 |
+| 7 | `v22_advanced_receiving` | 2.316 | 2.534 | -0.088 | 0.642 | 3.096 | 1216 |
+| 8 | `v26_vegas_residual` | 2.317 | 2.540 | -0.301 | 0.646 | 3.078 | 1216 |
+| 9 | `v25_draft_capital_residual` | 2.319 | 2.542 | -0.281 | 0.646 | 3.078 | 1216 |
+| 10 | `v20_learned_usage` | 2.321 | 2.535 | -0.069 | 0.641 | 3.101 | 1216 |
+| 11 | `v14_qb_starter` | 2.322 | 2.554 | -0.339 | 0.636 | 3.156 | 1261 |
+| 12 | `v16_snap_trend_full` | 2.325 | 2.567 | -0.366 | 0.632 | 3.175 | 1261 |
+| 13 | `external_fantasypros_v1` | 2.330 | **2.410** | +1.054 | 0.679 | 3.227 | 599 |
+| 14 | `v19_usage_level_full` | 2.332 | 2.563 | -0.453 | 0.633 | 3.170 | 1261 |
+| 15 | `v12_no_qb_trajectory` | 2.335 | 2.581 | -0.385 | 0.624 | 3.207 | 1261 |
+| 16 | `v4_availability_adjusted` | 2.337 | 2.592 | -0.134 | 0.611 | 3.265 | 1261 |
+| 17 | `v10_stat_efficiency_v2` | 2.338 | 2.582 | -0.397 | 0.623 | 3.213 | 1261 |
+| 18 | `v8_age_regression` | 2.338 | 2.581 | -0.404 | 0.622 | 3.217 | 1261 |
+| 19 | `v9_pos_specific` | 2.338 | 2.581 | -0.404 | 0.622 | 3.217 | 1261 |
+| 20 | `v13_qb_starter` | 2.340 | 2.584 | -0.401 | 0.622 | 3.220 | 1261 |
+| 21 | `v17_rookie_growth` | 2.341 | 2.572 | -0.380 | 0.633 | 3.168 | 1261 |
+| 22 | `v7_regression_to_mean` | 2.341 | 2.594 | -0.085 | 0.619 | 3.228 | 1261 |
+| 23 | `v5_team_context` | 2.357 | 2.616 | -0.151 | 0.603 | 3.298 | 1261 |
+| 24 | `v11_team_context_v2` | 2.357 | 2.602 | -0.414 | 0.616 | 3.243 | 1261 |
+| 25 | `v3_stat_weighted` | 2.376 | 2.625 | -0.585 | 0.601 | 3.307 | 1261 |
+| 26 | `v2_age_adjusted` | 2.377 | 2.625 | -0.587 | 0.600 | 3.309 | 1261 |
+| 27 | `v6_usage_share` | 2.383 | 2.635 | -0.259 | 0.597 | 3.323 | 1261 |
+| 28 | `v21_tiered_regression` | 2.395 | 2.638 | -0.316 | 0.599 | 3.314 | 1261 |
+| 29 | `v15_snap_trend` | 2.396 | 2.658 | -0.614 | 0.594 | 3.336 | 1261 |
+| 30 | `v18_usage_level` | 2.417 | 2.659 | -0.700 | 0.589 | 3.353 | 1261 |
+| 31 | `v1_baseline_weighted_ppg` | 2.430 | 2.681 | -0.751 | 0.585 | 3.373 | 1261 |
+| 32 | `naive_prior_season_ppg` | 2.498 | 2.816 | -0.448 | 0.539 | 3.559 | 1276 |
+| 33 | `position_mean_baseline` | 3.692 | 4.045 | +0.710 | 0.179 | 4.747 | 1276 |
+
+## Combined across eval seasons — by position
+
+### ALL
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v31_depth_chart` | 2.232 | -0.161 | 0.668 | 2.983 | 1216 |
+| `v27_vegas_full_refit` | 2.298 | -0.159 | 0.649 | 3.065 | 1216 |
+| `v30_reliability_full_refit` | 2.300 | -0.175 | 0.649 | 3.067 | 1216 |
+| `v29_reliability_residual` | 2.306 | -0.271 | 0.648 | 3.070 | 1216 |
+| `v28_reliability_weighting` | 2.307 | -0.088 | 0.643 | 3.090 | 1216 |
+| `v23_draft_capital` | 2.315 | -0.182 | 0.646 | 3.078 | 1216 |
+| `v22_advanced_receiving` | 2.316 | -0.088 | 0.642 | 3.096 | 1216 |
+| `v26_vegas_residual` | 2.317 | -0.301 | 0.646 | 3.078 | 1216 |
+| `v25_draft_capital_residual` | 2.319 | -0.281 | 0.646 | 3.078 | 1216 |
+| `v20_learned_usage` | 2.321 | -0.069 | 0.641 | 3.101 | 1216 |
+| `v14_qb_starter` | 2.322 | -0.339 | 0.636 | 3.156 | 1261 |
+| `v16_snap_trend_full` | 2.325 | -0.366 | 0.632 | 3.175 | 1261 |
+| `external_fantasypros_v1` | 2.330 | +1.054 | 0.679 | 3.227 | 599 |
+| `v19_usage_level_full` | 2.332 | -0.453 | 0.633 | 3.170 | 1261 |
+| `v12_no_qb_trajectory` | 2.335 | -0.385 | 0.624 | 3.207 | 1261 |
+| `v4_availability_adjusted` | 2.337 | -0.134 | 0.611 | 3.265 | 1261 |
+| `v10_stat_efficiency_v2` | 2.338 | -0.397 | 0.623 | 3.213 | 1261 |
+| `v8_age_regression` | 2.338 | -0.404 | 0.622 | 3.217 | 1261 |
+| `v9_pos_specific` | 2.338 | -0.404 | 0.622 | 3.217 | 1261 |
+| `v13_qb_starter` | 2.340 | -0.401 | 0.622 | 3.220 | 1261 |
+| `v17_rookie_growth` | 2.341 | -0.380 | 0.633 | 3.168 | 1261 |
+| `v7_regression_to_mean` | 2.341 | -0.085 | 0.619 | 3.228 | 1261 |
+| `v5_team_context` | 2.357 | -0.151 | 0.603 | 3.298 | 1261 |
+| `v11_team_context_v2` | 2.357 | -0.414 | 0.616 | 3.243 | 1261 |
+| `v3_stat_weighted` | 2.376 | -0.585 | 0.601 | 3.307 | 1261 |
+| `v2_age_adjusted` | 2.377 | -0.587 | 0.600 | 3.309 | 1261 |
+| `v6_usage_share` | 2.383 | -0.259 | 0.597 | 3.323 | 1261 |
+| `v21_tiered_regression` | 2.395 | -0.316 | 0.599 | 3.314 | 1261 |
+| `v15_snap_trend` | 2.396 | -0.614 | 0.594 | 3.336 | 1261 |
+| `v18_usage_level` | 2.417 | -0.700 | 0.589 | 3.353 | 1261 |
+| `v1_baseline_weighted_ppg` | 2.430 | -0.751 | 0.585 | 3.373 | 1261 |
+| `naive_prior_season_ppg` | 2.498 | -0.448 | 0.539 | 3.559 | 1276 |
+| `position_mean_baseline` | 3.692 | +0.710 | 0.179 | 4.747 | 1276 |
+
+### QB
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 3.517 | +2.001 | 0.438 | 4.849 | 122 |
+| `v22_advanced_receiving` | 3.665 | -0.283 | 0.424 | 4.699 | 152 |
+| `v31_depth_chart` | 3.666 | -0.575 | 0.441 | 4.630 | 152 |
+| `v20_learned_usage` | 3.682 | -0.365 | 0.417 | 4.726 | 152 |
+| `v26_vegas_residual` | 3.700 | -0.538 | 0.407 | 4.767 | 152 |
+| `v28_reliability_weighting` | 3.704 | -0.455 | 0.414 | 4.738 | 152 |
+| `v25_draft_capital_residual` | 3.713 | -0.500 | 0.410 | 4.755 | 152 |
+| `v27_vegas_full_refit` | 3.728 | -0.501 | 0.407 | 4.769 | 152 |
+| `v30_reliability_full_refit` | 3.742 | -0.552 | 0.402 | 4.788 | 152 |
+| `v29_reliability_residual` | 3.746 | -0.641 | 0.400 | 4.797 | 152 |
+| `v23_draft_capital` | 3.747 | -0.393 | 0.411 | 4.751 | 152 |
+| `v14_qb_starter` | 3.879 | -0.514 | 0.383 | 5.083 | 157 |
+| `v17_rookie_growth` | 3.879 | -0.514 | 0.383 | 5.083 | 157 |
+| `v19_usage_level_full` | 3.879 | -0.514 | 0.383 | 5.083 | 157 |
+| `v16_snap_trend_full` | 3.947 | -0.557 | 0.365 | 5.153 | 157 |
+| `v8_age_regression` | 3.984 | -1.006 | 0.313 | 5.360 | 157 |
+| `v9_pos_specific` | 3.984 | -1.006 | 0.313 | 5.360 | 157 |
+| `v12_no_qb_trajectory` | 3.987 | -0.883 | 0.321 | 5.330 | 157 |
+| `v10_stat_efficiency_v2` | 3.998 | -0.996 | 0.315 | 5.355 | 157 |
+| `v13_qb_starter` | 3.999 | -0.981 | 0.310 | 5.372 | 157 |
+| `v11_team_context_v2` | 4.012 | -1.045 | 0.306 | 5.390 | 157 |
+| `v21_tiered_regression` | 4.026 | -0.367 | 0.332 | 5.289 | 157 |
+| `v7_regression_to_mean` | 4.090 | +0.443 | 0.326 | 5.311 | 157 |
+| `v2_age_adjusted` | 4.093 | -1.305 | 0.268 | 5.534 | 157 |
+| `v18_usage_level` | 4.093 | -1.305 | 0.268 | 5.534 | 157 |
+| `v3_stat_weighted` | 4.103 | -1.296 | 0.268 | 5.537 | 157 |
+| `v4_availability_adjusted` | 4.128 | +0.192 | 0.293 | 5.438 | 157 |
+| `v6_usage_share` | 4.162 | +0.148 | 0.284 | 5.475 | 157 |
+| `v1_baseline_weighted_ppg` | 4.168 | -1.648 | 0.250 | 5.601 | 157 |
+| `v5_team_context` | 4.186 | +0.150 | 0.283 | 5.479 | 157 |
+| `v15_snap_trend` | 4.207 | -1.347 | 0.244 | 5.623 | 157 |
+| `naive_prior_season_ppg` | 4.716 | -0.817 | 0.076 | 6.219 | 157 |
+| `position_mean_baseline` | 5.482 | +0.774 | -0.015 | 6.519 | 157 |
+
+### RB
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v4_availability_adjusted` | 2.384 | -0.039 | 0.611 | 3.374 | 302 |
+| `v5_team_context` | 2.388 | -0.041 | 0.601 | 3.417 | 302 |
+| `v10_stat_efficiency_v2` | 2.405 | -0.196 | 0.624 | 3.314 | 302 |
+| `v8_age_regression` | 2.407 | -0.213 | 0.623 | 3.323 | 302 |
+| `v9_pos_specific` | 2.407 | -0.213 | 0.623 | 3.323 | 302 |
+| `v12_no_qb_trajectory` | 2.407 | -0.213 | 0.623 | 3.323 | 302 |
+| `v13_qb_starter` | 2.407 | -0.213 | 0.623 | 3.323 | 302 |
+| `v14_qb_starter` | 2.407 | -0.213 | 0.623 | 3.323 | 302 |
+| `v31_depth_chart` | 2.411 | +0.136 | 0.638 | 3.218 | 287 |
+| `v3_stat_weighted` | 2.412 | -0.402 | 0.609 | 3.381 | 302 |
+| `v16_snap_trend_full` | 2.414 | -0.269 | 0.619 | 3.339 | 302 |
+| `v6_usage_share` | 2.417 | -0.222 | 0.594 | 3.446 | 302 |
+| `v2_age_adjusted` | 2.418 | -0.407 | 0.607 | 3.392 | 302 |
+| `v19_usage_level_full` | 2.420 | -0.393 | 0.619 | 3.337 | 302 |
+| `v7_regression_to_mean` | 2.427 | -0.024 | 0.606 | 3.394 | 302 |
+| `v11_team_context_v2` | 2.431 | -0.215 | 0.616 | 3.352 | 302 |
+| `v15_snap_trend` | 2.442 | -0.463 | 0.599 | 3.423 | 302 |
+| `v17_rookie_growth` | 2.454 | -0.300 | 0.612 | 3.368 | 302 |
+| `v1_baseline_weighted_ppg` | 2.465 | -0.590 | 0.588 | 3.470 | 302 |
+| `v18_usage_level` | 2.465 | -0.587 | 0.591 | 3.460 | 302 |
+| `naive_prior_season_ppg` | 2.479 | -0.247 | 0.563 | 3.574 | 305 |
+| `v21_tiered_regression` | 2.506 | -0.137 | 0.574 | 3.531 | 302 |
+| `v20_learned_usage` | 2.565 | +0.106 | 0.594 | 3.405 | 287 |
+| `v27_vegas_full_refit` | 2.590 | +0.094 | 0.598 | 3.389 | 287 |
+| `v26_vegas_residual` | 2.593 | -0.030 | 0.604 | 3.365 | 287 |
+| `external_fantasypros_v1` | 2.597 | +1.313 | 0.645 | 3.305 | 139 |
+| `v23_draft_capital` | 2.597 | +0.033 | 0.597 | 3.392 | 287 |
+| `v25_draft_capital_residual` | 2.598 | -0.021 | 0.602 | 3.374 | 287 |
+| `v29_reliability_residual` | 2.603 | +0.071 | 0.598 | 3.391 | 287 |
+| `v30_reliability_full_refit` | 2.604 | +0.088 | 0.595 | 3.401 | 287 |
+| `v22_advanced_receiving` | 2.627 | +0.143 | 0.586 | 3.440 | 287 |
+| `v28_reliability_weighting` | 2.638 | +0.254 | 0.580 | 3.465 | 287 |
+| `position_mean_baseline` | 4.384 | +0.976 | -0.033 | 5.495 | 305 |
+
+### WR
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 2.037 | +0.498 | 0.694 | 2.626 | 187 |
+| `v31_depth_chart` | 2.192 | -0.382 | 0.618 | 2.772 | 431 |
+| `v30_reliability_full_refit` | 2.203 | -0.336 | 0.620 | 2.767 | 431 |
+| `v27_vegas_full_refit` | 2.213 | -0.337 | 0.616 | 2.780 | 431 |
+| `v28_reliability_weighting` | 2.224 | -0.192 | 0.607 | 2.812 | 431 |
+| `v29_reliability_residual` | 2.227 | -0.467 | 0.616 | 2.779 | 431 |
+| `v23_draft_capital` | 2.251 | -0.358 | 0.603 | 2.826 | 431 |
+| `v4_availability_adjusted` | 2.261 | -0.448 | 0.596 | 2.896 | 450 |
+| `v22_advanced_receiving` | 2.264 | -0.177 | 0.591 | 2.869 | 431 |
+| `v26_vegas_residual` | 2.265 | -0.515 | 0.601 | 2.834 | 431 |
+| `v25_draft_capital_residual` | 2.271 | -0.478 | 0.600 | 2.837 | 431 |
+| `v7_regression_to_mean` | 2.277 | -0.426 | 0.602 | 2.872 | 450 |
+| `v5_team_context` | 2.292 | -0.476 | 0.584 | 2.939 | 450 |
+| `v16_snap_trend_full` | 2.297 | -0.570 | 0.599 | 2.885 | 450 |
+| `v20_learned_usage` | 2.308 | -0.111 | 0.587 | 2.882 | 431 |
+| `v10_stat_efficiency_v2` | 2.311 | -0.529 | 0.601 | 2.877 | 450 |
+| `v8_age_regression` | 2.313 | -0.533 | 0.601 | 2.879 | 450 |
+| `v9_pos_specific` | 2.313 | -0.533 | 0.601 | 2.879 | 450 |
+| `v12_no_qb_trajectory` | 2.313 | -0.533 | 0.601 | 2.879 | 450 |
+| `v13_qb_starter` | 2.313 | -0.533 | 0.601 | 2.879 | 450 |
+| `v14_qb_starter` | 2.313 | -0.533 | 0.601 | 2.879 | 450 |
+| `v19_usage_level_full` | 2.332 | -0.688 | 0.593 | 2.907 | 450 |
+| `v17_rookie_growth` | 2.333 | -0.579 | 0.600 | 2.882 | 450 |
+| `v11_team_context_v2` | 2.333 | -0.547 | 0.591 | 2.912 | 450 |
+| `v6_usage_share` | 2.341 | -0.618 | 0.571 | 2.984 | 450 |
+| `v15_snap_trend` | 2.358 | -0.779 | 0.571 | 2.985 | 450 |
+| `v2_age_adjusted` | 2.358 | -0.742 | 0.573 | 2.975 | 450 |
+| `v3_stat_weighted` | 2.361 | -0.743 | 0.573 | 2.978 | 450 |
+| `v21_tiered_regression` | 2.376 | -0.655 | 0.554 | 3.041 | 450 |
+| `naive_prior_season_ppg` | 2.381 | -0.670 | 0.541 | 3.091 | 457 |
+| `v18_usage_level` | 2.423 | -0.897 | 0.552 | 3.048 | 450 |
+| `v1_baseline_weighted_ppg` | 2.424 | -0.862 | 0.553 | 3.045 | 450 |
+| `position_mean_baseline` | 3.739 | +0.796 | -0.032 | 4.637 | 457 |
+
+### TE
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 1.488 | +0.741 | 0.654 | 1.927 | 151 |
+| `v31_depth_chart` | 1.530 | -0.060 | 0.631 | 1.944 | 249 |
+| `v23_draft_capital` | 1.567 | -0.117 | 0.609 | 2.003 | 249 |
+| `v28_reliability_weighting` | 1.573 | -0.056 | 0.603 | 2.018 | 249 |
+| `v30_reliability_full_refit` | 1.574 | -0.079 | 0.609 | 2.003 | 249 |
+| `v27_vegas_full_refit` | 1.575 | -0.035 | 0.609 | 2.003 | 249 |
+| `v29_reliability_residual` | 1.578 | -0.140 | 0.607 | 2.008 | 249 |
+| `v22_advanced_receiving` | 1.579 | -0.066 | 0.600 | 2.027 | 249 |
+| `v7_regression_to_mean` | 1.582 | +0.042 | 0.591 | 2.062 | 255 |
+| `v20_learned_usage` | 1.584 | -0.025 | 0.588 | 2.057 | 249 |
+| `v25_draft_capital_residual` | 1.586 | -0.156 | 0.604 | 2.015 | 249 |
+| `v4_availability_adjusted` | 1.593 | +0.028 | 0.578 | 2.093 | 255 |
+| `v5_team_context` | 1.599 | +0.021 | 0.578 | 2.092 | 255 |
+| `v26_vegas_residual` | 1.604 | -0.155 | 0.600 | 2.026 | 249 |
+| `v16_snap_trend_full` | 1.608 | -0.147 | 0.592 | 2.059 | 255 |
+| `v10_stat_efficiency_v2` | 1.614 | -0.157 | 0.588 | 2.070 | 255 |
+| `v8_age_regression` | 1.618 | -0.159 | 0.587 | 2.072 | 255 |
+| `v9_pos_specific` | 1.618 | -0.159 | 0.587 | 2.072 | 255 |
+| `v12_no_qb_trajectory` | 1.618 | -0.159 | 0.587 | 2.072 | 255 |
+| `v13_qb_starter` | 1.618 | -0.159 | 0.587 | 2.072 | 255 |
+| `v14_qb_starter` | 1.618 | -0.159 | 0.587 | 2.072 | 255 |
+| `v17_rookie_growth` | 1.621 | -0.176 | 0.588 | 2.069 | 255 |
+| `v6_usage_share` | 1.621 | -0.049 | 0.565 | 2.125 | 255 |
+| `v19_usage_level_full` | 1.621 | -0.231 | 0.585 | 2.077 | 255 |
+| `v3_stat_weighted` | 1.623 | -0.265 | 0.577 | 2.097 | 255 |
+| `v15_snap_trend` | 1.623 | -0.256 | 0.581 | 2.085 | 255 |
+| `v2_age_adjusted` | 1.630 | -0.267 | 0.574 | 2.103 | 255 |
+| `v11_team_context_v2` | 1.631 | -0.158 | 0.582 | 2.084 | 255 |
+| `v21_tiered_regression` | 1.643 | -0.048 | 0.565 | 2.126 | 255 |
+| `v18_usage_level` | 1.654 | -0.340 | 0.561 | 2.136 | 255 |
+| `v1_baseline_weighted_ppg` | 1.669 | -0.468 | 0.550 | 2.163 | 255 |
+| `naive_prior_season_ppg` | 1.689 | -0.273 | 0.537 | 2.197 | 260 |
+| `position_mean_baseline` | 2.577 | +0.369 | -0.011 | 3.248 | 260 |
+
+### K
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `position_mean_baseline` | 1.390 | +0.282 | -0.050 | 1.793 | 97 |
+| `v28_reliability_weighting` | 1.394 | -0.152 | -0.117 | 1.849 | 97 |
+| `v29_reliability_residual` | 1.396 | -0.170 | -0.114 | 1.847 | 97 |
+| `v22_advanced_receiving` | 1.400 | -0.134 | -0.119 | 1.851 | 97 |
+| `v25_draft_capital_residual` | 1.403 | -0.152 | -0.116 | 1.849 | 97 |
+| `v26_vegas_residual` | 1.403 | -0.152 | -0.116 | 1.849 | 97 |
+| `v20_learned_usage` | 1.413 | -0.046 | -0.144 | 1.872 | 97 |
+| `v12_no_qb_trajectory` | 1.423 | -0.024 | -0.174 | 1.896 | 97 |
+| `v14_qb_starter` | 1.423 | -0.024 | -0.174 | 1.896 | 97 |
+| `v17_rookie_growth` | 1.423 | -0.024 | -0.174 | 1.896 | 97 |
+| `v19_usage_level_full` | 1.423 | -0.024 | -0.174 | 1.896 | 97 |
+| `v27_vegas_full_refit` | 1.431 | +0.095 | -0.141 | 1.869 | 97 |
+| `v16_snap_trend_full` | 1.432 | +0.013 | -0.190 | 1.909 | 97 |
+| `v30_reliability_full_refit` | 1.432 | +0.097 | -0.140 | 1.868 | 97 |
+| `v31_depth_chart` | 1.435 | +0.337 | -0.143 | 1.871 | 97 |
+| `v23_draft_capital` | 1.439 | +0.132 | -0.152 | 1.878 | 97 |
+| `v8_age_regression` | 1.471 | -0.070 | -0.283 | 1.982 | 97 |
+| `v9_pos_specific` | 1.471 | -0.070 | -0.283 | 1.982 | 97 |
+| `v10_stat_efficiency_v2` | 1.471 | -0.070 | -0.283 | 1.982 | 97 |
+| `v11_team_context_v2` | 1.471 | -0.070 | -0.283 | 1.982 | 97 |
+| `v13_qb_starter` | 1.471 | -0.070 | -0.283 | 1.982 | 97 |
+| `v21_tiered_regression` | 1.471 | +0.077 | -0.281 | 1.980 | 97 |
+| `v2_age_adjusted` | 1.525 | -0.108 | -0.390 | 2.063 | 97 |
+| `v3_stat_weighted` | 1.525 | -0.108 | -0.390 | 2.063 | 97 |
+| `v18_usage_level` | 1.525 | -0.108 | -0.390 | 2.063 | 97 |
+| `v15_snap_trend` | 1.533 | -0.071 | -0.405 | 2.074 | 97 |
+| `v1_baseline_weighted_ppg` | 1.534 | -0.036 | -0.408 | 2.077 | 97 |
+| `v7_regression_to_mean` | 1.538 | +0.113 | -0.478 | 2.127 | 97 |
+| `v4_availability_adjusted` | 1.591 | +0.074 | -0.586 | 2.203 | 97 |
+| `v5_team_context` | 1.591 | +0.074 | -0.586 | 2.203 | 97 |
+| `v6_usage_share` | 1.591 | +0.074 | -0.586 | 2.203 | 97 |
+| `naive_prior_season_ppg` | 1.685 | +0.104 | -0.920 | 2.425 | 97 |
+
+## Ranking quality — per-position ordering (GH #598)
+
+_The projections feed VORP, surplus value, auction pricing and keeper calls, which depend on within-position **ordering** and getting the top tier right — not absolute PPG level. **Spearman ρ** is the rank correlation between projected and actual PPG (1.0 = perfect order). **Top-N hit** is the share of each model's predicted top-N (≈ the starter pool: 12 for QB/TE, 24 for RB/WR) that actually finished top-N. A model can win MAE while losing here (#579) — these are the metrics the downstream decisions actually care about._
+
+### QB (top-12)
+
+| Model | Spearman ρ | Top-N hit | N |
+| --- | --- | --- | --- |
+| `external_fantasypros_v1` | **0.812** | 0.583 | 122 |
+| `v26_vegas_residual` | 0.677 | 0.417 | 152 |
+| `v25_draft_capital_residual` | 0.674 | 0.417 | 152 |
+| `v31_depth_chart` | 0.674 | 0.417 | 152 |
+| `v22_advanced_receiving` | 0.672 | 0.417 | 152 |
+| `v28_reliability_weighting` | 0.671 | 0.417 | 152 |
+| `v29_reliability_residual` | 0.669 | 0.417 | 152 |
+| `v20_learned_usage` | 0.668 | 0.417 | 152 |
+| `v23_draft_capital` | 0.665 | 0.417 | 152 |
+| `v30_reliability_full_refit` | 0.665 | 0.417 | 152 |
+| `v27_vegas_full_refit` | 0.664 | 0.417 | 152 |
+| `v14_qb_starter` | 0.659 | 0.417 | 157 |
+| `v17_rookie_growth` | 0.659 | 0.417 | 157 |
+| `v19_usage_level_full` | 0.659 | 0.417 | 157 |
+| `v16_snap_trend_full` | 0.658 | 0.500 | 157 |
+| `v21_tiered_regression` | 0.657 | 0.417 | 157 |
+| `v1_baseline_weighted_ppg` | 0.651 | 0.333 | 157 |
+| `v2_age_adjusted` | 0.648 | 0.417 | 157 |
+| `v18_usage_level` | 0.648 | 0.417 | 157 |
+| `v3_stat_weighted` | 0.646 | 0.417 | 157 |
+| `v8_age_regression` | 0.646 | 0.417 | 157 |
+| `v9_pos_specific` | 0.646 | 0.417 | 157 |
+| `v5_team_context` | 0.646 | 0.417 | 157 |
+| `v4_availability_adjusted` | 0.646 | 0.417 | 157 |
+| `v10_stat_efficiency_v2` | 0.645 | 0.417 | 157 |
+| `v6_usage_share` | 0.645 | 0.417 | 157 |
+| `v7_regression_to_mean` | 0.641 | 0.417 | 157 |
+| `v15_snap_trend` | 0.641 | 0.417 | 157 |
+| `v13_qb_starter` | 0.641 | 0.417 | 157 |
+| `v11_team_context_v2` | 0.639 | 0.417 | 157 |
+| `v12_no_qb_trajectory` | 0.637 | 0.417 | 157 |
+| `naive_prior_season_ppg` | 0.578 | 0.500 | 157 |
+| `position_mean_baseline` | -0.022 | 0.000 | 157 |
+
+### RB (top-24)
+
+| Model | Spearman ρ | Top-N hit | N |
+| --- | --- | --- | --- |
+| `external_fantasypros_v1` | **0.833** | 0.583 | 139 |
+| `v4_availability_adjusted` | 0.807 | 0.333 | 302 |
+| `v3_stat_weighted` | 0.806 | 0.458 | 302 |
+| `v15_snap_trend` | 0.806 | 0.375 | 302 |
+| `v18_usage_level` | 0.805 | 0.417 | 302 |
+| `v16_snap_trend_full` | 0.805 | 0.417 | 302 |
+| `v19_usage_level_full` | 0.805 | 0.417 | 302 |
+| `v2_age_adjusted` | 0.804 | 0.458 | 302 |
+| `v10_stat_efficiency_v2` | 0.804 | 0.417 | 302 |
+| `v8_age_regression` | 0.804 | 0.458 | 302 |
+| `v9_pos_specific` | 0.804 | 0.458 | 302 |
+| `v12_no_qb_trajectory` | 0.804 | 0.458 | 302 |
+| `v13_qb_starter` | 0.804 | 0.458 | 302 |
+| `v14_qb_starter` | 0.804 | 0.458 | 302 |
+| `v1_baseline_weighted_ppg` | 0.803 | 0.458 | 302 |
+| `naive_prior_season_ppg` | 0.802 | 0.458 | 305 |
+| `v6_usage_share` | 0.801 | 0.417 | 302 |
+| `v5_team_context` | 0.801 | 0.375 | 302 |
+| `v7_regression_to_mean` | 0.798 | 0.333 | 302 |
+| `v11_team_context_v2` | 0.797 | 0.458 | 302 |
+| `v21_tiered_regression` | 0.796 | 0.458 | 302 |
+| `v17_rookie_growth` | 0.795 | 0.458 | 302 |
+| `v26_vegas_residual` | 0.790 | 0.500 | 287 |
+| `v25_draft_capital_residual` | 0.789 | 0.500 | 287 |
+| `v31_depth_chart` | 0.787 | 0.417 | 287 |
+| `v29_reliability_residual` | 0.787 | 0.542 | 287 |
+| `v27_vegas_full_refit` | 0.786 | 0.458 | 287 |
+| `v23_draft_capital` | 0.785 | 0.458 | 287 |
+| `v22_advanced_receiving` | 0.784 | 0.500 | 287 |
+| `v30_reliability_full_refit` | 0.783 | 0.500 | 287 |
+| `v20_learned_usage` | 0.783 | 0.500 | 287 |
+| `v28_reliability_weighting` | 0.782 | 0.500 | 287 |
+| `position_mean_baseline` | 0.014 | 0.167 | 305 |
+
+### WR (top-24)
+
+| Model | Spearman ρ | Top-N hit | N |
+| --- | --- | --- | --- |
+| `external_fantasypros_v1` | **0.813** | 0.542 | 187 |
+| `v4_availability_adjusted` | 0.794 | 0.458 | 450 |
+| `v15_snap_trend` | 0.792 | 0.458 | 450 |
+| `v6_usage_share` | 0.791 | 0.458 | 450 |
+| `v5_team_context` | 0.790 | 0.417 | 450 |
+| `v18_usage_level` | 0.790 | 0.458 | 450 |
+| `v2_age_adjusted` | 0.790 | 0.458 | 450 |
+| `v7_regression_to_mean` | 0.790 | 0.417 | 450 |
+| `v16_snap_trend_full` | 0.789 | 0.458 | 450 |
+| `v3_stat_weighted` | 0.789 | 0.458 | 450 |
+| `v19_usage_level_full` | 0.789 | 0.458 | 450 |
+| `v8_age_regression` | 0.788 | 0.458 | 450 |
+| `v9_pos_specific` | 0.788 | 0.458 | 450 |
+| `v12_no_qb_trajectory` | 0.788 | 0.458 | 450 |
+| `v13_qb_starter` | 0.788 | 0.458 | 450 |
+| `v14_qb_starter` | 0.788 | 0.458 | 450 |
+| `v10_stat_efficiency_v2` | 0.788 | 0.458 | 450 |
+| `v1_baseline_weighted_ppg` | 0.787 | 0.375 | 450 |
+| `v17_rookie_growth` | 0.787 | 0.458 | 450 |
+| `v21_tiered_regression` | 0.786 | 0.458 | 450 |
+| `v11_team_context_v2` | 0.783 | 0.458 | 450 |
+| `v29_reliability_residual` | 0.783 | 0.417 | 431 |
+| `naive_prior_season_ppg` | 0.781 | 0.500 | 457 |
+| `v31_depth_chart` | 0.779 | 0.333 | 431 |
+| `v25_draft_capital_residual` | 0.778 | 0.375 | 431 |
+| `v23_draft_capital` | 0.778 | 0.250 | 431 |
+| `v26_vegas_residual` | 0.775 | 0.417 | 431 |
+| `v30_reliability_full_refit` | 0.775 | 0.375 | 431 |
+| `v27_vegas_full_refit` | 0.775 | 0.375 | 431 |
+| `v28_reliability_weighting` | 0.770 | 0.333 | 431 |
+| `v22_advanced_receiving` | 0.765 | 0.333 | 431 |
+| `v20_learned_usage` | 0.763 | 0.333 | 431 |
+| `position_mean_baseline` | -0.006 | 0.042 | 457 |
+
+### TE (top-12)
+
+| Model | Spearman ρ | Top-N hit | N |
+| --- | --- | --- | --- |
+| `external_fantasypros_v1` | **0.822** | 0.583 | 151 |
+| `v31_depth_chart` | 0.760 | 0.583 | 249 |
+| `v23_draft_capital` | 0.757 | 0.583 | 249 |
+| `v27_vegas_full_refit` | 0.753 | 0.583 | 249 |
+| `v30_reliability_full_refit` | 0.753 | 0.583 | 249 |
+| `v25_draft_capital_residual` | 0.750 | 0.583 | 249 |
+| `v29_reliability_residual` | 0.750 | 0.583 | 249 |
+| `v1_baseline_weighted_ppg` | 0.746 | 0.500 | 255 |
+| `v28_reliability_weighting` | 0.746 | 0.583 | 249 |
+| `v20_learned_usage` | 0.745 | 0.500 | 249 |
+| `v26_vegas_residual` | 0.744 | 0.583 | 249 |
+| `v22_advanced_receiving` | 0.744 | 0.583 | 249 |
+| `v7_regression_to_mean` | 0.743 | 0.583 | 255 |
+| `v6_usage_share` | 0.742 | 0.583 | 255 |
+| `v5_team_context` | 0.741 | 0.583 | 255 |
+| `v3_stat_weighted` | 0.739 | 0.583 | 255 |
+| `v4_availability_adjusted` | 0.738 | 0.583 | 255 |
+| `naive_prior_season_ppg` | 0.738 | 0.500 | 260 |
+| `v18_usage_level` | 0.738 | 0.667 | 255 |
+| `v2_age_adjusted` | 0.737 | 0.500 | 255 |
+| `v10_stat_efficiency_v2` | 0.737 | 0.583 | 255 |
+| `v19_usage_level_full` | 0.736 | 0.667 | 255 |
+| `v17_rookie_growth` | 0.736 | 0.583 | 255 |
+| `v8_age_regression` | 0.735 | 0.583 | 255 |
+| `v9_pos_specific` | 0.735 | 0.583 | 255 |
+| `v12_no_qb_trajectory` | 0.735 | 0.583 | 255 |
+| `v13_qb_starter` | 0.735 | 0.583 | 255 |
+| `v14_qb_starter` | 0.735 | 0.583 | 255 |
+| `v11_team_context_v2` | 0.734 | 0.583 | 255 |
+| `v15_snap_trend` | 0.732 | 0.667 | 255 |
+| `v16_snap_trend_full` | 0.731 | 0.583 | 255 |
+| `v21_tiered_regression` | 0.730 | 0.583 | 255 |
+| `position_mean_baseline` | 0.098 | 0.000 | 260 |
+
+## Season 2023 — ALL (held-out) — fold (train 2021,2022)
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `external_fantasypros_v1` | 2.057 | +1.320 | 0.731 | 2.919 | 154 |
+| `v31_depth_chart` | 2.210 | -0.288 | 0.650 | 3.026 | 406 |
+| `v28_reliability_weighting` | 2.287 | -0.177 | 0.618 | 3.165 | 406 |
+| `v30_reliability_full_refit` | 2.294 | -0.261 | 0.622 | 3.146 | 406 |
+| `v27_vegas_full_refit` | 2.297 | -0.214 | 0.622 | 3.150 | 406 |
+| `v29_reliability_residual` | 2.308 | -0.363 | 0.616 | 3.174 | 406 |
+| `v22_advanced_receiving` | 2.320 | -0.178 | 0.611 | 3.192 | 406 |
+| `v23_draft_capital` | 2.336 | -0.253 | 0.619 | 3.162 | 406 |
+| `v4_availability_adjusted` | 2.339 | -0.204 | 0.569 | 3.394 | 419 |
+| `v26_vegas_residual` | 2.350 | -0.431 | 0.605 | 3.217 | 406 |
+| `v20_learned_usage` | 2.352 | -0.177 | 0.604 | 3.220 | 406 |
+| `v25_draft_capital_residual` | 2.353 | -0.397 | 0.608 | 3.205 | 406 |
+| `v7_regression_to_mean` | 2.360 | -0.169 | 0.578 | 3.359 | 419 |
+| `v10_stat_efficiency_v2` | 2.362 | -0.519 | 0.587 | 3.323 | 419 |
+| `v16_snap_trend_full` | 2.364 | -0.493 | 0.581 | 3.348 | 419 |
+| `v8_age_regression` | 2.366 | -0.521 | 0.585 | 3.330 | 419 |
+| `v9_pos_specific` | 2.366 | -0.521 | 0.585 | 3.330 | 419 |
+| `v13_qb_starter` | 2.367 | -0.515 | 0.586 | 3.326 | 419 |
+| `v14_qb_starter` | 2.371 | -0.463 | 0.585 | 3.333 | 419 |
+| `v5_team_context` | 2.371 | -0.214 | 0.558 | 3.437 | 419 |
+| `v12_no_qb_trajectory` | 2.377 | -0.508 | 0.582 | 3.345 | 419 |
+| `v17_rookie_growth` | 2.382 | -0.512 | 0.580 | 3.349 | 419 |
+| `v11_team_context_v2` | 2.396 | -0.522 | 0.573 | 3.378 | 419 |
+| `v19_usage_level_full` | 2.397 | -0.592 | 0.576 | 3.369 | 419 |
+| `v2_age_adjusted` | 2.416 | -0.696 | 0.555 | 3.448 | 419 |
+| `v1_baseline_weighted_ppg` | 2.418 | -0.783 | 0.561 | 3.425 | 419 |
+| `v3_stat_weighted` | 2.420 | -0.695 | 0.554 | 3.451 | 419 |
+| `v6_usage_share` | 2.431 | -0.341 | 0.543 | 3.494 | 419 |
+| `v15_snap_trend` | 2.433 | -0.726 | 0.548 | 3.475 | 419 |
+| `naive_prior_season_ppg` | 2.447 | -0.466 | 0.538 | 3.516 | 421 |
+| `v18_usage_level` | 2.476 | -0.825 | 0.538 | 3.513 | 419 |
+| `v21_tiered_regression` | 2.493 | -0.459 | 0.523 | 3.569 | 419 |
+| `position_mean_baseline` | 3.623 | +0.646 | 0.196 | 4.640 | 421 |
+
+## Season 2024 — ALL (held-out) — fold (train 2021,2022,2023)
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v31_depth_chart` | 2.265 | +0.064 | 0.668 | 2.975 | 427 |
+| `v19_usage_level_full` | 2.299 | -0.228 | 0.661 | 3.043 | 443 |
+| `v14_qb_starter` | 2.301 | -0.122 | 0.661 | 3.042 | 443 |
+| `v12_no_qb_trajectory` | 2.303 | -0.161 | 0.654 | 3.072 | 443 |
+| `v16_snap_trend_full` | 2.309 | -0.140 | 0.655 | 3.068 | 443 |
+| `v17_rookie_growth` | 2.314 | -0.157 | 0.659 | 3.049 | 443 |
+| `v13_qb_starter` | 2.314 | -0.175 | 0.647 | 3.102 | 443 |
+| `v8_age_regression` | 2.316 | -0.171 | 0.646 | 3.106 | 443 |
+| `v9_pos_specific` | 2.316 | -0.171 | 0.646 | 3.106 | 443 |
+| `v10_stat_efficiency_v2` | 2.320 | -0.162 | 0.647 | 3.103 | 443 |
+| `v11_team_context_v2` | 2.333 | -0.189 | 0.642 | 3.123 | 443 |
+| `v2_age_adjusted` | 2.342 | -0.333 | 0.634 | 3.161 | 443 |
+| `v4_availability_adjusted` | 2.343 | +0.086 | 0.632 | 3.170 | 443 |
+| `v3_stat_weighted` | 2.345 | -0.333 | 0.634 | 3.160 | 443 |
+| `v20_learned_usage` | 2.350 | +0.162 | 0.645 | 3.075 | 427 |
+| `v25_draft_capital_residual` | 2.350 | -0.046 | 0.648 | 3.062 | 427 |
+| `v23_draft_capital` | 2.354 | +0.048 | 0.643 | 3.082 | 427 |
+| `v1_baseline_weighted_ppg` | 2.356 | -0.486 | 0.620 | 3.221 | 443 |
+| `v27_vegas_full_refit` | 2.361 | +0.066 | 0.645 | 3.076 | 427 |
+| `v26_vegas_residual` | 2.362 | -0.059 | 0.648 | 3.062 | 427 |
+| `v7_regression_to_mean` | 2.364 | +0.102 | 0.629 | 3.180 | 443 |
+| `v29_reliability_residual` | 2.364 | -0.044 | 0.644 | 3.078 | 427 |
+| `v22_advanced_receiving` | 2.366 | +0.128 | 0.640 | 3.098 | 427 |
+| `v18_usage_level` | 2.366 | -0.439 | 0.626 | 3.193 | 443 |
+| `v5_team_context` | 2.367 | +0.058 | 0.622 | 3.213 | 443 |
+| `v6_usage_share` | 2.368 | -0.033 | 0.622 | 3.210 | 443 |
+| `v15_snap_trend` | 2.371 | -0.352 | 0.626 | 3.193 | 443 |
+| `v30_reliability_full_refit` | 2.372 | +0.068 | 0.641 | 3.092 | 427 |
+| `v28_reliability_weighting` | 2.379 | +0.131 | 0.636 | 3.113 | 427 |
+| `v21_tiered_regression` | 2.387 | -0.064 | 0.626 | 3.196 | 443 |
+| `naive_prior_season_ppg` | 2.441 | -0.127 | 0.556 | 3.490 | 450 |
+| `external_fantasypros_v1` | 2.597 | +1.367 | 0.620 | 3.443 | 200 |
+| `position_mean_baseline` | 3.698 | +0.787 | 0.173 | 4.760 | 450 |
+
+## Season 2025 — ALL (held-out) — fold (train 2021,2022,2023,2024)
+
+| Model | MAE | Bias | R² | RMSE | N |
+| --- | --- | --- | --- | --- | --- |
+| `v31_depth_chart` | 2.218 | -0.276 | 0.685 | 2.946 | 383 |
+| `v30_reliability_full_refit` | 2.224 | -0.356 | 0.683 | 2.954 | 383 |
+| `v27_vegas_full_refit` | 2.231 | -0.353 | 0.682 | 2.960 | 383 |
+| `v26_vegas_residual` | 2.234 | -0.432 | 0.685 | 2.942 | 383 |
+| `v29_reliability_residual` | 2.240 | -0.426 | 0.684 | 2.947 | 383 |
+| `v25_draft_capital_residual` | 2.248 | -0.420 | 0.683 | 2.954 | 383 |
+| `v28_reliability_weighting` | 2.249 | -0.239 | 0.677 | 2.982 | 383 |
+| `v23_draft_capital` | 2.249 | -0.362 | 0.677 | 2.980 | 383 |
+| `v20_learned_usage` | 2.255 | -0.212 | 0.673 | 3.001 | 383 |
+| `v22_advanced_receiving` | 2.255 | -0.235 | 0.675 | 2.989 | 383 |
+| `external_fantasypros_v1` | 2.283 | +0.632 | 0.680 | 3.228 | 245 |
+| `v14_qb_starter` | 2.293 | -0.451 | 0.661 | 3.090 | 399 |
+| `v7_regression_to_mean` | 2.297 | -0.206 | 0.650 | 3.140 | 399 |
+| `v21_tiered_regression` | 2.300 | -0.446 | 0.645 | 3.162 | 399 |
+| `v16_snap_trend_full` | 2.301 | -0.484 | 0.657 | 3.107 | 399 |
+| `v19_usage_level_full` | 2.302 | -0.556 | 0.660 | 3.092 | 399 |
+| `v17_rookie_growth` | 2.326 | -0.490 | 0.658 | 3.103 | 399 |
+| `v4_availability_adjusted` | 2.326 | -0.304 | 0.629 | 3.231 | 399 |
+| `v12_no_qb_trajectory` | 2.327 | -0.505 | 0.635 | 3.205 | 399 |
+| `v5_team_context` | 2.330 | -0.318 | 0.627 | 3.241 | 399 |
+| `v10_stat_efficiency_v2` | 2.332 | -0.528 | 0.633 | 3.215 | 399 |
+| `v8_age_regression` | 2.334 | -0.539 | 0.632 | 3.218 | 399 |
+| `v9_pos_specific` | 2.334 | -0.539 | 0.632 | 3.218 | 399 |
+| `v13_qb_starter` | 2.341 | -0.532 | 0.629 | 3.233 | 399 |
+| `v11_team_context_v2` | 2.342 | -0.550 | 0.630 | 3.228 | 399 |
+| `v6_usage_share` | 2.348 | -0.425 | 0.622 | 3.262 | 399 |
+| `v3_stat_weighted` | 2.366 | -0.748 | 0.611 | 3.311 | 399 |
+| `v2_age_adjusted` | 2.376 | -0.754 | 0.609 | 3.320 | 399 |
+| `v15_snap_trend` | 2.385 | -0.787 | 0.603 | 3.343 | 399 |
+| `v18_usage_level` | 2.410 | -0.860 | 0.600 | 3.356 | 399 |
+| `v1_baseline_weighted_ppg` | 2.524 | -1.012 | 0.570 | 3.480 | 399 |
+| `naive_prior_season_ppg` | 2.615 | -0.785 | 0.521 | 3.677 | 405 |
+| `position_mean_baseline` | 3.757 | +0.691 | 0.169 | 4.842 | 405 |

--- a/docs/generated/projection-holdout-eval.md
+++ b/docs/generated/projection-holdout-eval.md
@@ -1,6 +1,6 @@
 # Projection Held-Out Evaluation (GH #572)
 
-_Generated: 2026-06-10 11:13_
+_Generated: 2026-06-10 14:10_
 
 **Every model is evaluated out-of-sample on a shared held-out window.** Learned/residual models were retrained on **2021,2022,2023** and never saw the eval seasons **2024,2025**; additive and external models are parameter-free w.r.t. training seasons, so their existing projections are already held-out. All models are scored through the identical `backtest_model` filter (target-season games ≥ 4, true rookies excluded). Unlike [projection-accuracy.md](projection-accuracy.md), **no model here is scored on data it trained on** — this is the honest ranking. See [docs/exec-plans/projection-methodology-audit.md](../exec-plans/projection-methodology-audit.md) (Finding 1b).
 
@@ -10,39 +10,39 @@ _**MAE** is the pooled-over-players ALL error. **Bal MAE** is the position-balan
 
 | Rank | Model | MAE | Bal MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | `v14_qb_starter` | **2.450** | 2.653 | -0.149 | 0.626 | 3.251 | 647 |
-| 2 | `v19_usage_level_full` | 2.456 | 2.659 | -0.280 | 0.627 | 3.249 | 647 |
-| 3 | `external_fantasypros_v1` | 2.462 | **2.544** | +0.990 | 0.645 | 3.360 | 430 |
-| 4 | `v16_snap_trend_full` | 2.467 | 2.681 | -0.183 | 0.620 | 3.278 | 647 |
-| 5 | `v12_no_qb_trajectory` | 2.471 | 2.687 | -0.207 | 0.606 | 3.339 | 647 |
-| 6 | `v10_stat_efficiency_v2` | 2.484 | 2.697 | -0.231 | 0.600 | 3.364 | 647 |
-| 7 | `v13_qb_starter` | 2.484 | 2.697 | -0.233 | 0.598 | 3.374 | 647 |
-| 8 | `v8_age_regression` | 2.485 | 2.697 | -0.235 | 0.599 | 3.369 | 647 |
-| 9 | `v9_pos_specific` | 2.485 | 2.697 | -0.235 | 0.599 | 3.369 | 647 |
-| 10 | `v11_team_context_v2` | 2.490 | 2.703 | -0.258 | 0.595 | 3.386 | 647 |
-| 11 | `v17_rookie_growth` | 2.495 | 2.698 | -0.208 | 0.619 | 3.283 | 647 |
-| 12 | `v21_tiered_regression` | 2.498 | 2.702 | +0.021 | 0.601 | 3.361 | 647 |
-| 13 | `v3_stat_weighted` | 2.528 | 2.741 | -0.375 | 0.580 | 3.448 | 647 |
-| 14 | `v7_regression_to_mean` | 2.529 | 2.737 | +0.018 | 0.595 | 3.385 | 647 |
-| 15 | `v2_age_adjusted` | 2.531 | 2.744 | -0.389 | 0.578 | 3.454 | 647 |
-| 16 | `v15_snap_trend` | 2.560 | 2.783 | -0.423 | 0.570 | 3.488 | 647 |
-| 17 | `v18_usage_level` | 2.563 | 2.774 | -0.520 | 0.571 | 3.484 | 647 |
-| 18 | `v4_availability_adjusted` | 2.565 | 2.772 | +0.015 | 0.575 | 3.466 | 647 |
-| 19 | `v5_team_context` | 2.566 | 2.775 | -0.006 | 0.572 | 3.479 | 647 |
-| 20 | `v6_usage_share` | 2.583 | 2.791 | -0.137 | 0.568 | 3.495 | 647 |
-| 21 | `v1_baseline_weighted_ppg` | 2.632 | 2.853 | -0.652 | 0.545 | 3.588 | 647 |
-| 22 | `v31_depth_chart` | 2.646 | 2.839 | -1.067 | 0.586 | 3.385 | 635 |
-| 23 | `v20_learned_usage` | 2.683 | 2.866 | -1.060 | 0.588 | 3.377 | 635 |
-| 24 | `v30_reliability_full_refit` | 2.687 | 2.889 | -1.201 | 0.579 | 3.415 | 635 |
-| 25 | `v27_vegas_full_refit` | 2.707 | 2.908 | -1.066 | 0.574 | 3.435 | 635 |
-| 26 | `v28_reliability_weighting` | 2.713 | 2.885 | -1.049 | 0.581 | 3.408 | 635 |
-| 27 | `v22_advanced_receiving` | 2.714 | 2.884 | -1.044 | 0.581 | 3.408 | 635 |
-| 28 | `v26_vegas_residual` | 2.716 | 2.889 | -1.198 | 0.577 | 3.422 | 635 |
-| 29 | `v29_reliability_residual` | 2.738 | 2.917 | -1.175 | 0.573 | 3.437 | 635 |
-| 30 | `naive_prior_season_ppg` | 2.754 | 3.020 | -0.428 | 0.482 | 3.861 | 667 |
-| 31 | `v23_draft_capital` | 2.764 | 2.970 | -1.105 | 0.561 | 3.486 | 635 |
-| 32 | `v25_draft_capital_residual` | 2.764 | 2.943 | -1.200 | 0.568 | 3.457 | 635 |
-| 33 | `position_mean_baseline` | 3.710 | 4.070 | +0.458 | 0.218 | 4.745 | 667 |
+| 1 | `v31_depth_chart` | **2.269** | **2.472** | -0.107 | 0.667 | 3.002 | 810 |
+| 2 | `v26_vegas_residual` | 2.295 | 2.511 | -0.255 | 0.665 | 3.009 | 810 |
+| 3 | `v14_qb_starter` | 2.297 | 2.515 | -0.278 | 0.661 | 3.065 | 842 |
+| 4 | `v19_usage_level_full` | 2.300 | 2.518 | -0.383 | 0.661 | 3.067 | 842 |
+| 5 | `v16_snap_trend_full` | 2.305 | 2.533 | -0.303 | 0.656 | 3.086 | 842 |
+| 6 | `v25_draft_capital_residual` | 2.311 | 2.526 | -0.242 | 0.665 | 3.011 | 810 |
+| 7 | `v12_no_qb_trajectory` | 2.314 | 2.549 | -0.324 | 0.645 | 3.136 | 842 |
+| 8 | `v17_rookie_growth` | 2.320 | 2.537 | -0.315 | 0.659 | 3.075 | 842 |
+| 9 | `v29_reliability_residual` | 2.324 | 2.532 | -0.234 | 0.658 | 3.043 | 810 |
+| 10 | `v8_age_regression` | 2.325 | 2.559 | -0.345 | 0.640 | 3.159 | 842 |
+| 11 | `v9_pos_specific` | 2.325 | 2.559 | -0.345 | 0.640 | 3.159 | 842 |
+| 12 | `v20_learned_usage` | 2.325 | 2.525 | -0.032 | 0.653 | 3.066 | 810 |
+| 13 | `v10_stat_efficiency_v2` | 2.326 | 2.563 | -0.336 | 0.640 | 3.157 | 842 |
+| 14 | `v13_qb_starter` | 2.327 | 2.563 | -0.344 | 0.638 | 3.165 | 842 |
+| 15 | `v23_draft_capital` | 2.328 | 2.546 | -0.154 | 0.652 | 3.070 | 810 |
+| 16 | `v22_advanced_receiving` | 2.330 | 2.532 | -0.035 | 0.656 | 3.051 | 810 |
+| 17 | `v30_reliability_full_refit` | 2.331 | 2.543 | -0.151 | 0.653 | 3.066 | 810 |
+| 18 | `v7_regression_to_mean` | 2.332 | 2.571 | -0.044 | 0.639 | 3.161 | 842 |
+| 19 | `v4_availability_adjusted` | 2.335 | 2.571 | -0.099 | 0.631 | 3.199 | 842 |
+| 20 | `v28_reliability_weighting` | 2.337 | 2.536 | -0.047 | 0.649 | 3.081 | 810 |
+| 21 | `v11_team_context_v2` | 2.338 | 2.572 | -0.360 | 0.637 | 3.173 | 842 |
+| 22 | `v27_vegas_full_refit` | 2.345 | 2.563 | -0.154 | 0.650 | 3.075 | 810 |
+| 23 | `v21_tiered_regression` | 2.346 | 2.571 | -0.245 | 0.635 | 3.180 | 842 |
+| 24 | `v5_team_context` | 2.349 | 2.592 | -0.120 | 0.624 | 3.226 | 842 |
+| 25 | `v3_stat_weighted` | 2.355 | 2.592 | -0.529 | 0.623 | 3.232 | 842 |
+| 26 | `v2_age_adjusted` | 2.358 | 2.595 | -0.533 | 0.622 | 3.237 | 842 |
+| 27 | `v6_usage_share` | 2.358 | 2.595 | -0.219 | 0.622 | 3.235 | 842 |
+| 28 | `v15_snap_trend` | 2.378 | 2.627 | -0.558 | 0.615 | 3.265 | 842 |
+| 29 | `v18_usage_level` | 2.387 | 2.621 | -0.638 | 0.614 | 3.271 | 842 |
+| 30 | `external_fantasypros_v1` | 2.424 | 2.514 | +0.963 | 0.659 | 3.326 | 445 |
+| 31 | `v1_baseline_weighted_ppg` | 2.436 | 2.681 | -0.735 | 0.596 | 3.347 | 842 |
+| 32 | `naive_prior_season_ppg` | 2.523 | 2.829 | -0.439 | 0.539 | 3.580 | 855 |
+| 33 | `position_mean_baseline` | 3.726 | 4.095 | +0.742 | 0.171 | 4.799 | 855 |
 
 ## Combined across eval seasons — by position
 
@@ -50,228 +50,228 @@ _**MAE** is the pooled-over-players ALL error. **Bal MAE** is the position-balan
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `v14_qb_starter` | 2.450 | -0.149 | 0.626 | 3.251 | 647 |
-| `v19_usage_level_full` | 2.456 | -0.280 | 0.627 | 3.249 | 647 |
-| `external_fantasypros_v1` | 2.462 | +0.990 | 0.645 | 3.360 | 430 |
-| `v16_snap_trend_full` | 2.467 | -0.183 | 0.620 | 3.278 | 647 |
-| `v12_no_qb_trajectory` | 2.471 | -0.207 | 0.606 | 3.339 | 647 |
-| `v10_stat_efficiency_v2` | 2.484 | -0.231 | 0.600 | 3.364 | 647 |
-| `v13_qb_starter` | 2.484 | -0.233 | 0.598 | 3.374 | 647 |
-| `v8_age_regression` | 2.485 | -0.235 | 0.599 | 3.369 | 647 |
-| `v9_pos_specific` | 2.485 | -0.235 | 0.599 | 3.369 | 647 |
-| `v11_team_context_v2` | 2.490 | -0.258 | 0.595 | 3.386 | 647 |
-| `v17_rookie_growth` | 2.495 | -0.208 | 0.619 | 3.283 | 647 |
-| `v21_tiered_regression` | 2.498 | +0.021 | 0.601 | 3.361 | 647 |
-| `v3_stat_weighted` | 2.528 | -0.375 | 0.580 | 3.448 | 647 |
-| `v7_regression_to_mean` | 2.529 | +0.018 | 0.595 | 3.385 | 647 |
-| `v2_age_adjusted` | 2.531 | -0.389 | 0.578 | 3.454 | 647 |
-| `v15_snap_trend` | 2.560 | -0.423 | 0.570 | 3.488 | 647 |
-| `v18_usage_level` | 2.563 | -0.520 | 0.571 | 3.484 | 647 |
-| `v4_availability_adjusted` | 2.565 | +0.015 | 0.575 | 3.466 | 647 |
-| `v5_team_context` | 2.566 | -0.006 | 0.572 | 3.479 | 647 |
-| `v6_usage_share` | 2.583 | -0.137 | 0.568 | 3.495 | 647 |
-| `v1_baseline_weighted_ppg` | 2.632 | -0.652 | 0.545 | 3.588 | 647 |
-| `v31_depth_chart` | 2.646 | -1.067 | 0.586 | 3.385 | 635 |
-| `v20_learned_usage` | 2.683 | -1.060 | 0.588 | 3.377 | 635 |
-| `v30_reliability_full_refit` | 2.687 | -1.201 | 0.579 | 3.415 | 635 |
-| `v27_vegas_full_refit` | 2.707 | -1.066 | 0.574 | 3.435 | 635 |
-| `v28_reliability_weighting` | 2.713 | -1.049 | 0.581 | 3.408 | 635 |
-| `v22_advanced_receiving` | 2.714 | -1.044 | 0.581 | 3.408 | 635 |
-| `v26_vegas_residual` | 2.716 | -1.198 | 0.577 | 3.422 | 635 |
-| `v29_reliability_residual` | 2.738 | -1.175 | 0.573 | 3.437 | 635 |
-| `naive_prior_season_ppg` | 2.754 | -0.428 | 0.482 | 3.861 | 667 |
-| `v23_draft_capital` | 2.764 | -1.105 | 0.561 | 3.486 | 635 |
-| `v25_draft_capital_residual` | 2.764 | -1.200 | 0.568 | 3.457 | 635 |
-| `position_mean_baseline` | 3.710 | +0.458 | 0.218 | 4.745 | 667 |
+| `v31_depth_chart` | 2.269 | -0.107 | 0.667 | 3.002 | 810 |
+| `v26_vegas_residual` | 2.295 | -0.255 | 0.665 | 3.009 | 810 |
+| `v14_qb_starter` | 2.297 | -0.278 | 0.661 | 3.065 | 842 |
+| `v19_usage_level_full` | 2.300 | -0.383 | 0.661 | 3.067 | 842 |
+| `v16_snap_trend_full` | 2.305 | -0.303 | 0.656 | 3.086 | 842 |
+| `v25_draft_capital_residual` | 2.311 | -0.242 | 0.665 | 3.011 | 810 |
+| `v12_no_qb_trajectory` | 2.314 | -0.324 | 0.645 | 3.136 | 842 |
+| `v17_rookie_growth` | 2.320 | -0.315 | 0.659 | 3.075 | 842 |
+| `v29_reliability_residual` | 2.324 | -0.234 | 0.658 | 3.043 | 810 |
+| `v8_age_regression` | 2.325 | -0.345 | 0.640 | 3.159 | 842 |
+| `v9_pos_specific` | 2.325 | -0.345 | 0.640 | 3.159 | 842 |
+| `v20_learned_usage` | 2.325 | -0.032 | 0.653 | 3.066 | 810 |
+| `v10_stat_efficiency_v2` | 2.326 | -0.336 | 0.640 | 3.157 | 842 |
+| `v13_qb_starter` | 2.327 | -0.344 | 0.638 | 3.165 | 842 |
+| `v23_draft_capital` | 2.328 | -0.154 | 0.652 | 3.070 | 810 |
+| `v22_advanced_receiving` | 2.330 | -0.035 | 0.656 | 3.051 | 810 |
+| `v30_reliability_full_refit` | 2.331 | -0.151 | 0.653 | 3.066 | 810 |
+| `v7_regression_to_mean` | 2.332 | -0.044 | 0.639 | 3.161 | 842 |
+| `v4_availability_adjusted` | 2.335 | -0.099 | 0.631 | 3.199 | 842 |
+| `v28_reliability_weighting` | 2.337 | -0.047 | 0.649 | 3.081 | 810 |
+| `v11_team_context_v2` | 2.338 | -0.360 | 0.637 | 3.173 | 842 |
+| `v27_vegas_full_refit` | 2.345 | -0.154 | 0.650 | 3.075 | 810 |
+| `v21_tiered_regression` | 2.346 | -0.245 | 0.635 | 3.180 | 842 |
+| `v5_team_context` | 2.349 | -0.120 | 0.624 | 3.226 | 842 |
+| `v3_stat_weighted` | 2.355 | -0.529 | 0.623 | 3.232 | 842 |
+| `v2_age_adjusted` | 2.358 | -0.533 | 0.622 | 3.237 | 842 |
+| `v6_usage_share` | 2.358 | -0.219 | 0.622 | 3.235 | 842 |
+| `v15_snap_trend` | 2.378 | -0.558 | 0.615 | 3.265 | 842 |
+| `v18_usage_level` | 2.387 | -0.638 | 0.614 | 3.271 | 842 |
+| `external_fantasypros_v1` | 2.424 | +0.963 | 0.659 | 3.326 | 445 |
+| `v1_baseline_weighted_ppg` | 2.436 | -0.735 | 0.596 | 3.347 | 842 |
+| `naive_prior_season_ppg` | 2.523 | -0.439 | 0.539 | 3.580 | 855 |
+| `position_mean_baseline` | 3.726 | +0.742 | 0.171 | 4.799 | 855 |
 
 ### QB
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `v22_advanced_receiving` | 3.551 | -0.988 | 0.442 | 4.566 | 98 |
-| `v28_reliability_weighting` | 3.562 | -1.032 | 0.439 | 4.579 | 98 |
-| `v26_vegas_residual` | 3.604 | -1.325 | 0.417 | 4.663 | 98 |
-| `v31_depth_chart` | 3.624 | -1.582 | 0.430 | 4.613 | 98 |
-| `v20_learned_usage` | 3.626 | -1.493 | 0.426 | 4.629 | 98 |
-| `v25_draft_capital_residual` | 3.657 | -1.300 | 0.410 | 4.694 | 98 |
-| `v29_reliability_residual` | 3.667 | -1.355 | 0.405 | 4.712 | 98 |
-| `v30_reliability_full_refit` | 3.673 | -1.577 | 0.387 | 4.783 | 98 |
-| `v27_vegas_full_refit` | 3.676 | -1.080 | 0.396 | 4.748 | 98 |
+| `v28_reliability_weighting` | 3.537 | -0.670 | 0.511 | 4.398 | 102 |
+| `v22_advanced_receiving` | 3.566 | -0.388 | 0.505 | 4.422 | 102 |
+| `v31_depth_chart` | 3.582 | -0.801 | 0.507 | 4.416 | 102 |
+| `v20_learned_usage` | 3.591 | -0.448 | 0.498 | 4.456 | 102 |
+| `v29_reliability_residual` | 3.598 | -0.890 | 0.494 | 4.470 | 102 |
+| `v26_vegas_residual` | 3.603 | -0.676 | 0.492 | 4.482 | 102 |
+| `v30_reliability_full_refit` | 3.633 | -0.799 | 0.484 | 4.514 | 102 |
+| `v25_draft_capital_residual` | 3.633 | -0.663 | 0.488 | 4.498 | 102 |
 | `external_fantasypros_v1` | 3.690 | +2.129 | 0.413 | 5.072 | 88 |
-| `v23_draft_capital` | 3.744 | -1.077 | 0.389 | 4.777 | 98 |
-| `v14_qb_starter` | 3.783 | -0.742 | 0.443 | 4.826 | 102 |
-| `v17_rookie_growth` | 3.783 | -0.742 | 0.443 | 4.826 | 102 |
-| `v19_usage_level_full` | 3.783 | -0.742 | 0.443 | 4.826 | 102 |
-| `v21_tiered_regression` | 3.852 | -0.322 | 0.414 | 4.947 | 102 |
-| `v16_snap_trend_full` | 3.857 | -0.755 | 0.429 | 4.886 | 102 |
-| `v12_no_qb_trajectory` | 3.919 | -1.111 | 0.354 | 5.194 | 102 |
-| `v13_qb_starter` | 3.957 | -1.234 | 0.327 | 5.304 | 102 |
-| `v8_age_regression` | 3.959 | -1.246 | 0.331 | 5.287 | 102 |
-| `v9_pos_specific` | 3.959 | -1.246 | 0.331 | 5.287 | 102 |
-| `v10_stat_efficiency_v2` | 3.976 | -1.232 | 0.332 | 5.282 | 102 |
-| `v11_team_context_v2` | 3.986 | -1.284 | 0.322 | 5.324 | 102 |
-| `v7_regression_to_mean` | 4.017 | +0.185 | 0.364 | 5.155 | 102 |
-| `v2_age_adjusted` | 4.064 | -1.387 | 0.299 | 5.412 | 102 |
-| `v18_usage_level` | 4.064 | -1.387 | 0.299 | 5.412 | 102 |
-| `v3_stat_weighted` | 4.068 | -1.367 | 0.302 | 5.401 | 102 |
-| `v4_availability_adjusted` | 4.085 | +0.079 | 0.329 | 5.297 | 102 |
-| `v5_team_context` | 4.134 | +0.044 | 0.320 | 5.329 | 102 |
-| `v6_usage_share` | 4.134 | +0.044 | 0.320 | 5.329 | 102 |
-| `v15_snap_trend` | 4.158 | -1.400 | 0.281 | 5.481 | 102 |
-| `v1_baseline_weighted_ppg` | 4.218 | -1.808 | 0.263 | 5.548 | 102 |
-| `naive_prior_season_ppg` | 4.851 | -0.904 | 0.050 | 6.300 | 102 |
-| `position_mean_baseline` | 5.184 | -0.755 | -0.013 | 6.506 | 102 |
+| `v23_draft_capital` | 3.710 | -0.761 | 0.475 | 4.554 | 102 |
+| `v27_vegas_full_refit` | 3.713 | -0.540 | 0.472 | 4.567 | 102 |
+| `v14_qb_starter` | 3.774 | -0.666 | 0.461 | 4.839 | 106 |
+| `v17_rookie_growth` | 3.774 | -0.666 | 0.461 | 4.839 | 106 |
+| `v19_usage_level_full` | 3.774 | -0.666 | 0.461 | 4.839 | 106 |
+| `v16_snap_trend_full` | 3.845 | -0.671 | 0.449 | 4.896 | 106 |
+| `v21_tiered_regression` | 3.857 | -0.533 | 0.433 | 4.966 | 106 |
+| `v12_no_qb_trajectory` | 3.910 | -1.034 | 0.381 | 5.188 | 106 |
+| `v8_age_regression` | 3.950 | -1.163 | 0.360 | 5.272 | 106 |
+| `v9_pos_specific` | 3.950 | -1.163 | 0.360 | 5.272 | 106 |
+| `v11_team_context_v2` | 3.962 | -1.201 | 0.357 | 5.285 | 106 |
+| `v13_qb_starter` | 3.967 | -1.153 | 0.354 | 5.298 | 106 |
+| `v10_stat_efficiency_v2` | 3.967 | -1.145 | 0.363 | 5.262 | 106 |
+| `v7_regression_to_mean` | 4.034 | +0.224 | 0.384 | 5.175 | 106 |
+| `v4_availability_adjusted` | 4.049 | -0.026 | 0.357 | 5.285 | 106 |
+| `v2_age_adjusted` | 4.056 | -1.473 | 0.323 | 5.425 | 106 |
+| `v18_usage_level` | 4.056 | -1.473 | 0.323 | 5.425 | 106 |
+| `v3_stat_weighted` | 4.060 | -1.461 | 0.324 | 5.421 | 106 |
+| `v6_usage_share` | 4.089 | -0.065 | 0.353 | 5.302 | 106 |
+| `v5_team_context` | 4.129 | -0.077 | 0.349 | 5.321 | 106 |
+| `v15_snap_trend` | 4.147 | -1.478 | 0.307 | 5.490 | 106 |
+| `v1_baseline_weighted_ppg` | 4.204 | -1.879 | 0.290 | 5.556 | 106 |
+| `naive_prior_season_ppg` | 4.781 | -0.955 | 0.097 | 6.264 | 106 |
+| `position_mean_baseline` | 5.490 | +0.605 | -0.011 | 6.628 | 106 |
 
 ### RB
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `v11_team_context_v2` | 2.686 | -0.005 | 0.616 | 3.479 | 137 |
-| `v10_stat_efficiency_v2` | 2.702 | +0.057 | 0.615 | 3.480 | 137 |
-| `v6_usage_share` | 2.712 | -0.088 | 0.598 | 3.556 | 137 |
-| `v3_stat_weighted` | 2.713 | -0.132 | 0.607 | 3.520 | 137 |
-| `v5_team_context` | 2.716 | +0.150 | 0.597 | 3.562 | 137 |
-| `v8_age_regression` | 2.717 | +0.039 | 0.612 | 3.495 | 137 |
-| `v9_pos_specific` | 2.717 | +0.039 | 0.612 | 3.495 | 137 |
-| `v12_no_qb_trajectory` | 2.717 | +0.039 | 0.612 | 3.495 | 137 |
-| `v13_qb_starter` | 2.717 | +0.039 | 0.612 | 3.495 | 137 |
-| `v14_qb_starter` | 2.717 | +0.039 | 0.612 | 3.495 | 137 |
-| `external_fantasypros_v1` | 2.718 | +1.056 | 0.636 | 3.345 | 100 |
-| `v2_age_adjusted` | 2.719 | -0.175 | 0.605 | 3.526 | 137 |
-| `v19_usage_level_full` | 2.721 | -0.200 | 0.616 | 3.479 | 137 |
-| `v7_regression_to_mean` | 2.725 | +0.126 | 0.606 | 3.523 | 137 |
-| `v4_availability_adjusted` | 2.758 | +0.176 | 0.594 | 3.574 | 137 |
-| `v18_usage_level` | 2.762 | -0.413 | 0.596 | 3.569 | 137 |
-| `v16_snap_trend_full` | 2.769 | -0.068 | 0.601 | 3.543 | 137 |
-| `naive_prior_season_ppg` | 2.777 | -0.454 | 0.543 | 3.857 | 144 |
-| `v15_snap_trend` | 2.778 | -0.281 | 0.589 | 3.596 | 137 |
-| `v21_tiered_regression` | 2.782 | +0.220 | 0.578 | 3.647 | 137 |
-| `v17_rookie_growth` | 2.785 | -0.068 | 0.600 | 3.547 | 137 |
-| `v1_baseline_weighted_ppg` | 2.806 | -0.518 | 0.561 | 3.716 | 137 |
-| `v31_depth_chart` | 2.963 | -0.978 | 0.568 | 3.656 | 135 |
-| `v20_learned_usage` | 3.101 | -1.005 | 0.533 | 3.802 | 135 |
-| `v26_vegas_residual` | 3.184 | -1.226 | 0.519 | 3.857 | 135 |
-| `v30_reliability_full_refit` | 3.191 | -1.350 | 0.517 | 3.867 | 135 |
-| `v22_advanced_receiving` | 3.208 | -1.094 | 0.514 | 3.877 | 135 |
-| `v29_reliability_residual` | 3.210 | -1.210 | 0.515 | 3.873 | 135 |
-| `v25_draft_capital_residual` | 3.211 | -1.217 | 0.515 | 3.874 | 135 |
-| `v28_reliability_weighting` | 3.211 | -1.097 | 0.513 | 3.883 | 135 |
-| `v23_draft_capital` | 3.234 | -1.135 | 0.495 | 3.953 | 135 |
-| `v27_vegas_full_refit` | 3.235 | -1.170 | 0.497 | 3.944 | 135 |
-| `position_mean_baseline` | 4.557 | +0.934 | 0.049 | 5.566 | 144 |
+| `v5_team_context` | 2.279 | +0.024 | 0.675 | 3.150 | 194 |
+| `v6_usage_share` | 2.287 | -0.162 | 0.676 | 3.144 | 194 |
+| `v4_availability_adjusted` | 2.298 | +0.023 | 0.681 | 3.122 | 194 |
+| `v3_stat_weighted` | 2.300 | -0.331 | 0.681 | 3.120 | 194 |
+| `v2_age_adjusted` | 2.312 | -0.346 | 0.678 | 3.136 | 194 |
+| `v19_usage_level_full` | 2.329 | -0.314 | 0.681 | 3.120 | 194 |
+| `v8_age_regression` | 2.330 | -0.137 | 0.679 | 3.130 | 194 |
+| `v9_pos_specific` | 2.330 | -0.137 | 0.679 | 3.130 | 194 |
+| `v12_no_qb_trajectory` | 2.330 | -0.137 | 0.679 | 3.130 | 194 |
+| `v13_qb_starter` | 2.330 | -0.137 | 0.679 | 3.130 | 194 |
+| `v14_qb_starter` | 2.330 | -0.137 | 0.679 | 3.130 | 194 |
+| `v10_stat_efficiency_v2` | 2.332 | -0.108 | 0.679 | 3.132 | 194 |
+| `v7_regression_to_mean` | 2.333 | +0.053 | 0.669 | 3.177 | 194 |
+| `v11_team_context_v2` | 2.342 | -0.151 | 0.678 | 3.136 | 194 |
+| `v16_snap_trend_full` | 2.346 | -0.214 | 0.671 | 3.169 | 194 |
+| `v15_snap_trend` | 2.349 | -0.423 | 0.665 | 3.197 | 194 |
+| `v18_usage_level` | 2.352 | -0.523 | 0.667 | 3.186 | 194 |
+| `v1_baseline_weighted_ppg` | 2.374 | -0.588 | 0.646 | 3.287 | 194 |
+| `naive_prior_season_ppg` | 2.376 | -0.319 | 0.621 | 3.403 | 197 |
+| `v17_rookie_growth` | 2.384 | -0.216 | 0.669 | 3.180 | 194 |
+| `v21_tiered_regression` | 2.426 | -0.046 | 0.642 | 3.304 | 194 |
+| `v31_depth_chart` | 2.472 | +0.239 | 0.638 | 3.282 | 184 |
+| `v20_learned_usage` | 2.559 | +0.084 | 0.620 | 3.363 | 184 |
+| `v25_draft_capital_residual` | 2.577 | -0.058 | 0.632 | 3.312 | 184 |
+| `v26_vegas_residual` | 2.583 | -0.065 | 0.630 | 3.320 | 184 |
+| `v29_reliability_residual` | 2.606 | +0.098 | 0.623 | 3.352 | 184 |
+| `v23_draft_capital` | 2.609 | +0.057 | 0.606 | 3.426 | 184 |
+| `v27_vegas_full_refit` | 2.610 | -0.007 | 0.610 | 3.407 | 184 |
+| `v22_advanced_receiving` | 2.613 | +0.084 | 0.616 | 3.382 | 184 |
+| `v30_reliability_full_refit` | 2.621 | +0.089 | 0.610 | 3.409 | 184 |
+| `external_fantasypros_v1` | 2.649 | +1.044 | 0.656 | 3.292 | 104 |
+| `v28_reliability_weighting` | 2.656 | +0.280 | 0.600 | 3.452 | 184 |
+| `position_mean_baseline` | 4.468 | +1.071 | -0.038 | 5.630 | 197 |
 
 ### WR
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 2.200 | +0.436 | 0.610 | 2.767 | 131 |
-| `v16_snap_trend_full` | 2.348 | -0.214 | 0.581 | 2.997 | 200 |
-| `v8_age_regression` | 2.373 | -0.175 | 0.582 | 2.993 | 200 |
-| `v9_pos_specific` | 2.373 | -0.175 | 0.582 | 2.993 | 200 |
-| `v12_no_qb_trajectory` | 2.373 | -0.175 | 0.582 | 2.993 | 200 |
-| `v13_qb_starter` | 2.373 | -0.175 | 0.582 | 2.993 | 200 |
-| `v14_qb_starter` | 2.373 | -0.175 | 0.582 | 2.993 | 200 |
-| `v10_stat_efficiency_v2` | 2.376 | -0.175 | 0.582 | 2.992 | 200 |
-| `v19_usage_level_full` | 2.380 | -0.379 | 0.581 | 2.996 | 200 |
-| `v11_team_context_v2` | 2.390 | -0.193 | 0.572 | 3.028 | 200 |
-| `v21_tiered_regression` | 2.408 | -0.166 | 0.549 | 3.108 | 200 |
-| `v7_regression_to_mean` | 2.421 | -0.279 | 0.564 | 3.056 | 200 |
-| `v15_snap_trend` | 2.425 | -0.431 | 0.542 | 3.132 | 200 |
-| `v3_stat_weighted` | 2.430 | -0.382 | 0.546 | 3.119 | 200 |
-| `v2_age_adjusted` | 2.435 | -0.392 | 0.543 | 3.127 | 200 |
-| `v4_availability_adjusted` | 2.444 | -0.270 | 0.535 | 3.155 | 200 |
-| `v17_rookie_growth` | 2.450 | -0.267 | 0.566 | 3.050 | 200 |
-| `v5_team_context` | 2.459 | -0.293 | 0.527 | 3.181 | 200 |
-| `v18_usage_level` | 2.488 | -0.596 | 0.528 | 3.180 | 200 |
-| `v6_usage_share` | 2.488 | -0.497 | 0.515 | 3.222 | 200 |
-| `naive_prior_season_ppg` | 2.587 | -0.551 | 0.480 | 3.375 | 207 |
-| `v1_baseline_weighted_ppg` | 2.614 | -0.624 | 0.491 | 3.301 | 200 |
-| `v20_learned_usage` | 2.637 | -0.923 | 0.510 | 3.186 | 196 |
-| `v30_reliability_full_refit` | 2.689 | -1.484 | 0.490 | 3.252 | 196 |
-| `v27_vegas_full_refit` | 2.702 | -1.402 | 0.490 | 3.253 | 196 |
-| `v26_vegas_residual` | 2.752 | -1.621 | 0.470 | 3.314 | 196 |
-| `v28_reliability_weighting` | 2.762 | -1.341 | 0.470 | 3.313 | 196 |
-| `v22_advanced_receiving` | 2.769 | -1.347 | 0.468 | 3.321 | 196 |
-| `v29_reliability_residual` | 2.778 | -1.527 | 0.470 | 3.316 | 196 |
-| `v23_draft_capital` | 2.783 | -1.395 | 0.463 | 3.338 | 196 |
-| `v25_draft_capital_residual` | 2.792 | -1.508 | 0.463 | 3.338 | 196 |
-| `v31_depth_chart` | 2.815 | -1.514 | 0.416 | 3.478 | 196 |
-| `position_mean_baseline` | 3.770 | +0.975 | 0.056 | 4.549 | 207 |
+| `external_fantasypros_v1` | 2.160 | +0.391 | 0.653 | 2.752 | 140 |
+| `v26_vegas_residual` | 2.196 | -0.337 | 0.614 | 2.765 | 286 |
+| `v31_depth_chart` | 2.226 | -0.269 | 0.591 | 2.846 | 286 |
+| `v25_draft_capital_residual` | 2.235 | -0.307 | 0.609 | 2.783 | 286 |
+| `v4_availability_adjusted` | 2.246 | -0.349 | 0.590 | 2.895 | 299 |
+| `v7_regression_to_mean` | 2.251 | -0.317 | 0.606 | 2.839 | 299 |
+| `v16_snap_trend_full` | 2.252 | -0.433 | 0.606 | 2.839 | 299 |
+| `v23_draft_capital` | 2.256 | -0.211 | 0.592 | 2.841 | 286 |
+| `v30_reliability_full_refit` | 2.260 | -0.215 | 0.586 | 2.864 | 286 |
+| `v10_stat_efficiency_v2` | 2.264 | -0.401 | 0.608 | 2.833 | 299 |
+| `v29_reliability_residual` | 2.265 | -0.341 | 0.587 | 2.859 | 286 |
+| `v8_age_regression` | 2.267 | -0.406 | 0.607 | 2.836 | 299 |
+| `v9_pos_specific` | 2.267 | -0.406 | 0.607 | 2.836 | 299 |
+| `v12_no_qb_trajectory` | 2.267 | -0.406 | 0.607 | 2.836 | 299 |
+| `v13_qb_starter` | 2.267 | -0.406 | 0.607 | 2.836 | 299 |
+| `v14_qb_starter` | 2.267 | -0.406 | 0.607 | 2.836 | 299 |
+| `v19_usage_level_full` | 2.272 | -0.551 | 0.604 | 2.847 | 299 |
+| `v5_team_context` | 2.274 | -0.383 | 0.577 | 2.944 | 299 |
+| `v27_vegas_full_refit` | 2.276 | -0.241 | 0.589 | 2.853 | 286 |
+| `v21_tiered_regression` | 2.284 | -0.514 | 0.577 | 2.942 | 299 |
+| `v11_team_context_v2` | 2.287 | -0.421 | 0.600 | 2.862 | 299 |
+| `v17_rookie_growth` | 2.288 | -0.451 | 0.610 | 2.827 | 299 |
+| `v22_advanced_receiving` | 2.290 | +0.005 | 0.581 | 2.881 | 286 |
+| `v6_usage_share` | 2.295 | -0.512 | 0.570 | 2.966 | 299 |
+| `v28_reliability_weighting` | 2.295 | -0.071 | 0.566 | 2.930 | 286 |
+| `v20_learned_usage` | 2.305 | -0.036 | 0.575 | 2.901 | 286 |
+| `v15_snap_trend` | 2.310 | -0.647 | 0.574 | 2.952 | 299 |
+| `v3_stat_weighted` | 2.314 | -0.620 | 0.575 | 2.950 | 299 |
+| `v2_age_adjusted` | 2.314 | -0.619 | 0.575 | 2.949 | 299 |
+| `v18_usage_level` | 2.360 | -0.765 | 0.559 | 3.006 | 299 |
+| `naive_prior_season_ppg` | 2.427 | -0.607 | 0.512 | 3.167 | 304 |
+| `v1_baseline_weighted_ppg` | 2.434 | -0.775 | 0.539 | 3.073 | 299 |
+| `position_mean_baseline` | 3.739 | +0.918 | -0.041 | 4.626 | 304 |
 
 ### TE
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `external_fantasypros_v1` | 1.568 | +0.683 | 0.618 | 2.057 | 111 |
-| `v10_stat_efficiency_v2` | 1.736 | +0.017 | 0.576 | 2.216 | 144 |
-| `v8_age_regression` | 1.740 | +0.024 | 0.574 | 2.221 | 144 |
-| `v9_pos_specific` | 1.740 | +0.024 | 0.574 | 2.221 | 144 |
-| `v12_no_qb_trajectory` | 1.740 | +0.024 | 0.574 | 2.221 | 144 |
-| `v13_qb_starter` | 1.740 | +0.024 | 0.574 | 2.221 | 144 |
-| `v14_qb_starter` | 1.740 | +0.024 | 0.574 | 2.221 | 144 |
-| `v16_snap_trend_full` | 1.749 | +0.031 | 0.572 | 2.225 | 144 |
-| `v11_team_context_v2` | 1.750 | +0.016 | 0.571 | 2.229 | 144 |
-| `v3_stat_weighted` | 1.753 | -0.063 | 0.565 | 2.245 | 144 |
-| `v19_usage_level_full` | 1.754 | -0.054 | 0.570 | 2.231 | 144 |
-| `v2_age_adjusted` | 1.756 | -0.058 | 0.564 | 2.246 | 144 |
-| `v21_tiered_regression` | 1.765 | +0.242 | 0.555 | 2.269 | 144 |
-| `v15_snap_trend` | 1.770 | -0.050 | 0.564 | 2.246 | 144 |
-| `v1_baseline_weighted_ppg` | 1.773 | -0.326 | 0.541 | 2.304 | 144 |
-| `v17_rookie_growth` | 1.774 | -0.014 | 0.564 | 2.246 | 144 |
-| `v18_usage_level` | 1.784 | -0.136 | 0.550 | 2.283 | 144 |
-| `v7_regression_to_mean` | 1.784 | +0.109 | 0.545 | 2.295 | 144 |
-| `v5_team_context` | 1.793 | +0.104 | 0.538 | 2.312 | 144 |
-| `v4_availability_adjusted` | 1.800 | +0.117 | 0.539 | 2.309 | 144 |
-| `v6_usage_share` | 1.828 | +0.025 | 0.524 | 2.346 | 144 |
-| `naive_prior_season_ppg` | 1.864 | -0.197 | 0.490 | 2.435 | 150 |
-| `v31_depth_chart` | 1.953 | -0.658 | 0.529 | 2.322 | 142 |
-| `v30_reliability_full_refit` | 2.001 | -0.748 | 0.511 | 2.367 | 142 |
-| `v28_reliability_weighting` | 2.006 | -0.701 | 0.493 | 2.410 | 142 |
-| `v22_advanced_receiving` | 2.008 | -0.701 | 0.491 | 2.414 | 142 |
-| `v29_reliability_residual` | 2.013 | -0.758 | 0.494 | 2.408 | 142 |
-| `v26_vegas_residual` | 2.014 | -0.734 | 0.496 | 2.402 | 142 |
-| `v27_vegas_full_refit` | 2.019 | -0.745 | 0.490 | 2.417 | 142 |
-| `v20_learned_usage` | 2.099 | -1.109 | 0.453 | 2.504 | 142 |
-| `v25_draft_capital_residual` | 2.113 | -0.927 | 0.448 | 2.515 | 142 |
-| `v23_draft_capital` | 2.117 | -0.982 | 0.443 | 2.527 | 142 |
-| `position_mean_baseline` | 2.769 | +0.223 | 0.017 | 3.381 | 150 |
+| `external_fantasypros_v1` | 1.558 | +0.688 | 0.622 | 2.046 | 113 |
+| `v31_depth_chart` | 1.607 | -0.001 | 0.616 | 2.051 | 171 |
+| `v23_draft_capital` | 1.610 | -0.065 | 0.595 | 2.105 | 171 |
+| `v20_learned_usage` | 1.645 | +0.032 | 0.571 | 2.168 | 171 |
+| `v27_vegas_full_refit` | 1.652 | -0.141 | 0.589 | 2.121 | 171 |
+| `v28_reliability_weighting` | 1.655 | +0.036 | 0.582 | 2.140 | 171 |
+| `v30_reliability_full_refit` | 1.657 | -0.045 | 0.592 | 2.112 | 171 |
+| `v22_advanced_receiving` | 1.659 | -0.049 | 0.582 | 2.140 | 171 |
+| `v29_reliability_residual` | 1.659 | -0.066 | 0.588 | 2.125 | 171 |
+| `v25_draft_capital_residual` | 1.659 | -0.175 | 0.592 | 2.113 | 171 |
+| `v26_vegas_residual` | 1.662 | -0.174 | 0.581 | 2.142 | 171 |
+| `v7_regression_to_mean` | 1.666 | +0.065 | 0.580 | 2.157 | 176 |
+| `v5_team_context` | 1.684 | +0.035 | 0.574 | 2.172 | 176 |
+| `v10_stat_efficiency_v2` | 1.687 | -0.107 | 0.580 | 2.157 | 176 |
+| `v8_age_regression` | 1.690 | -0.103 | 0.579 | 2.159 | 176 |
+| `v9_pos_specific` | 1.690 | -0.103 | 0.579 | 2.159 | 176 |
+| `v12_no_qb_trajectory` | 1.690 | -0.103 | 0.579 | 2.159 | 176 |
+| `v13_qb_starter` | 1.690 | -0.103 | 0.579 | 2.159 | 176 |
+| `v14_qb_starter` | 1.690 | -0.103 | 0.579 | 2.159 | 176 |
+| `v16_snap_trend_full` | 1.691 | -0.093 | 0.579 | 2.159 | 176 |
+| `v4_availability_adjusted` | 1.691 | +0.050 | 0.569 | 2.184 | 176 |
+| `v3_stat_weighted` | 1.695 | -0.213 | 0.573 | 2.174 | 176 |
+| `v19_usage_level_full` | 1.696 | -0.166 | 0.577 | 2.163 | 176 |
+| `v11_team_context_v2` | 1.697 | -0.110 | 0.576 | 2.167 | 176 |
+| `v2_age_adjusted` | 1.698 | -0.207 | 0.572 | 2.177 | 176 |
+| `v15_snap_trend` | 1.701 | -0.198 | 0.573 | 2.174 | 176 |
+| `v17_rookie_growth` | 1.702 | -0.117 | 0.577 | 2.165 | 176 |
+| `v6_usage_share` | 1.708 | -0.018 | 0.557 | 2.215 | 176 |
+| `v1_baseline_weighted_ppg` | 1.711 | -0.426 | 0.552 | 2.226 | 176 |
+| `v18_usage_level` | 1.716 | -0.271 | 0.560 | 2.208 | 176 |
+| `v21_tiered_regression` | 1.717 | +0.010 | 0.556 | 2.216 | 176 |
+| `naive_prior_season_ppg` | 1.731 | -0.214 | 0.527 | 2.290 | 181 |
+| `position_mean_baseline` | 2.684 | +0.341 | -0.010 | 3.348 | 181 |
 
 ### K
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `position_mean_baseline` | 1.471 | +0.195 | -0.045 | 1.934 | 64 |
-| `v31_depth_chart` | 1.502 | +0.002 | -0.094 | 1.978 | 64 |
-| `v12_no_qb_trajectory` | 1.589 | +0.090 | -0.251 | 2.115 | 64 |
-| `v14_qb_starter` | 1.589 | +0.090 | -0.251 | 2.115 | 64 |
-| `v17_rookie_growth` | 1.589 | +0.090 | -0.251 | 2.115 | 64 |
-| `v19_usage_level_full` | 1.589 | +0.090 | -0.251 | 2.115 | 64 |
-| `v16_snap_trend_full` | 1.598 | +0.101 | -0.253 | 2.117 | 64 |
-| `v30_reliability_full_refit` | 1.625 | -0.454 | -0.208 | 2.079 | 64 |
-| `v23_draft_capital` | 1.644 | -0.467 | -0.230 | 2.097 | 64 |
-| `v27_vegas_full_refit` | 1.651 | -0.509 | -0.230 | 2.097 | 64 |
-| `v21_tiered_regression` | 1.658 | +0.230 | -0.397 | 2.235 | 64 |
-| `v8_age_regression` | 1.662 | +0.019 | -0.393 | 2.232 | 64 |
-| `v9_pos_specific` | 1.662 | +0.019 | -0.393 | 2.232 | 64 |
-| `v10_stat_efficiency_v2` | 1.662 | +0.019 | -0.393 | 2.232 | 64 |
-| `v11_team_context_v2` | 1.662 | +0.019 | -0.393 | 2.232 | 64 |
-| `v13_qb_starter` | 1.662 | +0.019 | -0.393 | 2.232 | 64 |
-| `v1_baseline_weighted_ppg` | 1.727 | +0.079 | -0.541 | 2.348 | 64 |
-| `v2_age_adjusted` | 1.732 | +0.006 | -0.517 | 2.329 | 64 |
-| `v3_stat_weighted` | 1.732 | +0.006 | -0.517 | 2.329 | 64 |
-| `v18_usage_level` | 1.732 | +0.006 | -0.517 | 2.329 | 64 |
-| `v15_snap_trend` | 1.742 | +0.017 | -0.519 | 2.331 | 64 |
-| `v7_regression_to_mean` | 1.753 | +0.243 | -0.636 | 2.419 | 64 |
-| `v28_reliability_weighting` | 1.782 | -0.846 | -0.350 | 2.197 | 64 |
-| `v20_learned_usage` | 1.789 | -0.824 | -0.363 | 2.208 | 64 |
-| `v22_advanced_receiving` | 1.790 | -0.856 | -0.357 | 2.203 | 64 |
-| `v29_reliability_residual` | 1.808 | -0.669 | -0.404 | 2.241 | 64 |
-| `v25_draft_capital_residual` | 1.812 | -0.677 | -0.409 | 2.245 | 64 |
-| `v26_vegas_residual` | 1.812 | -0.677 | -0.409 | 2.245 | 64 |
-| `v4_availability_adjusted` | 1.826 | +0.229 | -0.760 | 2.509 | 64 |
-| `v5_team_context` | 1.826 | +0.229 | -0.760 | 2.509 | 64 |
-| `v6_usage_share` | 1.826 | +0.229 | -0.760 | 2.509 | 64 |
-| `naive_prior_season_ppg` | 1.980 | +0.247 | -1.198 | 2.804 | 64 |
+| `position_mean_baseline` | 1.510 | +0.268 | -0.055 | 1.963 | 67 |
+| `v25_draft_capital_residual` | 1.550 | +0.007 | -0.165 | 2.063 | 67 |
+| `v26_vegas_residual` | 1.550 | +0.007 | -0.165 | 2.063 | 67 |
+| `v29_reliability_residual` | 1.554 | -0.125 | -0.154 | 2.054 | 67 |
+| `v28_reliability_weighting` | 1.555 | -0.102 | -0.159 | 2.058 | 67 |
+| `v22_advanced_receiving` | 1.556 | +0.032 | -0.173 | 2.070 | 67 |
+| `v30_reliability_full_refit` | 1.573 | +0.185 | -0.178 | 2.075 | 67 |
+| `v20_learned_usage` | 1.575 | +0.134 | -0.202 | 2.096 | 67 |
+| `v31_depth_chart` | 1.585 | +0.414 | -0.184 | 2.080 | 67 |
+| `v23_draft_capital` | 1.591 | +0.203 | -0.201 | 2.095 | 67 |
+| `v12_no_qb_trajectory` | 1.595 | +0.042 | -0.227 | 2.118 | 67 |
+| `v14_qb_starter` | 1.595 | +0.042 | -0.227 | 2.118 | 67 |
+| `v17_rookie_growth` | 1.595 | +0.042 | -0.227 | 2.118 | 67 |
+| `v19_usage_level_full` | 1.595 | +0.042 | -0.227 | 2.118 | 67 |
+| `v27_vegas_full_refit` | 1.602 | +0.367 | -0.222 | 2.113 | 67 |
+| `v16_snap_trend_full` | 1.603 | +0.053 | -0.229 | 2.119 | 67 |
+| `v21_tiered_regression` | 1.650 | +0.164 | -0.349 | 2.220 | 67 |
+| `v8_age_regression` | 1.663 | -0.025 | -0.360 | 2.229 | 67 |
+| `v9_pos_specific` | 1.663 | -0.025 | -0.360 | 2.229 | 67 |
+| `v10_stat_efficiency_v2` | 1.663 | -0.025 | -0.360 | 2.229 | 67 |
+| `v11_team_context_v2` | 1.663 | -0.025 | -0.360 | 2.229 | 67 |
+| `v13_qb_starter` | 1.663 | -0.025 | -0.360 | 2.229 | 67 |
+| `v1_baseline_weighted_ppg` | 1.727 | +0.015 | -0.499 | 2.341 | 67 |
+| `v2_age_adjusted` | 1.731 | -0.055 | -0.476 | 2.323 | 67 |
+| `v3_stat_weighted` | 1.731 | -0.055 | -0.476 | 2.323 | 67 |
+| `v18_usage_level` | 1.731 | -0.055 | -0.476 | 2.323 | 67 |
+| `v15_snap_trend` | 1.741 | -0.045 | -0.478 | 2.324 | 67 |
+| `v7_regression_to_mean` | 1.750 | +0.188 | -0.589 | 2.410 | 67 |
+| `v4_availability_adjusted` | 1.821 | +0.158 | -0.704 | 2.495 | 67 |
+| `v5_team_context` | 1.821 | +0.158 | -0.704 | 2.495 | 67 |
+| `v6_usage_share` | 1.821 | +0.158 | -0.704 | 2.495 | 67 |
+| `naive_prior_season_ppg` | 1.960 | +0.184 | -1.116 | 2.781 | 67 |
 
 ## Ranking quality — per-position ordering (GH #598)
 
@@ -282,225 +282,225 @@ _The projections feed VORP, surplus value, auction pricing and keeper calls, whi
 | Model | Spearman ρ | Top-N hit | N |
 | --- | --- | --- | --- |
 | `external_fantasypros_v1` | **0.800** | 0.417 | 88 |
-| `v26_vegas_residual` | 0.726 | 0.333 | 98 |
-| `v31_depth_chart` | 0.721 | 0.333 | 98 |
-| `v20_learned_usage` | 0.720 | 0.417 | 98 |
-| `v25_draft_capital_residual` | 0.719 | 0.250 | 98 |
-| `v30_reliability_full_refit` | 0.717 | 0.333 | 98 |
-| `v22_advanced_receiving` | 0.715 | 0.417 | 98 |
-| `v29_reliability_residual` | 0.714 | 0.250 | 98 |
-| `v28_reliability_weighting` | 0.714 | 0.417 | 98 |
-| `v21_tiered_regression` | 0.712 | 0.333 | 102 |
-| `v16_snap_trend_full` | 0.710 | 0.417 | 102 |
-| `v14_qb_starter` | 0.709 | 0.333 | 102 |
-| `v17_rookie_growth` | 0.709 | 0.333 | 102 |
-| `v19_usage_level_full` | 0.709 | 0.333 | 102 |
-| `v27_vegas_full_refit` | 0.701 | 0.250 | 98 |
-| `v23_draft_capital` | 0.685 | 0.250 | 98 |
-| `v4_availability_adjusted` | 0.680 | 0.417 | 102 |
-| `v5_team_context` | 0.679 | 0.417 | 102 |
-| `v6_usage_share` | 0.679 | 0.417 | 102 |
-| `v7_regression_to_mean` | 0.679 | 0.417 | 102 |
-| `v15_snap_trend` | 0.673 | 0.417 | 102 |
-| `v2_age_adjusted` | 0.671 | 0.417 | 102 |
-| `v18_usage_level` | 0.671 | 0.417 | 102 |
-| `v12_no_qb_trajectory` | 0.670 | 0.333 | 102 |
-| `v3_stat_weighted` | 0.670 | 0.417 | 102 |
-| `v10_stat_efficiency_v2` | 0.669 | 0.417 | 102 |
-| `v8_age_regression` | 0.668 | 0.417 | 102 |
-| `v9_pos_specific` | 0.668 | 0.417 | 102 |
-| `v13_qb_starter` | 0.666 | 0.417 | 102 |
-| `v11_team_context_v2` | 0.662 | 0.417 | 102 |
-| `v1_baseline_weighted_ppg` | 0.660 | 0.417 | 102 |
-| `naive_prior_season_ppg` | 0.593 | 0.333 | 102 |
-| `position_mean_baseline` | 0.007 | 0.250 | 102 |
+| `v26_vegas_residual` | 0.735 | 0.333 | 102 |
+| `v28_reliability_weighting` | 0.735 | 0.417 | 102 |
+| `v29_reliability_residual` | 0.733 | 0.333 | 102 |
+| `v31_depth_chart` | 0.728 | 0.333 | 102 |
+| `v22_advanced_receiving` | 0.728 | 0.417 | 102 |
+| `v25_draft_capital_residual` | 0.726 | 0.333 | 102 |
+| `v20_learned_usage` | 0.723 | 0.417 | 102 |
+| `v16_snap_trend_full` | 0.720 | 0.417 | 106 |
+| `v21_tiered_regression` | 0.718 | 0.333 | 106 |
+| `v14_qb_starter` | 0.718 | 0.333 | 106 |
+| `v17_rookie_growth` | 0.718 | 0.333 | 106 |
+| `v19_usage_level_full` | 0.718 | 0.333 | 106 |
+| `v30_reliability_full_refit` | 0.718 | 0.333 | 102 |
+| `v27_vegas_full_refit` | 0.710 | 0.250 | 102 |
+| `v23_draft_capital` | 0.705 | 0.250 | 102 |
+| `v5_team_context` | 0.689 | 0.417 | 106 |
+| `v4_availability_adjusted` | 0.689 | 0.417 | 106 |
+| `v6_usage_share` | 0.688 | 0.417 | 106 |
+| `v7_regression_to_mean` | 0.685 | 0.417 | 106 |
+| `v3_stat_weighted` | 0.683 | 0.417 | 106 |
+| `v15_snap_trend` | 0.683 | 0.417 | 106 |
+| `v12_no_qb_trajectory` | 0.683 | 0.333 | 106 |
+| `v2_age_adjusted` | 0.682 | 0.417 | 106 |
+| `v18_usage_level` | 0.682 | 0.417 | 106 |
+| `v8_age_regression` | 0.681 | 0.417 | 106 |
+| `v9_pos_specific` | 0.681 | 0.417 | 106 |
+| `v10_stat_efficiency_v2` | 0.680 | 0.417 | 106 |
+| `v11_team_context_v2` | 0.679 | 0.417 | 106 |
+| `v13_qb_starter` | 0.676 | 0.417 | 106 |
+| `v1_baseline_weighted_ppg` | 0.672 | 0.417 | 106 |
+| `naive_prior_season_ppg` | 0.606 | 0.333 | 106 |
+| `position_mean_baseline` | -0.025 | 0.167 | 106 |
 
 ### RB (top-24)
 
 | Model | Spearman ρ | Top-N hit | N |
 | --- | --- | --- | --- |
-| `external_fantasypros_v1` | **0.829** | 0.667 | 100 |
-| `v11_team_context_v2` | 0.790 | 0.625 | 137 |
-| `v18_usage_level` | 0.789 | 0.625 | 137 |
-| `v19_usage_level_full` | 0.788 | 0.667 | 137 |
-| `v31_depth_chart` | 0.788 | 0.583 | 135 |
-| `v7_regression_to_mean` | 0.787 | 0.625 | 137 |
-| `v6_usage_share` | 0.787 | 0.625 | 137 |
-| `naive_prior_season_ppg` | 0.786 | 0.583 | 144 |
-| `v10_stat_efficiency_v2` | 0.785 | 0.583 | 137 |
-| `v16_snap_trend_full` | 0.783 | 0.583 | 137 |
-| `v3_stat_weighted` | 0.783 | 0.583 | 137 |
-| `v15_snap_trend` | 0.782 | 0.625 | 137 |
-| `v8_age_regression` | 0.782 | 0.583 | 137 |
-| `v9_pos_specific` | 0.782 | 0.583 | 137 |
-| `v12_no_qb_trajectory` | 0.782 | 0.583 | 137 |
-| `v13_qb_starter` | 0.782 | 0.583 | 137 |
-| `v14_qb_starter` | 0.782 | 0.583 | 137 |
-| `v5_team_context` | 0.782 | 0.583 | 137 |
-| `v2_age_adjusted` | 0.781 | 0.583 | 137 |
-| `v30_reliability_full_refit` | 0.779 | 0.625 | 135 |
-| `v4_availability_adjusted` | 0.776 | 0.583 | 137 |
-| `v17_rookie_growth` | 0.775 | 0.583 | 137 |
-| `v26_vegas_residual` | 0.775 | 0.667 | 135 |
-| `v1_baseline_weighted_ppg` | 0.770 | 0.667 | 137 |
-| `v21_tiered_regression` | 0.770 | 0.583 | 137 |
-| `v25_draft_capital_residual` | 0.769 | 0.625 | 135 |
-| `v29_reliability_residual` | 0.768 | 0.667 | 135 |
-| `v20_learned_usage` | 0.765 | 0.667 | 135 |
-| `v22_advanced_receiving` | 0.764 | 0.667 | 135 |
-| `v28_reliability_weighting` | 0.763 | 0.667 | 135 |
-| `v27_vegas_full_refit` | 0.756 | 0.542 | 135 |
-| `v23_draft_capital` | 0.748 | 0.542 | 135 |
-| `position_mean_baseline` | 0.300 | 0.375 | 144 |
+| `external_fantasypros_v1` | **0.842** | 0.667 | 104 |
+| `v4_availability_adjusted` | 0.834 | 0.583 | 194 |
+| `v6_usage_share` | 0.833 | 0.625 | 194 |
+| `v5_team_context` | 0.832 | 0.583 | 194 |
+| `v3_stat_weighted` | 0.831 | 0.625 | 194 |
+| `v15_snap_trend` | 0.831 | 0.625 | 194 |
+| `v18_usage_level` | 0.830 | 0.625 | 194 |
+| `v16_snap_trend_full` | 0.830 | 0.625 | 194 |
+| `v19_usage_level_full` | 0.830 | 0.583 | 194 |
+| `v7_regression_to_mean` | 0.830 | 0.583 | 194 |
+| `v2_age_adjusted` | 0.829 | 0.625 | 194 |
+| `v8_age_regression` | 0.829 | 0.625 | 194 |
+| `v9_pos_specific` | 0.829 | 0.625 | 194 |
+| `v12_no_qb_trajectory` | 0.829 | 0.625 | 194 |
+| `v13_qb_starter` | 0.829 | 0.625 | 194 |
+| `v14_qb_starter` | 0.829 | 0.625 | 194 |
+| `v10_stat_efficiency_v2` | 0.829 | 0.583 | 194 |
+| `v11_team_context_v2` | 0.827 | 0.625 | 194 |
+| `naive_prior_season_ppg` | 0.825 | 0.583 | 197 |
+| `v1_baseline_weighted_ppg` | 0.823 | 0.667 | 194 |
+| `v21_tiered_regression` | 0.823 | 0.583 | 194 |
+| `v17_rookie_growth` | 0.819 | 0.625 | 194 |
+| `v25_draft_capital_residual` | 0.807 | 0.667 | 184 |
+| `v29_reliability_residual` | 0.806 | 0.625 | 184 |
+| `v26_vegas_residual` | 0.805 | 0.667 | 184 |
+| `v22_advanced_receiving` | 0.803 | 0.667 | 184 |
+| `v20_learned_usage` | 0.799 | 0.667 | 184 |
+| `v28_reliability_weighting` | 0.798 | 0.667 | 184 |
+| `v27_vegas_full_refit` | 0.797 | 0.542 | 184 |
+| `v30_reliability_full_refit` | 0.796 | 0.583 | 184 |
+| `v23_draft_capital` | 0.795 | 0.542 | 184 |
+| `v31_depth_chart` | 0.782 | 0.542 | 184 |
+| `position_mean_baseline` | 0.012 | 0.208 | 197 |
 
 ### WR (top-24)
 
 | Model | Spearman ρ | Top-N hit | N |
 | --- | --- | --- | --- |
-| `v30_reliability_full_refit` | **0.791** | 0.542 | 196 |
-| `v26_vegas_residual` | 0.783 | 0.542 | 196 |
-| `v27_vegas_full_refit` | 0.781 | 0.500 | 196 |
-| `v19_usage_level_full` | 0.780 | 0.417 | 200 |
-| `v29_reliability_residual` | 0.779 | 0.500 | 196 |
-| `v18_usage_level` | 0.777 | 0.417 | 200 |
-| `v15_snap_trend` | 0.775 | 0.417 | 200 |
-| `v16_snap_trend_full` | 0.775 | 0.458 | 200 |
-| `v3_stat_weighted` | 0.774 | 0.417 | 200 |
-| `v10_stat_efficiency_v2` | 0.774 | 0.417 | 200 |
-| `v8_age_regression` | 0.773 | 0.417 | 200 |
-| `v9_pos_specific` | 0.773 | 0.417 | 200 |
-| `v12_no_qb_trajectory` | 0.773 | 0.417 | 200 |
-| `v13_qb_starter` | 0.773 | 0.417 | 200 |
-| `v14_qb_starter` | 0.773 | 0.417 | 200 |
-| `v2_age_adjusted` | 0.772 | 0.417 | 200 |
-| `v7_regression_to_mean` | 0.769 | 0.417 | 200 |
-| `v6_usage_share` | 0.768 | 0.417 | 200 |
-| `v11_team_context_v2` | 0.768 | 0.417 | 200 |
-| `v25_draft_capital_residual` | 0.766 | 0.458 | 196 |
-| `v21_tiered_regression` | 0.765 | 0.458 | 200 |
-| `naive_prior_season_ppg` | 0.765 | 0.458 | 207 |
-| `v4_availability_adjusted` | 0.763 | 0.417 | 200 |
-| `v5_team_context` | 0.762 | 0.417 | 200 |
-| `v28_reliability_weighting` | 0.762 | 0.500 | 196 |
-| `v17_rookie_growth` | 0.762 | 0.417 | 200 |
-| `v23_draft_capital` | 0.761 | 0.375 | 196 |
-| `v22_advanced_receiving` | 0.760 | 0.500 | 196 |
-| `v1_baseline_weighted_ppg` | 0.756 | 0.500 | 200 |
-| `v31_depth_chart` | 0.751 | 0.500 | 196 |
-| `external_fantasypros_v1` | 0.749 | 0.500 | 131 |
-| `v20_learned_usage` | 0.748 | 0.542 | 196 |
-| `position_mean_baseline` | 0.345 | 0.125 | 207 |
+| `v4_availability_adjusted` | **0.802** | 0.417 | 299 |
+| `v6_usage_share` | **0.802** | 0.417 | 299 |
+| `v7_regression_to_mean` | 0.801 | 0.417 | 299 |
+| `v18_usage_level` | 0.801 | 0.417 | 299 |
+| `v19_usage_level_full` | 0.801 | 0.417 | 299 |
+| `v15_snap_trend` | 0.800 | 0.417 | 299 |
+| `v5_team_context` | 0.800 | 0.417 | 299 |
+| `v17_rookie_growth` | 0.800 | 0.417 | 299 |
+| `v25_draft_capital_residual` | 0.800 | 0.417 | 286 |
+| `v2_age_adjusted` | 0.799 | 0.417 | 299 |
+| `v3_stat_weighted` | 0.799 | 0.417 | 299 |
+| `v16_snap_trend_full` | 0.799 | 0.458 | 299 |
+| `v10_stat_efficiency_v2` | 0.798 | 0.417 | 299 |
+| `v8_age_regression` | 0.798 | 0.417 | 299 |
+| `v9_pos_specific` | 0.798 | 0.417 | 299 |
+| `v12_no_qb_trajectory` | 0.798 | 0.417 | 299 |
+| `v13_qb_starter` | 0.798 | 0.417 | 299 |
+| `v14_qb_starter` | 0.798 | 0.417 | 299 |
+| `v21_tiered_regression` | 0.797 | 0.500 | 299 |
+| `v29_reliability_residual` | 0.797 | 0.458 | 286 |
+| `v11_team_context_v2` | 0.797 | 0.417 | 299 |
+| `v23_draft_capital` | 0.796 | 0.333 | 286 |
+| `v1_baseline_weighted_ppg` | 0.793 | 0.500 | 299 |
+| `v26_vegas_residual` | 0.792 | 0.583 | 286 |
+| `v31_depth_chart` | 0.792 | 0.458 | 286 |
+| `naive_prior_season_ppg` | 0.788 | 0.458 | 304 |
+| `v30_reliability_full_refit` | 0.785 | 0.458 | 286 |
+| `v22_advanced_receiving` | 0.784 | 0.417 | 286 |
+| `external_fantasypros_v1` | 0.784 | 0.500 | 140 |
+| `v28_reliability_weighting` | 0.783 | 0.458 | 286 |
+| `v27_vegas_full_refit` | 0.782 | 0.375 | 286 |
+| `v20_learned_usage` | 0.777 | 0.500 | 286 |
+| `position_mean_baseline` | 0.007 | 0.042 | 304 |
 
 ### TE (top-12)
 
 | Model | Spearman ρ | Top-N hit | N |
 | --- | --- | --- | --- |
-| `external_fantasypros_v1` | **0.788** | 0.750 | 111 |
-| `v1_baseline_weighted_ppg` | 0.758 | 0.333 | 144 |
-| `v20_learned_usage` | 0.758 | 0.333 | 142 |
-| `v31_depth_chart` | 0.756 | 0.333 | 142 |
-| `v19_usage_level_full` | 0.755 | 0.417 | 144 |
-| `v10_stat_efficiency_v2` | 0.752 | 0.417 | 144 |
-| `v30_reliability_full_refit` | 0.752 | 0.417 | 142 |
-| `v18_usage_level` | 0.752 | 0.417 | 144 |
-| `v3_stat_weighted` | 0.751 | 0.417 | 144 |
-| `v11_team_context_v2` | 0.751 | 0.417 | 144 |
-| `v2_age_adjusted` | 0.751 | 0.417 | 144 |
-| `v8_age_regression` | 0.751 | 0.417 | 144 |
-| `v9_pos_specific` | 0.751 | 0.417 | 144 |
-| `v12_no_qb_trajectory` | 0.751 | 0.417 | 144 |
-| `v13_qb_starter` | 0.751 | 0.417 | 144 |
-| `v14_qb_starter` | 0.751 | 0.417 | 144 |
-| `v15_snap_trend` | 0.748 | 0.500 | 144 |
-| `v21_tiered_regression` | 0.747 | 0.417 | 144 |
-| `v29_reliability_residual` | 0.747 | 0.417 | 142 |
-| `v16_snap_trend_full` | 0.746 | 0.500 | 144 |
-| `v6_usage_share` | 0.745 | 0.417 | 144 |
-| `v7_regression_to_mean` | 0.745 | 0.417 | 144 |
-| `v5_team_context` | 0.744 | 0.417 | 144 |
-| `v28_reliability_weighting` | 0.742 | 0.333 | 142 |
-| `v23_draft_capital` | 0.740 | 0.333 | 142 |
-| `v22_advanced_receiving` | 0.740 | 0.333 | 142 |
-| `v26_vegas_residual` | 0.740 | 0.417 | 142 |
-| `v4_availability_adjusted` | 0.740 | 0.417 | 144 |
-| `v27_vegas_full_refit` | 0.739 | 0.417 | 142 |
-| `v17_rookie_growth` | 0.737 | 0.417 | 144 |
-| `v25_draft_capital_residual` | 0.734 | 0.417 | 142 |
-| `naive_prior_season_ppg` | 0.726 | 0.417 | 150 |
-| `position_mean_baseline` | 0.185 | 0.167 | 150 |
+| `external_fantasypros_v1` | **0.791** | 0.750 | 113 |
+| `v31_depth_chart` | 0.748 | 0.417 | 171 |
+| `v23_draft_capital` | 0.743 | 0.333 | 171 |
+| `v25_draft_capital_residual` | 0.740 | 0.333 | 171 |
+| `v27_vegas_full_refit` | 0.739 | 0.417 | 171 |
+| `v26_vegas_residual` | 0.735 | 0.417 | 171 |
+| `v7_regression_to_mean` | 0.734 | 0.417 | 176 |
+| `v22_advanced_receiving` | 0.733 | 0.333 | 171 |
+| `v1_baseline_weighted_ppg` | 0.733 | 0.333 | 176 |
+| `v29_reliability_residual` | 0.733 | 0.417 | 171 |
+| `v5_team_context` | 0.732 | 0.417 | 176 |
+| `v30_reliability_full_refit` | 0.731 | 0.417 | 171 |
+| `v6_usage_share` | 0.730 | 0.417 | 176 |
+| `naive_prior_season_ppg` | 0.728 | 0.417 | 181 |
+| `v20_learned_usage` | 0.727 | 0.333 | 171 |
+| `v28_reliability_weighting` | 0.726 | 0.417 | 171 |
+| `v4_availability_adjusted` | 0.725 | 0.417 | 176 |
+| `v3_stat_weighted` | 0.721 | 0.417 | 176 |
+| `v2_age_adjusted` | 0.720 | 0.417 | 176 |
+| `v18_usage_level` | 0.719 | 0.417 | 176 |
+| `v11_team_context_v2` | 0.719 | 0.417 | 176 |
+| `v10_stat_efficiency_v2` | 0.719 | 0.417 | 176 |
+| `v19_usage_level_full` | 0.718 | 0.417 | 176 |
+| `v8_age_regression` | 0.717 | 0.417 | 176 |
+| `v9_pos_specific` | 0.717 | 0.417 | 176 |
+| `v12_no_qb_trajectory` | 0.717 | 0.417 | 176 |
+| `v13_qb_starter` | 0.717 | 0.417 | 176 |
+| `v14_qb_starter` | 0.717 | 0.417 | 176 |
+| `v17_rookie_growth` | 0.714 | 0.417 | 176 |
+| `v15_snap_trend` | 0.714 | 0.500 | 176 |
+| `v16_snap_trend_full` | 0.712 | 0.500 | 176 |
+| `v21_tiered_regression` | 0.709 | 0.417 | 176 |
+| `position_mean_baseline` | 0.057 | 0.083 | 181 |
 
 ## Season 2024 — ALL (held-out)
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `v31_depth_chart` | 2.636 | -0.928 | 0.566 | 3.345 | 271 |
-| `v19_usage_level_full` | 2.660 | +0.011 | 0.552 | 3.440 | 274 |
-| `v14_qb_starter` | 2.660 | +0.168 | 0.549 | 3.449 | 274 |
-| `v12_no_qb_trajectory` | 2.663 | +0.106 | 0.537 | 3.495 | 274 |
-| `v16_snap_trend_full` | 2.669 | +0.152 | 0.543 | 3.471 | 274 |
-| `external_fantasypros_v1` | 2.671 | +1.449 | 0.579 | 3.509 | 187 |
-| `v13_qb_starter` | 2.675 | +0.082 | 0.525 | 3.540 | 274 |
-| `v11_team_context_v2` | 2.676 | +0.063 | 0.523 | 3.546 | 274 |
-| `v17_rookie_growth` | 2.676 | +0.135 | 0.544 | 3.468 | 274 |
-| `v8_age_regression` | 2.682 | +0.089 | 0.524 | 3.544 | 274 |
-| `v9_pos_specific` | 2.682 | +0.089 | 0.524 | 3.544 | 274 |
-| `v10_stat_efficiency_v2` | 2.690 | +0.090 | 0.524 | 3.542 | 274 |
-| `v22_advanced_receiving` | 2.691 | -0.675 | 0.535 | 3.462 | 271 |
-| `v27_vegas_full_refit` | 2.695 | -0.661 | 0.528 | 3.490 | 271 |
-| `v28_reliability_weighting` | 2.700 | -0.679 | 0.533 | 3.472 | 271 |
-| `v20_learned_usage` | 2.712 | -0.796 | 0.531 | 3.477 | 271 |
-| `v23_draft_capital` | 2.725 | -0.697 | 0.516 | 3.533 | 271 |
-| `v26_vegas_residual` | 2.728 | -0.842 | 0.526 | 3.498 | 271 |
-| `v2_age_adjusted` | 2.731 | -0.043 | 0.505 | 3.612 | 274 |
-| `v3_stat_weighted` | 2.732 | -0.026 | 0.507 | 3.606 | 274 |
-| `v21_tiered_regression` | 2.739 | +0.406 | 0.510 | 3.597 | 274 |
-| `v25_draft_capital_residual` | 2.746 | -0.830 | 0.518 | 3.527 | 271 |
-| `v29_reliability_residual` | 2.748 | -0.814 | 0.518 | 3.528 | 271 |
-| `v30_reliability_full_refit` | 2.754 | -0.994 | 0.510 | 3.556 | 271 |
-| `v1_baseline_weighted_ppg` | 2.755 | -0.289 | 0.482 | 3.698 | 274 |
-| `v18_usage_level` | 2.757 | -0.199 | 0.500 | 3.631 | 274 |
-| `v15_snap_trend` | 2.764 | -0.059 | 0.497 | 3.642 | 274 |
-| `v7_regression_to_mean` | 2.796 | +0.362 | 0.497 | 3.643 | 274 |
-| `v4_availability_adjusted` | 2.838 | +0.413 | 0.475 | 3.722 | 274 |
-| `v5_team_context` | 2.843 | +0.387 | 0.471 | 3.735 | 274 |
-| `v6_usage_share` | 2.850 | +0.231 | 0.471 | 3.737 | 274 |
-| `naive_prior_season_ppg` | 2.963 | +0.039 | 0.369 | 4.112 | 278 |
-| `position_mean_baseline` | 3.650 | +0.702 | 0.174 | 4.704 | 278 |
+| `v31_depth_chart` | 2.265 | +0.064 | 0.668 | 2.975 | 427 |
+| `v19_usage_level_full` | 2.299 | -0.228 | 0.661 | 3.043 | 443 |
+| `v14_qb_starter` | 2.301 | -0.122 | 0.661 | 3.042 | 443 |
+| `v12_no_qb_trajectory` | 2.303 | -0.161 | 0.654 | 3.072 | 443 |
+| `v16_snap_trend_full` | 2.309 | -0.140 | 0.655 | 3.068 | 443 |
+| `v17_rookie_growth` | 2.314 | -0.157 | 0.659 | 3.049 | 443 |
+| `v13_qb_starter` | 2.314 | -0.175 | 0.647 | 3.102 | 443 |
+| `v8_age_regression` | 2.316 | -0.171 | 0.646 | 3.106 | 443 |
+| `v9_pos_specific` | 2.316 | -0.171 | 0.646 | 3.106 | 443 |
+| `v10_stat_efficiency_v2` | 2.320 | -0.162 | 0.647 | 3.103 | 443 |
+| `v26_vegas_residual` | 2.328 | -0.078 | 0.654 | 3.038 | 427 |
+| `v11_team_context_v2` | 2.333 | -0.189 | 0.642 | 3.123 | 443 |
+| `v25_draft_capital_residual` | 2.336 | -0.049 | 0.656 | 3.028 | 427 |
+| `v20_learned_usage` | 2.339 | +0.139 | 0.648 | 3.061 | 427 |
+| `v2_age_adjusted` | 2.342 | -0.333 | 0.634 | 3.161 | 443 |
+| `v23_draft_capital` | 2.343 | +0.072 | 0.647 | 3.066 | 427 |
+| `v4_availability_adjusted` | 2.343 | +0.086 | 0.632 | 3.170 | 443 |
+| `v3_stat_weighted` | 2.345 | -0.333 | 0.634 | 3.160 | 443 |
+| `v22_advanced_receiving` | 2.350 | +0.143 | 0.649 | 3.059 | 427 |
+| `v1_baseline_weighted_ppg` | 2.356 | -0.486 | 0.620 | 3.221 | 443 |
+| `v7_regression_to_mean` | 2.364 | +0.102 | 0.629 | 3.180 | 443 |
+| `v29_reliability_residual` | 2.364 | -0.044 | 0.644 | 3.078 | 427 |
+| `v18_usage_level` | 2.366 | -0.439 | 0.626 | 3.193 | 443 |
+| `v5_team_context` | 2.367 | +0.058 | 0.622 | 3.213 | 443 |
+| `v6_usage_share` | 2.368 | -0.033 | 0.622 | 3.210 | 443 |
+| `v15_snap_trend` | 2.371 | -0.352 | 0.626 | 3.193 | 443 |
+| `v30_reliability_full_refit` | 2.372 | +0.068 | 0.641 | 3.092 | 427 |
+| `v27_vegas_full_refit` | 2.374 | +0.068 | 0.644 | 3.080 | 427 |
+| `v28_reliability_weighting` | 2.379 | +0.131 | 0.636 | 3.113 | 427 |
+| `v21_tiered_regression` | 2.387 | -0.064 | 0.626 | 3.196 | 443 |
+| `naive_prior_season_ppg` | 2.441 | -0.127 | 0.556 | 3.490 | 450 |
+| `external_fantasypros_v1` | 2.597 | +1.367 | 0.620 | 3.443 | 200 |
+| `position_mean_baseline` | 3.698 | +0.787 | 0.173 | 4.760 | 450 |
 
 ## Season 2025 — ALL (held-out)
 
 | Model | MAE | Bias | R² | RMSE | N |
 | --- | --- | --- | --- | --- | --- |
-| `v14_qb_starter` | 2.296 | -0.381 | 0.656 | 3.097 | 373 |
-| `external_fantasypros_v1` | 2.301 | +0.637 | 0.675 | 3.241 | 243 |
-| `v19_usage_level_full` | 2.306 | -0.493 | 0.655 | 3.102 | 373 |
-| `v16_snap_trend_full` | 2.320 | -0.428 | 0.650 | 3.128 | 373 |
-| `v21_tiered_regression` | 2.320 | -0.262 | 0.638 | 3.178 | 373 |
-| `v12_no_qb_trajectory` | 2.330 | -0.437 | 0.629 | 3.220 | 373 |
-| `v10_stat_efficiency_v2` | 2.333 | -0.466 | 0.627 | 3.227 | 373 |
-| `v7_regression_to_mean` | 2.333 | -0.235 | 0.637 | 3.182 | 373 |
-| `v8_age_regression` | 2.340 | -0.473 | 0.625 | 3.236 | 373 |
-| `v9_pos_specific` | 2.340 | -0.473 | 0.625 | 3.236 | 373 |
-| `v13_qb_starter` | 2.344 | -0.465 | 0.623 | 3.247 | 373 |
-| `v11_team_context_v2` | 2.353 | -0.493 | 0.619 | 3.263 | 373 |
-| `v17_rookie_growth` | 2.362 | -0.460 | 0.647 | 3.139 | 373 |
-| `v5_team_context` | 2.363 | -0.295 | 0.615 | 3.279 | 373 |
-| `v4_availability_adjusted` | 2.364 | -0.278 | 0.618 | 3.266 | 373 |
-| `v3_stat_weighted` | 2.379 | -0.631 | 0.604 | 3.328 | 373 |
-| `v2_age_adjusted` | 2.385 | -0.643 | 0.602 | 3.334 | 373 |
-| `v6_usage_share` | 2.386 | -0.407 | 0.609 | 3.305 | 373 |
-| `v15_snap_trend` | 2.409 | -0.691 | 0.593 | 3.370 | 373 |
-| `v18_usage_level` | 2.421 | -0.756 | 0.593 | 3.372 | 373 |
-| `v1_baseline_weighted_ppg` | 2.543 | -0.919 | 0.560 | 3.505 | 373 |
-| `naive_prior_season_ppg` | 2.603 | -0.761 | 0.522 | 3.671 | 389 |
-| `v30_reliability_full_refit` | 2.636 | -1.356 | 0.602 | 3.305 | 364 |
-| `v31_depth_chart` | 2.654 | -1.170 | 0.575 | 3.415 | 364 |
-| `v20_learned_usage` | 2.661 | -1.256 | 0.603 | 3.301 | 364 |
-| `v26_vegas_residual` | 2.706 | -1.463 | 0.587 | 3.364 | 364 |
-| `v27_vegas_full_refit` | 2.716 | -1.368 | 0.580 | 3.394 | 364 |
-| `v28_reliability_weighting` | 2.723 | -1.324 | 0.588 | 3.360 | 364 |
-| `v29_reliability_residual` | 2.730 | -1.443 | 0.587 | 3.368 | 364 |
-| `v22_advanced_receiving` | 2.731 | -1.318 | 0.587 | 3.366 | 364 |
-| `v25_draft_capital_residual` | 2.777 | -1.476 | 0.577 | 3.404 | 364 |
-| `v23_draft_capital` | 2.793 | -1.408 | 0.566 | 3.451 | 364 |
-| `position_mean_baseline` | 3.753 | +0.283 | 0.192 | 4.774 | 389 |
+| `v26_vegas_residual` | 2.258 | -0.452 | 0.678 | 2.976 | 383 |
+| `v31_depth_chart` | 2.273 | -0.298 | 0.666 | 3.031 | 383 |
+| `v29_reliability_residual` | 2.278 | -0.446 | 0.672 | 3.003 | 383 |
+| `v25_draft_capital_residual` | 2.283 | -0.456 | 0.674 | 2.993 | 383 |
+| `external_fantasypros_v1` | 2.283 | +0.632 | 0.680 | 3.228 | 245 |
+| `v30_reliability_full_refit` | 2.284 | -0.395 | 0.665 | 3.037 | 383 |
+| `v28_reliability_weighting` | 2.291 | -0.245 | 0.663 | 3.044 | 383 |
+| `v14_qb_starter` | 2.293 | -0.451 | 0.661 | 3.090 | 399 |
+| `v7_regression_to_mean` | 2.297 | -0.206 | 0.650 | 3.140 | 399 |
+| `v21_tiered_regression` | 2.300 | -0.446 | 0.645 | 3.162 | 399 |
+| `v16_snap_trend_full` | 2.301 | -0.484 | 0.657 | 3.107 | 399 |
+| `v19_usage_level_full` | 2.302 | -0.556 | 0.660 | 3.092 | 399 |
+| `v22_advanced_receiving` | 2.307 | -0.234 | 0.663 | 3.043 | 383 |
+| `v20_learned_usage` | 2.310 | -0.222 | 0.657 | 3.070 | 383 |
+| `v23_draft_capital` | 2.311 | -0.407 | 0.656 | 3.075 | 383 |
+| `v27_vegas_full_refit` | 2.313 | -0.402 | 0.657 | 3.070 | 383 |
+| `v17_rookie_growth` | 2.326 | -0.490 | 0.658 | 3.103 | 399 |
+| `v4_availability_adjusted` | 2.326 | -0.304 | 0.629 | 3.231 | 399 |
+| `v12_no_qb_trajectory` | 2.327 | -0.505 | 0.635 | 3.205 | 399 |
+| `v5_team_context` | 2.330 | -0.318 | 0.627 | 3.241 | 399 |
+| `v10_stat_efficiency_v2` | 2.332 | -0.528 | 0.633 | 3.215 | 399 |
+| `v8_age_regression` | 2.334 | -0.539 | 0.632 | 3.218 | 399 |
+| `v9_pos_specific` | 2.334 | -0.539 | 0.632 | 3.218 | 399 |
+| `v13_qb_starter` | 2.341 | -0.532 | 0.629 | 3.233 | 399 |
+| `v11_team_context_v2` | 2.342 | -0.550 | 0.630 | 3.228 | 399 |
+| `v6_usage_share` | 2.348 | -0.425 | 0.622 | 3.262 | 399 |
+| `v3_stat_weighted` | 2.366 | -0.748 | 0.611 | 3.311 | 399 |
+| `v2_age_adjusted` | 2.376 | -0.754 | 0.609 | 3.320 | 399 |
+| `v15_snap_trend` | 2.385 | -0.787 | 0.603 | 3.343 | 399 |
+| `v18_usage_level` | 2.410 | -0.860 | 0.600 | 3.356 | 399 |
+| `v1_baseline_weighted_ppg` | 2.524 | -1.012 | 0.570 | 3.480 | 399 |
+| `naive_prior_season_ppg` | 2.615 | -0.785 | 0.521 | 3.677 | 405 |
+| `position_mean_baseline` | 3.757 | +0.691 | 0.169 | 4.842 | 405 |


### PR DESCRIPTION
Follow-up to #599 (merged in #607): executes the recommended 2021–2023 `player_stats` backfill and re-runs the held-out harness. **The result reverses the #579 negative conclusion.**

## What was done
- `pull_player_stats` for 2021,2022,2023 → **+1,997 qualifying player-seasons** from nflverse (same source/scoring as 2018–2020 & 2024–2025; the ~1,932 unmatched are DEF/OL not in the fantasy `players` table — correctly skipped).
- Coverage **29–40% → 82–84%**, mean PPG **8–10 → ~6.2** — now consistent with every season.
- All 22 additive models re-projected (2023–2025) and every learned model retrained OOS on the corrected population. Held-out cache cleared (it's keyed on model definition, not data).

## Result — the over-projection bias was the coverage artifact

| Model | MAE before → after | Bias before → after |
|---|---|---|
| `v20_learned_usage` | 2.683 → 2.325 | **−1.060 → −0.032** |
| `v27_vegas_full_refit` | 2.707 → 2.345 | −1.066 → −0.154 |
| `v31_depth_chart` | 2.660 (rank 22) → **2.269 (rank 1)** | −1.4 → −0.107 |
| `v14_qb_starter` (prod) | 2.450 (rank 1) → 2.297 (rank 3) | −0.149 → −0.278 |

The learned models' −1.0…−1.3 bias collapses to ≈0 and the whole family returns to the top of the **honest** ranking (retrained OOS, no leakage). #579's "learned models can't beat `v14`" was itself an artifact of the 2021–2023 coverage bug.

## Significance — clears the promotion gate (rolling protocol)
- **Fixed window** (3-season train handicap): `v31` ties `v14` (Δ−0.020, CI [−0.113,+0.078], p=0.68).
- **Rolling-origin (#594, fair 5-season window):** `v31` **significantly** beats `v14` — Δ **−0.091**, 95% CI **[−0.163, −0.020]**, p=0.014, 617 player clusters (N=1,216). `v27` second.

This is the first model to clear the standing promotion gate ("a *significant* held-out win over the active model") post-audit.

## Backlog re-scope
- #590 (delta-anchored) / #592 (QB-specific) now bet on a **competitive, calibrated** learned base.
- **#591 (level-matched 2018–2020 window) is moot** — the level mismatch was the coverage bug, now fixed.

## Scope / files
Docs only (the backfill is a data mutation; this PR carries the regenerated artifacts): audit-doc backfill section + #579 superseded banner, accuracy-improvement backlog, experiment-log held-out rows, and regenerated holdout (fixed/rolling/matched), availability, and coverage reports.

## Two operator decisions (not done here)
1. **Promotion** — `v31_depth_chart` now clears the gate under the rolling protocol. Promoting is a production change (`just promote v31_depth_chart`) — left to you.
2. **`just analyze`** — the active model's current-season (2026) projections were computed on pre-backfill history and should be regenerated so the web app is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)