### PR TITLE
docs(projections): flip experiment comparator v14_qb_starter -> v31_depth_chart

### DIFF
--- a/.claude/commands/ablation.md
+++ b/.claude/commands/ablation.md
@@ -8,7 +8,7 @@ arbitrary-band decisions Finding 2 condemned — do not use it for verdicts.
 
 // turbo
 
-1. **Identify the target model** (default: production `v14_qb_starter`). If the
+1. **Identify the target model** (default: the active model `v31_depth_chart`). If the
    user specifies a model, use that.
 
 2. **List the model's features** from `scripts/feature_projections/model_config.py`.

--- a/.claude/commands/compare-models.md
+++ b/.claude/commands/compare-models.md
@@ -8,8 +8,8 @@ per-player divergence inspection, never to declare a winner.
 
 // turbo
 
-1. **Parse model names from arguments** (2–3 names, e.g. `v14 v20`). Resolve
-   partial names to full names from `model_config.py` (`v14` → `v14_qb_starter`).
+1. **Parse model names from arguments** (2–3 names, e.g. `v31 v14`). Resolve
+   partial names to full names from `model_config.py` (`v31` → `v31_depth_chart`).
 
 2. **Held-out comparison (the verdict).** Score exactly the requested models
    out-of-sample on the shared window:

--- a/.claude/commands/diagnose-segment.md
+++ b/.claude/commands/diagnose-segment.md
@@ -11,18 +11,18 @@ held-out harness (`/experiment`), never on the in-sample segment numbers.
 1. **Parse the segment** from arguments (e.g. "bench WR", "elite QB", "age 30+",
    "high-usage RB"). If none given, ask the user.
 
-2. **Run segment analysis** across production + a learned reference + the naïve
+2. **Run segment analysis** across the active model + an additive reference + the naïve
    baseline (use `venv/bin/python` directly — no `source venv/bin/activate`):
    ```bash
    venv/bin/python scripts/feature_projections/cli.py segment-analysis \
-     --models v14_qb_starter,v20_learned_usage,naive_prior_season_ppg \
+     --models v31_depth_chart,v14_qb_starter,naive_prior_season_ppg \
      --seasons 2022,2023,2024,2025
    ```
 
 3. **Run per-player diagnostics** for the player-level view:
    ```bash
    venv/bin/python scripts/feature_projections/cli.py diagnostics \
-     --model v14_qb_starter --season 2025 --top 50 \
+     --model v31_depth_chart --season 2025 --top 50 \
      --output docs/generated/player-diagnostics.md
    ```
 
@@ -38,6 +38,6 @@ held-out harness (`/experiment`), never on the in-sample segment numbers.
 
 7. **Propose improvements as hypotheses, not conclusions.** For any proposed
    feature or weight change, hand off to `/experiment` to get a held-out,
