### PR TITLE
feat(value): availability-inclusive VORP/surplus/arbitration (#587 stage c2)

### DIFF
--- a/web/__tests__/lib/vorp.test.ts
+++ b/web/__tests__/lib/vorp.test.ts
@@ -117,3 +117,36 @@ describe("calculateVorp — edge cases", () => {
         }
     });
 });
+
+describe("calculateVorp — availability adjustment (#587 c2)", () => {
+    test("projected_games discounts VORP but leaves displayed ppg untouched", () => {
+        // Two identical 18-PPG RBs; one is projected for only 9 games.
+        const players = [
+            makePlayer({ player_id: "durable", position: "RB", ppg: 18, projected_games: 17 }),
+            makePlayer({ player_id: "fragile", position: "RB", ppg: 18, projected_games: 9 }),
+            // Replacement-tier filler so the fixed-rank fallback has a baseline.
+            makePlayer({ player_id: "repl", position: "RB", ppg: 6, projected_games: 17 }),
+        ];
+        const { players: result } = calculateVorp(players);
+        const durable = result.find((p) => p.player_id === "durable")!;
+        const fragile = result.find((p) => p.player_id === "fragile")!;
+
+        // Displayed rate (ppg) is the raw projection for both.
+        expect(durable.ppg).toBe(18);
+        expect(fragile.ppg).toBe(18);
+        // But the fragile player's availability-adjusted value is lower.
+        expect(fragile.vorp_per_game).toBeLessThan(durable.vorp_per_game);
+        // Fragile per-game value ≈ 18×9/17 − replacement; durable ≈ 18 − replacement.
+        expect(durable.vorp_per_game - fragile.vorp_per_game).toBeCloseTo(18 - (18 * 9) / 17, 1);
+    });
+
+    test("absent projected_games is a no-op (observed-PPG pages unaffected)", () => {
+        const withGames = makePlayer({ player_id: "g", position: "WR", ppg: 14, projected_games: 17 });
+        const without = makePlayer({ player_id: "n", position: "WR", ppg: 14 });
+        const { players: a } = calculateVorp([withGames, makePlayer({ player_id: "r1", position: "WR", ppg: 5 })]);
+        const { players: b } = calculateVorp([without, makePlayer({ player_id: "r2", position: "WR", ppg: 5 })]);
+        // projected_games == 17 (full) and projected_games == undefined behave identically.
+        expect(a.find((p) => p.player_id === "g")!.vorp_per_game)
+            .toBeCloseTo(b.find((p) => p.player_id === "n")!.vorp_per_game, 5);
+    });
+});

