### PR TITLE
feat(eval): expected-games availability haircut — #587 stage a (bar-setter)

### DIFF
--- a/docs/generated/experiment-log.md
+++ b/docs/generated/experiment-log.md
@@ -24,6 +24,33 @@ Iterate on the rolling folds; the final window is confirmation-only (one look).
 | 2026-06-10 | v31_depth_chart | same — fixed window (3-season train handicap) | 2.269 | −0.020 | [−0.113, +0.078] | N (p=0.68) | fixed 2021–23→24–25 | #599 backfill |
 | 2026-06-10 | v20_learned_usage | same backfill — over-projection bias check | 2.325 | — | bias −1.060→**−0.032** | bias artifact removed | fixed | #599 backfill |
 
+### Availability / expected-games (#587) — measured on `availability-backtest`, not rate MAE
+
+#587 targets the *availability budget* (avail-MAE − rate-MAE), a different metric
+from the rate-MAE held-out table above. Stage (a) is a leakage-free eval-time
+expected-games haircut on the rate projection
+(`pred_avail = pred × min(E[games], 17)/17`, E[games] from seasons strictly before
+the target), exposed as `just availability-backtest --expected-games {none,constant,history}`.
+The rate projection — and its `significance` gate — are untouched, so this isolates
+the availability question. Seasons 2022–2025, model `v14_qb_starter` (DoD names its
++0.589 budget):
+
+| Mode | Avail MAE | Availability budget | Avail bias | Note |
+|------|-----------|---------------------|------------|------|
+| none (raw rate) | 2.986 | +0.589 | −1.946 | baseline — no availability modeling |
+| constant (per-position mean games) | 2.630 | +0.232 | +1.020 | overcorrects — flat haircut over-penalises durable players |
+| **history (player recency-weighted games)** | **2.268** | **−0.130** | **−0.236** | **bar-setter: −0.718 avail MAE (−24%), budget turns negative, bias collapses** |
+
+The per-player **history** haircut clears the DoD decisively — v14's availability
+budget +0.589 → −0.130 (below even FantasyPros's −0.124) and the −1.95
+over-projection bias collapses to −0.24, with the rate projection unchanged. The
+same effect holds on `v8_age_regression` (budget +0.625 → −0.138), so it is not a
+v14 quirk. **Guardrail:** the haircut *hurts* already-availability-aware projections
+(FantasyPros budget −0.124 → +0.084) — apply it to pure-rate models only. Next
+increments: (b) age/position/depth-role expected-games model, then productionise as
+a separate `projected_games` output column so the live VORP/auction consumers get
+availability-inclusive projections without disturbing the rate gate.
+
 ## Historical (in-sample) log — pre-audit, deltas not reliable
 
 These rows predate the held-out harness; their `ALL MAE`/`R²` are in-sample for

--- a/scripts/feature_projections/availability_backtest.py
+++ b/scripts/feature_projections/availability_backtest.py
@@ -39,8 +39,10 @@ from __future__ import annotations
 import argparse
 import os
 from datetime import datetime
+from typing import Optional
 
 from scripts.config import get_supabase_client, fetch_all_rows, POSITIONS
+from scripts.feature_projections.expected_games import MODES, build_expected_games
 from scripts.feature_projections.backtest import (
     TOP_N_BY_POSITION,
     _compute_metrics,
@@ -98,6 +100,7 @@ def _combined_avail_metrics(
     preds_by_season: dict[int, dict[str, float]],
     actuals_by_season: dict[int, dict[str, dict]],
     pos_map: dict[str, str],
+    expected_games: Optional[dict[tuple[str, int], float]] = None,
 ) -> dict:
     """Rate + availability metrics (ALL + per position), POOLED across seasons.
 
@@ -106,6 +109,12 @@ def _combined_avail_metrics(
     average of per-season R² (GH #576, Finding 5). MAE/bias/RMSE are unchanged
     vs an N-weighted aggregate; R² is the one that was wrong. Returns
     {"rate": {pos: metrics}, "avail": {pos: metrics}, "mean_games": float}.
+
+    When ``expected_games`` is supplied (GH #587 stage a), the *availability*
+    prediction is haircut to ``pred × min(E[games], 17) / 17`` while the rate
+    prediction is left untouched — so the rate gate is unaffected and only the
+    availability budget moves. A player with no expected-games estimate keeps the
+    unscaled rate prediction (the prior behaviour).
     """
     targets = {"rate": "ppg", "avail": "avail"}
     buckets: dict[str, dict[str, tuple[list, list]]] = {
@@ -123,11 +132,18 @@ def _combined_avail_metrics(
             pos = pos_map.get(pid)
             games_sum += actual["games"]
             games_n += 1
+            # Availability-haircut prediction (rate prediction is unchanged).
+            avail_pred = pred
+            if expected_games is not None:
+                eg = expected_games.get((pid, season))
+                if eg is not None:
+                    avail_pred = pred * min(eg, GAMES_FULL_SEASON) / GAMES_FULL_SEASON
+            pred_for = {"rate": pred, "avail": avail_pred}
             for t, key in targets.items():
-                buckets[t]["ALL"][0].append(pred)
+                buckets[t]["ALL"][0].append(pred_for[t])
                 buckets[t]["ALL"][1].append(actual[key])
                 if pos in buckets[t]:
-                    buckets[t][pos][0].append(pred)
+                    buckets[t][pos][0].append(pred_for[t])
                     buckets[t][pos][1].append(actual[key])
 
     out: dict = {"mean_games": (games_sum / games_n) if games_n else None}
@@ -172,7 +188,7 @@ def _balanced_mae(pos_metrics: dict) -> float | None:
     return sum(maes) / len(maes) if maes else None
 
 
-def run(seasons: list[int], model_names: list[str]) -> str:
+def run(seasons: list[int], model_names: list[str], expected_games_mode: str = "none") -> str:
     supabase = get_supabase_client()
     players_data = fetch_all_rows(supabase, "players", "id, position")
     pos_map = {row["id"]: row["position"] for row in players_data}
@@ -181,6 +197,13 @@ def run(seasons: list[int], model_names: list[str]) -> str:
     actuals_by_season = {s: _build_availability_actuals(supabase, s, all_stats) for s in seasons}
     for s in seasons:
         print(f"Season {s}: {len(actuals_by_season[s])} players (games ≥ {MIN_INCLUDE_GAMES}, non-rookie)")
+
+    # Expected-games haircut lookup (GH #587 stage a) — leakage-free, built from
+    # seasons strictly before each target. {} when mode == "none".
+    expected_games = build_expected_games(all_stats, pos_map, seasons, expected_games_mode)
+    if expected_games_mode != "none":
+        print(f"Expected-games haircut: mode={expected_games_mode}, "
+              f"{len(expected_games)} (player, season) estimates")
 
     # {model: pooled combined metrics}
     combined: dict[str, dict] = {}
@@ -197,19 +220,28 @@ def run(seasons: list[int], model_names: list[str]) -> str:
             )
             preds_by_season[s] = {r["player_id"]: float(r["projected_ppg"]) for r in preds_rows
                                   if r.get("projected_ppg") is not None}
-        cm = _combined_avail_metrics(preds_by_season, actuals_by_season, pos_map)
+        cm = _combined_avail_metrics(preds_by_season, actuals_by_season, pos_map, expected_games)
         if cm.get("avail", {}).get("ALL"):
             combined[name] = cm
 
-    return _render(combined, seasons)
+    return _render(combined, seasons, expected_games_mode)
 
 
-def _render(combined: dict[str, dict], seasons: list[int]) -> str:
+def _render(combined: dict[str, dict], seasons: list[int], expected_games_mode: str = "none") -> str:
     report_positions = ["ALL"] + list(POSITIONS)
 
     lines: list[str] = []
     lines.append("# Projection Availability-Inclusive Evaluation (GH #574)\n")
     lines.append(f"_Generated: {datetime.now().strftime('%Y-%m-%d %H:%M')}_\n")
+    if expected_games_mode != "none":
+        lines.append(
+            f"> **Expected-games haircut active (GH #587 stage a, mode "
+            f"`{expected_games_mode}`).** The *availability* prediction is scaled to "
+            f"`pred × min(E[games], {GAMES_FULL_SEASON}) / {GAMES_FULL_SEASON}` using a "
+            f"leakage-free expected-games estimate (seasons strictly before the target); "
+            f"the **rate** prediction and its gate are unchanged. Compare the availability "
+            f"budget below against the unscaled (`--expected-games none`) run.\n"
+        )
     lines.append(
         f"Standard backtests score only players with ≥4 games, hiding injured/benched/bust "
         f"seasons. This evaluation keeps everyone with ≥{MIN_INCLUDE_GAMES} game (non-rookie) and "
@@ -310,6 +342,10 @@ def main() -> None:
                         help="Comma-separated subset (default: all parameter-free models)")
     parser.add_argument("--include-learned", action="store_true",
                         help="Also include learned/residual models (in-sample projections — diagnostic only)")
+    parser.add_argument("--expected-games", default="none", choices=list(MODES),
+                        help="Availability haircut (GH #587 stage a): 'none' (raw rate), "
+                             "'constant' (per-position mean games), or 'history' "
+                             "(player recency-weighted games). Scales the avail prediction only.")
     parser.add_argument("--output",
                         default=os.path.join(repo_root, "docs", "generated", "projection-availability-eval.md"))
     args = parser.parse_args()
@@ -322,7 +358,7 @@ def main() -> None:
         if args.include_learned:
             model_names += [n for n, m in MODELS.items() if m.combiner_type in ("learned", "residual")]
 
-    table = run(seasons, model_names)
+    table = run(seasons, model_names, expected_games_mode=args.expected_games)
 
     os.makedirs(os.path.dirname(args.output), exist_ok=True)
     with open(args.output, "w") as f:

--- a/scripts/feature_projections/expected_games.py
+++ b/scripts/feature_projections/expected_games.py
@@ -1,0 +1,133 @@
+"""Expected-games (availability) estimation for the availability-inclusive
+backtest (GH #587, stage a).
+
+The availability-inclusive backtest (`availability_backtest.py`, #574) exposes a
+large over-projection bias: a pure-rate PPG projection scores against
+`ppg × games/17`, so every game a player misses is unmodeled error (v14:
++0.589 availability budget, −1.95 avail bias). This module supplies the simplest
+fix the #587 review asked for first — a **constant expected-games haircut** that
+converts a rate projection into an availability-inclusive one,
+`pred_avail = pred × min(E[games], 17) / 17`, to *set the bar* before any learned
+expected-games model.
+
+Two modes:
+
+- ``constant`` — ``E[games]`` is the per-position mean ``games_played`` over all
+  prior seasons (strictly before the target season — leakage-free).
+- ``history`` — the player's own recency-weighted mean games over their prior
+  seasons, falling back to the position constant when the player has no prior
+  games on record.
+
+All estimates use only seasons *strictly before* the target season, so applying
+them to a backtest target is leakage-free by construction.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+FULL_SEASON_GAMES = 17
+
+# Most-recent-first recency weights for the player-history mode (up to 3 seasons).
+RECENCY_WEIGHTS = [0.6, 0.3, 0.1]
+
+MODES = ("none", "constant", "history")
+
+
+def _positional_constants(
+    rows_before: List[dict], pos_map: Dict[str, str]
+) -> Dict[str, float]:
+    """Per-position mean games_played over the supplied (prior-season) rows.
+
+    Only counts player-seasons with at least one game so injured-out / inactive
+    rows don't drag the mean to zero for players who were genuinely on a roster.
+    """
+    sums: Dict[str, float] = {}
+    counts: Dict[str, int] = {}
+    for r in rows_before:
+        games = int(r.get("games_played", 0) or 0)
+        if games < 1:
+            continue
+        pos = pos_map.get(r["player_id"])
+        if pos is None:
+            continue
+        sums[pos] = sums.get(pos, 0.0) + min(games, FULL_SEASON_GAMES)
+        counts[pos] = counts.get(pos, 0) + 1
+    return {pos: sums[pos] / counts[pos] for pos in sums if counts[pos] > 0}
+
+
+def _player_recency_games(
+    player_rows_before: List[dict],
+) -> Optional[float]:
+    """Recency-weighted mean games over a player's prior *played* seasons (most
+    recent weighted highest). Seasons with 0 games are skipped (a missed year is
+    not evidence the player will miss the next one — defer to the position
+    constant instead). Returns None when the player has no prior played season.
+    """
+    seasons = sorted(
+        (r for r in player_rows_before if int(r.get("games_played", 0) or 0) >= 1),
+        key=lambda r: int(r["season"]),
+        reverse=True,
+    )
+    recent = seasons[: len(RECENCY_WEIGHTS)]
+    weighted = 0.0
+    total_w = 0.0
+    for w, r in zip(RECENCY_WEIGHTS, recent):
+        games = min(int(r.get("games_played", 0) or 0), FULL_SEASON_GAMES)
+        weighted += games * w
+        total_w += w
+    if total_w == 0:
+        return None
+    return weighted / total_w
+
+
+def build_expected_games(
+    all_stats: List[dict],
+    pos_map: Dict[str, str],
+    seasons: List[int],
+    mode: str,
+    full_season: int = FULL_SEASON_GAMES,
+) -> Dict[Tuple[str, int], float]:
+    """Leakage-free expected-games per (player_id, target_season).
+
+    ``all_stats`` rows need ``player_id``, ``games_played`` and ``season``.
+    Returns {} for ``mode == "none"`` (caller then uses unscaled rate predictions).
+    The returned value is the expected number of games, capped at ``full_season``;
+    callers scale a rate projection by ``E[games] / full_season``.
+    """
+    if mode == "none":
+        return {}
+    if mode not in MODES:
+        raise ValueError(f"Unknown expected-games mode '{mode}'. Choices: {MODES}")
+
+    out: Dict[Tuple[str, int], float] = {}
+    for target_season in seasons:
+        rows_before = [
+            r
+            for r in all_stats
+            if r.get("season") is not None and int(r["season"]) < int(target_season)
+        ]
+        pos_constants = _positional_constants(rows_before, pos_map)
+        if not pos_constants:
+            continue
+
+        # Players to estimate for: anyone with a prior-season row (the backtest's
+        # actuals are restricted to non-rookies anyway, so this is a superset).
+        player_ids = {r["player_id"] for r in rows_before}
+        by_player: Dict[str, List[dict]] = {}
+        if mode == "history":
+            for r in rows_before:
+                by_player.setdefault(r["player_id"], []).append(r)
+
+        for pid in player_ids:
+            pos = pos_map.get(pid)
+            constant = pos_constants.get(pos)
+            if constant is None:
+                continue
+            if mode == "constant":
+                eg = constant
+            else:  # history
+                player_eg = _player_recency_games(by_player.get(pid, []))
+                eg = player_eg if player_eg is not None else constant
+            out[(pid, int(target_season))] = min(eg, float(full_season))
+    return out

--- a/scripts/tests/test_expected_games.py
+++ b/scripts/tests/test_expected_games.py
@@ -1,0 +1,65 @@
+"""Tests for the expected-games availability haircut (GH #587 stage a)."""
+
+from scripts.feature_projections.expected_games import (
+    FULL_SEASON_GAMES,
+    build_expected_games,
+)
+
+
+POS_MAP = {"rb1": "RB", "rb2": "RB", "wr1": "WR"}
+
+
+def _stats():
+    # rb1: durable (16, 17 games); rb2: injury-prone (4, 6); wr1: 12, 14.
+    return [
+        {"player_id": "rb1", "season": 2022, "games_played": 16},
+        {"player_id": "rb1", "season": 2023, "games_played": 17},
+        {"player_id": "rb2", "season": 2022, "games_played": 4},
+        {"player_id": "rb2", "season": 2023, "games_played": 6},
+        {"player_id": "wr1", "season": 2022, "games_played": 12},
+        {"player_id": "wr1", "season": 2023, "games_played": 14},
+    ]
+
+
+def test_mode_none_returns_empty():
+    assert build_expected_games(_stats(), POS_MAP, [2024], "none") == {}
+
+
+def test_leakage_free_only_uses_prior_seasons():
+    # Target 2023 may only see 2022 rows; rb1's 2023 (17) must not leak in.
+    eg = build_expected_games(_stats(), POS_MAP, [2023], "history")
+    assert eg[("rb1", 2023)] == 16  # only 2022 season available
+    assert eg[("rb2", 2023)] == 4
+
+
+def test_history_is_per_player_recency_weighted():
+    eg = build_expected_games(_stats(), POS_MAP, [2024], "history")
+    # rb1 most-recent (2023=17) weighted 0.6, 2022=16 weighted 0.3 -> (17*.6+16*.3)/.9
+    assert abs(eg[("rb1", 2024)] - (17 * 0.6 + 16 * 0.3) / 0.9) < 1e-9
+    # Durable rb1 estimate > injury-prone rb2 estimate.
+    assert eg[("rb1", 2024)] > eg[("rb2", 2024)]
+
+
+def test_constant_is_per_position_mean():
+    eg = build_expected_games(_stats(), POS_MAP, [2024], "constant")
+    # RB constant = mean of all prior RB player-seasons (16,17,4,6) = 10.75.
+    assert abs(eg[("rb1", 2024)] - (16 + 17 + 4 + 6) / 4) < 1e-9
+    # Same constant for both RBs (it's positional, not per-player).
+    assert eg[("rb1", 2024)] == eg[("rb2", 2024)]
+
+
+def test_estimates_capped_at_full_season():
+    stats = [{"player_id": "rb1", "season": 2023, "games_played": 25}]
+    eg = build_expected_games(stats, POS_MAP, [2024], "history")
+    assert eg[("rb1", 2024)] == FULL_SEASON_GAMES
+
+
+def test_history_falls_back_to_position_constant():
+    # rb2 has no prior games (all zero) on the target window -> use RB constant.
+    stats = [
+        {"player_id": "rb1", "season": 2023, "games_played": 17},
+        {"player_id": "rb2", "season": 2023, "games_played": 0},
+    ]
+    eg = build_expected_games(stats, POS_MAP, [2024], "history")
+    # rb2 fell back to the RB constant (only rb1's 17 counts; rb2's 0 excluded).
+    assert eg[("rb2", 2024)] == 17


### PR DESCRIPTION
## #587 stage (a): expected-games availability haircut (bar-setter)

First, falsifiable increment of #587 (availability / expected-games — the top Wave 3 priority). Availability is the largest **unmodeled, rate-orthogonal** error: a pure-rate PPG projection scores against `ppg × games/17`, so every missed game is unmodeled (v14: **+0.589 availability budget, −1.95 over-projection bias**, per the audit's Finding 3).

### Approach
A **leakage-free, eval-time** expected-games haircut on the rate projection — `pred_avail = pred × min(E[games], 17)/17` — with `E[games]` estimated from seasons **strictly before** the target. New `scripts/feature_projections/expected_games.py` (modes `none` / `constant` / `history`); `availability_backtest.py` gains `--expected-games`. The **rate** projection and its `significance` gate are untouched, so this isolates the availability question (the dual-gate tension from the Wave 3 re-scope #610). Evaluated on the **additive** models, whose stored projections are leakage-free and whose budget the DoD names.

### Result — `just availability-backtest --expected-games {none,constant,history}` (2022–2025, `v14_qb_starter`)

| Mode | Avail MAE | Availability budget | Avail bias |
|------|-----------|---------------------|------------|
| none (raw rate) | 2.986 | +0.589 | −1.946 |
| constant (per-position mean games) | 2.630 | +0.232 | +1.020 (overcorrects) |
| **history (player recency-weighted games)** | **2.268** | **−0.130** | **−0.236** |

The per-player **history** haircut **clears the DoD decisively**: v14's availability budget **+0.589 → −0.130** (below even FantasyPros's −0.124), avail MAE **−0.718 (−24%)**, and the −1.95 over-projection bias collapses to −0.24 — *with the rate projection unchanged*. The same effect holds on `v8_age_regression` (budget +0.625 → −0.138), so it's not a v14 quirk.

**Guardrail:** the haircut *hurts* already-availability-aware projections (FantasyPros budget −0.124 → +0.084). Apply to pure-rate models only.

### Scope / next
This is the bar-setting stage. Follow-ups (separate PRs): (b) age/position/depth-role expected-games model; then productionise as a separate `projected_games` output column so the live VORP/auction/keeper consumers get availability-inclusive projections **without** disturbing the rate gate.

### Tests
`scripts/tests/test_expected_games.py` — leakage-safety (only prior seasons), per-player recency weighting, position-constant fallback, full-season capping. `just check-arch` passes.

Note on comparator: this PR uses `v14_qb_starter` because the DoD names its +0.589 budget and additive projections are leakage-free; the active-model comparator flip to `v31` lands in #611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)