-   significance-tested verdict vs `v14_qb_starter` before trusting it. Be alert to
+   significance-tested verdict vs `v31_depth_chart` before trusting it. Be alert to
    the level-vs-ordering split (#579/#598): a segment can be biased in level while
    still ranked correctly, which changes whether a fix is even worth making.

--- a/.claude/commands/experiment.md
+++ b/.claude/commands/experiment.md
@@ -22,12 +22,12 @@ point-estimate delta.
      `holdout-eval` sandbox automatically — no pre-training or pre-projection
      needed (and never train on the eval seasons yourself).
 
-3. **Run the held-out re-rank** against production (`v14_qb_starter`) and the
+3. **Run the held-out re-rank** against production (`v31_depth_chart`) and the
    naïve baselines (`naive_prior_season_ppg`, `position_mean_baseline`). Prefer
    the rolling-origin protocol (#594); the cache (#597) makes re-runs fast:
    ```bash
    just holdout-eval --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021 \
-     --models MODEL_NAME,v14_qb_starter,naive_prior_season_ppg,position_mean_baseline
+     --models MODEL_NAME,v31_depth_chart,naive_prior_season_ppg,position_mean_baseline
    ```
    Read the **Ranking quality** section too (per-position Spearman ρ + top-N hit
    rate, #598) — the projections feed VORP/auction/keepers, which consume
@@ -36,18 +36,18 @@ point-estimate delta.
 4. **Test significance vs the production model** (player-clustered paired
    bootstrap, #594). This is the gate:
    ```bash
-   just significance MODEL_NAME v14_qb_starter --protocol rolling \
+   just significance MODEL_NAME v31_depth_chart --protocol rolling \
      --eval-seasons 2023,2024,2025 --min-train-season 2021
    ```
 
 5. **If the model touches availability / expected games**, additionally report
    the availability budget (rate vs availability MAE, #574):
    ```bash
-   just availability-backtest --models MODEL_NAME,v14_qb_starter
+   just availability-backtest --models MODEL_NAME,v31_depth_chart
    ```
 
 6. **State the verdict** from the significance test, not an MAE band:
-   - **SIGNIFICANT WIN** — the 95% CI for MAE(NEW) − MAE(v14_qb_starter) lies
+   - **SIGNIFICANT WIN** — the 95% CI for MAE(NEW) − MAE(v31_depth_chart) lies
      entirely below 0. Only this clears the bar to consider promotion.
    - **NOT SIGNIFICANT** — CI spans 0. The gap is sampling noise; do not promote
      on it, regardless of the point estimate.
@@ -57,7 +57,7 @@ point-estimate delta.
 
 7. **Append to the experiment log** (`docs/generated/experiment-log.md`) using the
    held-out columns: date, model, change, **held-out ALL MAE**, **Δ vs
-   v14_qb_starter**, **95% CI**, **significant? (Y/N)**, protocol, PR. The
+   v31_depth_chart**, **95% CI**, **significant? (Y/N)**, protocol, PR. The
    in-sample `accuracy-report` is a secondary diagnostic only.
 
 8. **In the PR description**, lead with the held-out + significance result; the

--- a/.claude/commands/feature-importance.md
+++ b/.claude/commands/feature-importance.md
@@ -8,9 +8,10 @@ place, cross-check with held-out ablation (`/ablation`, #588), not these numbers
 
 // turbo
 
-1. **Identify the learned model** (default: `v20_learned_usage` — note this is a
-   learned reference model, not production; production is the additive
-   `v14_qb_starter`, which has no learned coefficients to inspect). Use the
+1. **Identify the learned model** (default: the active model `v31_depth_chart`,
+   itself a learned Ridge model whose coefficients are inspectable). Only the
+   additive models — e.g. `v14_qb_starter` — have no learned coefficients to
+   inspect; pick a learned model if the user names an additive one. Use the
    user-specified model if given.
 
 2. **Run the feature analysis script** (use `venv/bin/python` directly — no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,14 +131,14 @@ Run `just check-arch` to validate these rules locally.
 
 When any task modifies the projection system — including `scripts/feature_projections/`, `scripts/projection_methods.py`, `scripts/update_projections.py`, or `model_config.py` — you MUST validate it on the **leakage-free held-out harness**. The in-sample `accuracy-report` scores learned models on the seasons they trained on (methodology audit, Findings 1 & 2); it is a **secondary diagnostic only** and must never be the gate or the basis for a promote decision. Use `/experiment` to run this flow.
 
-1. **Run the held-out re-rank** against production (`v14_qb_starter`) and the naïve baselines, on the rolling-origin protocol (#594). Learned models retrain out-of-sample inside the sandbox; additive/external models need their held-out projections generated first (`just project <name> 2023,2024,2025`). The cache (#597) makes re-runs fast.
+1. **Run the held-out re-rank** against production (`v31_depth_chart`) and the naïve baselines, on the rolling-origin protocol (#594). Learned models retrain out-of-sample inside the sandbox; additive/external models need their held-out projections generated first (`just project <name> 2023,2024,2025`). The cache (#597) makes re-runs fast.
    ```
    just holdout-eval --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021 \
-     --models <name>,v14_qb_starter,naive_prior_season_ppg,position_mean_baseline
+     --models <name>,v31_depth_chart,naive_prior_season_ppg,position_mean_baseline
    ```
 2. **Test significance vs the active model** (player-clustered paired bootstrap). This is the gate — a point-estimate MAE delta is **not** a result:
    ```
-   just significance <name> v14_qb_starter --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
+   just significance <name> v31_depth_chart --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
    ```
    Availability-touching changes additionally run `just availability-backtest` and report **both** rate and availability MAE (#574).
 3. **In the PR description**, lead with the held-out ranking + significance verdict (and the per-position Ranking-quality rows, #598). Include the in-sample `accuracy-report` table only if labelled "in-sample diagnostic — not the ranking".

--- a/docs/generated/experiment-log.md
+++ b/docs/generated/experiment-log.md
@@ -3,19 +3,24 @@
 _Tracks every model iteration attempt to prevent re-trying failed approaches._
 
 > ⚠️ **The historical table at the bottom is in-sample for the learned models
-> (`v20`–`v31`) — they were trained on the seasons they're scored on. The
-> [methodology audit](../exec-plans/projection-methodology-audit.md) (2026-06-10)
-> re-ranked everything out-of-sample: the additive **`v14_qb_starter`** is the
-> honest best and is in production; the entire `v20`→`v31` "progression" was a
-> leakage artifact. Do not read those deltas as real gains.**
+> (`v20`–`v31`) — they were trained on the seasons they're scored on; do not read
+> those deltas as real gains.** The [methodology audit](../exec-plans/projection-methodology-audit.md)
+> (2026-06-10) re-ranked everything out-of-sample. At that point the additive
+> `v14_qb_starter` was the honest best (the `v20`→`v31` in-sample "progression"
+> was a leakage artifact). **That reversed after the #599 coverage backfill**
+> (PRs #607/#608): on the corrected population the learned **`v31_depth_chart`**
+> is the honest held-out #1 and *significantly* beats `v14_qb_starter`
+> (Δ−0.091, CI [−0.163, −0.020], rolling-origin), so `v31_depth_chart` was
+> promoted to active (#609). The current comparator/gate is the active model
+> (`projection_models.is_active` = `v31_depth_chart`), **not** `v14_qb_starter`.
 
 ## Held-out experiments (post-audit protocol — #594+)
 
 New experiments are logged here with **leakage-free held-out** numbers, the gate
 being a *significant* win over the active model. Generate the row with
 `/experiment`: `just holdout-eval --protocol rolling …` for the MAE/CI and
-`just significance NEW v14_qb_starter --protocol rolling …` for the verdict. Δ
-and CI are for `MAE(model) − MAE(v14_qb_starter)` (negative ⇒ model better).
+`just significance NEW v31_depth_chart --protocol rolling …` for the verdict. Δ
+and CI are for `MAE(model) − MAE(v31_depth_chart)` (negative ⇒ model better).
 Iterate on the rolling folds; the final window is confirmation-only (one look).
 
 | Date | Model | Change | Held-out ALL MAE | Δ vs v14 | 95% CI | Significant? | Protocol | PR |


### PR DESCRIPTION
## Flip the experiment comparator from `v14_qb_starter` to `v31_depth_chart`

Follow-up flagged by the Wave 3 re-scope (#610). `v31_depth_chart` became the **active** model (#609) after the #599 coverage backfill reversed #579, but the agent workflow docs still hard-named `v14_qb_starter` as the production/comparator model — so any agent following them would gate experiments against the wrong (no-longer-active) model.

### Changes
- **Comparator/gate references flipped to `v31_depth_chart`:** `/experiment` (re-rank + significance + availability + log columns), `/ablation` (default target), `/diagnose-segment` (segment + diagnostics + verdict), CLAUDE.md "Projection Model Update Requirements" example commands, and the experiment-log "Held-out experiments" gate command (`MAE(model) − MAE(v31_depth_chart)`).
- **Reworded (not swapped) the legitimate `v14`-as-additive-example spots:** `/feature-importance`'s "additive models have no coefficients" note (v31 *is* learned/inspectable now) and `/compare-models`'s name-expansion example.
- **Rewrote the experiment-log warning header** to record the post-#599 reversal (v31 is now the honest held-out #1, significantly beats v14, promoted #609) instead of the stale "the additive v14_qb_starter is the honest best and is in production" claim.

All remaining `v14_qb_starter` mentions are intentional (historical narrative / additive-reference examples). `just check-arch` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)