### PR TITLE
feat(projections): store projected_games (#587 stage c1 — data layer)

### DIFF
--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -57,7 +57,8 @@ The Supabase project (`OttoneuDB`, ref `rbinbcwinchphipvcfqk`) is **shared with 
 - `model_id` UUID FK -> `projection_models`
 - `player_id` UUID FK -> `players`
 - `season` int
-- `projected_ppg` float
+- `projected_ppg` float — pure-rate per-game projection
+- `projected_games` numeric — expected games played (0–17), leakage-free recency-weighted mean of the player's prior-season `games_played` (#587 stage c). `NULL` = no estimate / full availability. Availability-inclusive PPG = `projected_ppg × min(projected_games,17)/17`.
 - `feature_values` jsonb — per-feature computed values for audit/debug
 
 **`backtest_results`**

--- a/migrations/030_add_projected_games.sql
+++ b/migrations/030_add_projected_games.sql
@@ -1,0 +1,26 @@
+-- Migration 030: Add projected_games to model_projections and player_projections.
+--
+-- The availability-inclusive backtest (#574) and #587 stage (a) showed every
+-- pure-rate PPG projection pays a large availability budget (+0.59 MAE for the
+-- production line, a −1.95 over-projection bias) because missed games are
+-- unmodeled. The robust, deterministic fix (#587 stage c) stores a per-player
+-- expected-games estimate — a leakage-free, recency-weighted mean of the
+-- player's own prior-season games_played (see scripts/feature_projections/
+-- expected_games.py, "history" mode). Consumers compute availability-inclusive
+-- production as `projected_ppg × min(projected_games, 17) / 17` without
+-- disturbing the rate projection (and its leakage-free significance gate).
+--
+-- NULL means "no estimate" (e.g. a player with no prior games): consumers treat
+-- NULL as full availability (no haircut), preserving the prior rate behaviour.
+
+ALTER TABLE model_projections ADD COLUMN projected_games numeric;
+ALTER TABLE player_projections ADD COLUMN projected_games numeric;
+
+COMMENT ON COLUMN model_projections.projected_games IS
+  'Expected games played (0-17), leakage-free recency-weighted mean of the '
+  'player''s prior-season games_played (#587). NULL = no estimate / full '
+  'availability. Consumers: availability-inclusive PPG = projected_ppg × '
+  'min(projected_games,17)/17.';
+COMMENT ON COLUMN player_projections.projected_games IS
+  'Expected games played (0-17), promoted from model_projections (#587). '
+  'NULL = no estimate / full availability.';

--- a/scripts/feature_projections/promote.py
+++ b/scripts/feature_projections/promote.py
@@ -35,7 +35,7 @@ def promote_model(model_name: str) -> int:
     while True:
         proj_res = (
             supabase.table("model_projections")
-            .select("player_id, season, projected_ppg")
+            .select("player_id, season, projected_ppg, projected_games")
             .eq("model_id", model_id)
             .range(offset, offset + page_size - 1)
             .execute()
@@ -46,6 +46,7 @@ def promote_model(model_name: str) -> int:
                 "player_id": row["player_id"],
                 "season": row["season"],
                 "projected_ppg": row["projected_ppg"],
+                "projected_games": row.get("projected_games"),
                 "projection_method": model_name,
             })
         if len(page) < page_size:

--- a/scripts/feature_projections/runner.py
+++ b/scripts/feature_projections/runner.py
@@ -18,6 +18,7 @@ from scripts.feature_projections.learned_combiner import (
     load_model_params,
 )
 from scripts.feature_projections.qb_starters import get_all_starter_ids, is_qb_starter
+from scripts.feature_projections.expected_games import build_expected_games
 
 
 def _ensure_model_in_db(supabase, model_def: ModelDefinition) -> str:
@@ -494,6 +495,16 @@ def run_model(
     # Fetch opening-day depth-chart tiers once (used across all target seasons)
     depth_charts_lookup = _build_depth_charts_lookup(supabase)
 
+    # Leakage-free expected-games per (player, target season) — the #587 stage-c
+    # availability haircut. Built from each player's prior-season games_played
+    # (recency-weighted "history" mode); seasons strictly before the target only.
+    # Stored as projected_games so consumers can compute availability-inclusive
+    # production without disturbing the rate projection (or its significance gate).
+    pos_map = dict(zip(players_df["player_id_ref"], players_df["position"]))
+    games_stats = fetch_all_rows(supabase, "player_stats", "player_id, games_played, season")
+    expected_games = build_expected_games(games_stats, pos_map, seasons, "history")
+    print(f"Expected-games (history) estimates: {len(expected_games)} (player, season)")
+
     total_records = 0
 
     for target_season in seasons:
@@ -609,11 +620,13 @@ def run_model(
                 )
 
             if projected_ppg is not None:
+                eg = expected_games.get((player_id_str, target_season))
                 records.append({
                     "model_id": model_id,
                     "player_id": player_id_str,
                     "season": target_season,
                     "projected_ppg": round(float(projected_ppg), 4),
+                    "projected_games": round(float(eg), 2) if eg is not None else None,
                     "feature_values": json.dumps(
                         {k: round(v, 4) if v is not None else None for k, v in feature_values.items()}
                     ),

--- a/web/types/supabase.ts
+++ b/web/types/supabase.ts
@@ -447,6 +447,7 @@ export type Database = {
           id: string
           model_id: string
           player_id: string
+          projected_games: number | null
           projected_ppg: number
           season: number
         }
@@ -456,6 +457,7 @@ export type Database = {
           id?: string
           model_id: string
           player_id: string
+          projected_games?: number | null
           projected_ppg: number
           season: number
         }
@@ -465,6 +467,7 @@ export type Database = {
           id?: string
           model_id?: string
           player_id?: string
+          projected_games?: number | null
           projected_ppg?: number
           season?: number
         }
@@ -609,6 +612,7 @@ export type Database = {
           created_at: string
           id: string
           player_id: string
+          projected_games: number | null
           projected_ppg: number
           projection_method: string
           season: number
@@ -618,6 +622,7 @@ export type Database = {
           created_at?: string
           id?: string
           player_id: string
+          projected_games?: number | null
           projected_ppg: number
           projection_method: string
           season: number
@@ -627,6 +632,7 @@ export type Database = {
           created_at?: string
           id?: string
           player_id?: string
+          projected_games?: number | null
           projected_ppg?: number
           projection_method?: string
           season?: number


### PR DESCRIPTION
## #587 stage (c1): store `projected_games` (data layer)

Productionises the stage-(a) availability haircut as a **data-layer column only** — no consumer/UI behaviour changes yet, so nothing on the live site moves. Stage (c2) will wire availability-inclusive value into VORP/auction/keepers (where you'll review the changed numbers).

### Context
Stage (a) (#612) showed a leakage-free, recency-weighted **history** expected-games haircut drives the production line's availability budget from +0.589 to **−0.130** (below FantasyPros) with the rate projection untouched. Stage (b) investigation found structural/linear features tie history and only a fragile nonlinear GBM edges it (~4%, hyperparameter-sensitive) — so the robust deterministic **history** estimator is the production choice.

### Changes
- **migration 030** — nullable `projected_games numeric` on `model_projections` and `player_projections` (`NULL` = no estimate / full availability). Applied to the remote DB.
- **runner** — computes the leakage-free expected-games estimate per (player, target season) via `expected_games.build_expected_games(..., "history")` and stores it next to `projected_ppg`.
- **promote** — carries `projected_games` from `model_projections` → `player_projections`.
- **TS types + db-schema doc** — column added (hand-edited types per CLAUDE.md to avoid churning `fp_*`).

Consumers will compute availability-inclusive production as `projected_ppg × min(projected_games,17)/17`. The rate projection and its significance gate are unchanged.

### Verification
- Smoke test: runner populates **894/894** v14 2025 rows, mean games 9.43 (range 1.0–17.0), sensible per-player values.
- `just typecheck`, `just check-migrations`, `scripts/tests/test_expected_games.py` (6) + architecture tests (20) all pass.

### Operational note
The active model (`v31`) gets populated in production by `just analyze` after merge — production writes run from `main`, not a branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)