--- a/web/lib/analysis.ts
+++ b/web/lib/analysis.ts
@@ -189,21 +189,25 @@ export async function fetchModelBacktestData(
  */
 async function buildProjectionMap(
   season: number
-): Promise<Map<string, { ppg: number; method: string }>> {
+): Promise<Map<string, { ppg: number; method: string; games: number | null }>> {
   // Paginate: a single season of player_projections (~1,289-1,458) exceeds the
   // 1000-row cap, so a plain select silently drops ~25% of projected players.
   const projectionsData = await fetchAllRows((from, to) =>
     supabase
       .from("player_projections")
-      .select("player_id, projected_ppg, projection_method")
+      .select("player_id, projected_ppg, projection_method, projected_games")
       .eq("season", season)
       .order("id").range(from, to),
   );
 
-  const projections = new Map<string, { ppg: number; method: string }>();
+  const projections = new Map<string, { ppg: number; method: string; games: number | null }>();
   if (projectionsData) {
     projectionsData.forEach(p => {
-      projections.set(p.player_id, { ppg: p.projected_ppg, method: p.projection_method });
+      projections.set(p.player_id, {
+        ppg: p.projected_ppg,
+        method: p.projection_method,
+        games: p.projected_games,
+      });
     });
   }
 
@@ -215,7 +219,7 @@ async function buildProjectionMap(
  */
 export async function fetchProjectionMap(
   season: number
-): Promise<Record<string, { ppg: number; method: string }>> {
+): Promise<Record<string, { ppg: number; method: string; games: number | null }>> {
   const map = await buildProjectionMap(season);
   return Object.fromEntries(map);
 }
@@ -226,7 +230,7 @@ export async function fetchProjectionMap(
  */
 export function buildHoverDataMap(
   players: Player[],
-  projMap: Record<string, { ppg: number; method: string }> | null = null,
+  projMap: Record<string, { ppg: number; method: string; games?: number | null }> | null = null,
   dsMap: Record<string, DraftSharksValue> | null = null
 ): Record<string, PlayerHoverData> {
   return Object.fromEntries(
@@ -310,7 +314,9 @@ export async function fetchPlayersWithProjectedPpg(
   return currentPlayers.map((player) => {
     const projEntry = projectionMap.get(player.player_id);
     if (projEntry === undefined) return player; // no projection: use observed PPG
-    return { ...player, ppg: projEntry.ppg };
+    // ppg = raw projected rate (for display); projected_games lets the value
+    // math (calculateVorp) availability-discount it without changing the rate.
+    return { ...player, ppg: projEntry.ppg, projected_games: projEntry.games };
   });
 }
 
@@ -421,6 +427,7 @@ export async function fetchAndMergeProjectedData(
       ...player,
       observed_ppg: player.ppg,
       ppg: projEntry.ppg,
+      projected_games: projEntry.games,
       projection_method: projEntry.method,
     });
   }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -35,6 +35,12 @@ export interface StatsPlayer extends RosteredPlayer {
   snaps: number;
   ppg: number;
   pps: number;
+  // Expected games played (0–17) for the projection that set `ppg`, from
+  // player_projections.projected_games (#587). Only populated on the projection
+  // value paths (arbitration/projected modes); undefined on observed-PPG pages.
+  // Value math (calculateVorp) uses it to availability-discount projected PPG;
+  // `ppg` itself stays the raw rate for display.
+  projected_games?: number | null;
 }
 
 /** Full player with stats — used by analysis pages (VORP, surplus, arb, etc.). */

--- a/web/lib/vorp.ts
+++ b/web/lib/vorp.ts
@@ -1,6 +1,24 @@
 import { MIN_GAMES, MIN_SALARY_PLAYERS, SALARY_REPLACEMENT_PERCENTILE, REPLACEMENT_LEVEL } from "./config";
 import { Player, VorpPlayer } from "./types";
 
+const FULL_SEASON_GAMES = 17;
+
+/**
+ * Availability-adjusted per-game value used for the VORP math (#587 stage c2).
+ *
+ * When a player carries a projected_games estimate (set only on the projection
+ * value paths — arbitration / projected modes), their value is discounted for
+ * expected playing-time loss: `ppg × min(games,17)/17`. This is a per-game,
+ * season-equivalent rate, so the downstream `× 17` still yields expected season
+ * points (above an also-adjusted replacement level). Observed-PPG pages never
+ * set projected_games, so this is a no-op there — `ppg` is returned unchanged.
+ * The player's own `ppg` field (the displayed rate) is never mutated.
+ */
+function availabilityAdjustedPpg(p: Player): number {
+    if (p.projected_games == null) return p.ppg;
+    return p.ppg * Math.min(p.projected_games, FULL_SEASON_GAMES) / FULL_SEASON_GAMES;
+}
+
 /**
  * Return the value at the given percentile (0–1) in a sorted numeric array.
  * Uses linear interpolation between adjacent values.
@@ -50,7 +68,7 @@ export function calculateVorp(
             const bottomTier = rostered.filter((p) => p.price <= threshold);
 
             if (bottomTier.length >= MIN_SALARY_PLAYERS) {
-                const sortedPpg = [...bottomTier.map((p) => p.ppg)].sort((a, b) => a - b);
+                const sortedPpg = [...bottomTier.map((p) => availabilityAdjustedPpg(p))].sort((a, b) => a - b);
                 replacementPpg[pos] = percentile(sortedPpg, 0.5); // median
                 replacementN[pos] = bottomTier.length;
                 continue;
@@ -63,9 +81,9 @@ export function calculateVorp(
             .sort((a, b) => b.total_points - a.total_points);
 
         if (posPlayers.length >= rank) {
-            replacementPpg[pos] = posPlayers[rank - 1].ppg;
+            replacementPpg[pos] = availabilityAdjustedPpg(posPlayers[rank - 1]);
         } else if (posPlayers.length > 0) {
-            replacementPpg[pos] = posPlayers[posPlayers.length - 1].ppg;
+            replacementPpg[pos] = availabilityAdjustedPpg(posPlayers[posPlayers.length - 1]);
         } else {
             replacementPpg[pos] = 0;
         }
@@ -74,7 +92,9 @@ export function calculateVorp(
 
     const vorpPlayers: VorpPlayer[] = qualified.map((p) => {
         const repPpg = replacementPpg[p.position] ?? 0;
-        const vorpPerGame = p.ppg - repPpg;
+        // Availability-adjusted value above replacement (#587 c2). On observed-PPG
+        // pages availabilityAdjustedPpg(p) === p.ppg, so this is unchanged there.
+        const vorpPerGame = availabilityAdjustedPpg(p) - repPpg;
         return {
             ...p,
             replacement_ppg: repPpg,


### PR DESCRIPTION
## #587 stage (c2): availability-inclusive value (VORP / surplus / arbitration)

**⚠️ Not for auto-merge — this is the before/after review.** It changes the value numbers on the projection-driven pages (arbitration projected/raw targets).

### What it does
Wires `projected_games` (#613) into the value math at the single chokepoint — `calculateVorp` (behind VORP → surplus → dollar value → arbitration targets). Each projection's value is discounted for expected playing-time loss: `ppg × min(projected_games,17)/17`, applied to both the replacement level and value-above-replacement. The displayed `ppg` (the rate) is **untouched**, so "Proj PPG"/efficiency views still show the raw projection.

**Self-gating:** `projected_games` is only set on the projection value paths (arbitration). `/value` VORP & Surplus use observed end-of-season PPG (`fetchPlayersEndOfSeason`) and never set it, so they're **byte-for-byte unchanged** — availability is already baked into actuals there. Verified: `availabilityAdjustedPpg(p) === p.ppg` when `projected_games` is absent.

### Impact on the live 2026 projections (the review)
Among 89 projections ≥10 PPG: mean expected games 14.0, mean value discount 2.27 PPG; 68/89 get some haircut, 21 durable players unchanged. Largest discounts:

| Player | Pos | Proj PPG | E[games] | Adj PPG |
|---|---|---|---|---|
| Deshaun Watson | QB | 14.05 | 6.6 | 5.45 |
| Anthony Richardson | QB | 11.77 | 4.9 | 3.39 |
| Kyler Murray | QB | 15.80 | 8.9 | 8.27 |
| Jayden Daniels | QB | 17.15 | 10.3 | 10.42 |
| Malik Nabers | WR | 12.19 | 7.7 | 5.50 |

### Known limitation (please weigh)
A pure-history estimator correctly discounts chronically-unavailable vets (Watson 6/6/7/0 games, Wilson) but **over-penalizes**:
- **Ascending young players** whose thin/partial history reflects a *rising role*, not durability (Penix 5→9 games, Skattebo rookie 8).
- **Players off a single injury year** (Daniels 17→7, Purdy 9).

The aggregate availability-backtest still decisively validates the haircut (#612: budget +0.59 → −0.13, avail MAE −24%) — it helps on average, and the prior behaviour (assume everyone plays 17) is clearly worse. But the ascending-player wart is real. Options: ship as-is (validated on average), or add a thin-history/role-ramp guard first (re-opens the stage-(b) modeling we concluded against), or don't apply to arbitration.

### Tests
9 vorp + full 210-test web lib suite + `check-arch` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)