### PR TITLE
feat(eval): thin-history guard for the expected-games haircut (#587 c2 review)

### DIFF
--- a/docs/generated/experiment-log.md
+++ b/docs/generated/experiment-log.md
@@ -51,10 +51,33 @@ budget +0.589 → −0.130 (below even FantasyPros's −0.124) and the −1.95
 over-projection bias collapses to −0.24, with the rate projection unchanged. The
 same effect holds on `v8_age_regression` (budget +0.625 → −0.138), so it is not a
 v14 quirk. **Guardrail:** the haircut *hurts* already-availability-aware projections
-(FantasyPros budget −0.124 → +0.084) — apply it to pure-rate models only. Next
-increments: (b) age/position/depth-role expected-games model, then productionise as
-a separate `projected_games` output column so the live VORP/auction consumers get
-availability-inclusive projections without disturbing the rate gate.
+(FantasyPros budget −0.124 → +0.084) — apply it to pure-rate models only.
+
+**Stage (b) — structural expected-games model: NEGATIVE.** Age/position/depth-role
+features (linear) tie plain history on games-MAE (3.59→3.58); a nonlinear GBM gets
+a fragile ~4% that is hyperparameter-sensitive and burns confirmation looks. Plain
+history is the robust production estimator; no trained model. (Matches the issue's
+own staging — injury/structural features only if (b) leaves budget; it doesn't.)
+
+**Stage (c) — productionised** as the `projected_games` column (PR #613) and
+availability-inclusive value in VORP/surplus/arbitration (PR #614).
+
+**Thin-history guard (c2 review).** The before/after review showed plain history
+over-penalises *ascending young players* (thin/partial history reflects a rising
+role, not injury — e.g. Penix, Skattebo, Daniels). Empirically, any guard that
+lifts them costs games-MAE because the thin-history cohort genuinely under-plays on
+average (a blunt "young ⇒ full 17 games" gate worsens games-MAE 3.59→4.74). The
+chosen guard floors only players with <3 prior played seasons at 12 games
+(`YOUNG_PLAYER_GAMES_FLOOR`): vets keep the full discount, young players aren't
+read as injury risks. Cost: v14 availability budget −0.130 → **−0.042** (still well
+below the +0.589 no-modeling baseline; avail MAE 2.986 → 2.356, −21%; bias −1.95 →
+−0.46) — a deliberate accuracy-for-fairness trade on the young cohort.
+
+| Mode | Avail MAE | Budget | Avail bias |
+|------|-----------|--------|------------|
+| none (raw rate) | 2.986 | +0.589 | −1.946 |
+| history (unguarded) | 2.268 | −0.130 | −0.236 |
+| **history + thin-history guard (production)** | **2.356** | **−0.042** | **−0.464** |
 
 ## Historical (in-sample) log — pre-audit, deltas not reliable
 

--- a/scripts/feature_projections/expected_games.py
+++ b/scripts/feature_projections/expected_games.py
@@ -31,6 +31,22 @@ FULL_SEASON_GAMES = 17
 # Most-recent-first recency weights for the player-history mode (up to 3 seasons).
 RECENCY_WEIGHTS = [0.6, 0.3, 0.1]
 
+# Thin-history guard (#587 c2 review). A player's own recency-weighted games are
+# the best *average* availability predictor, but for players without an
+# established multi-season track record a low value usually reflects a *role
+# ramp* (rookies/sophomores easing into a starting job) rather than injury
+# proneness — so a pure-history haircut over-penalises ascending young players
+# (e.g. a 2nd-year QB who started 9 games as a rookie is not a 9-game injury
+# risk). We therefore floor the estimate for players with fewer than
+# YOUNG_PLAYER_MAX_PRIOR_SEASONS prior *played* seasons at YOUNG_PLAYER_GAMES_FLOOR
+# (≈70% of a season): they can still be discounted, just not below a reasonable
+# starter floor until they've accrued a durability record. Established players
+# (≥ the threshold) keep the full history discount, so chronic-injury vets are
+# unaffected. This costs a little games-MAE accuracy (+~0.3) on the thin-history
+# cohort in exchange for not mis-valuing ascending players.
+YOUNG_PLAYER_MAX_PRIOR_SEASONS = 3
+YOUNG_PLAYER_GAMES_FLOOR = 12.0
+
 MODES = ("none", "constant", "history")
 
 
@@ -127,7 +143,19 @@ def build_expected_games(
             if mode == "constant":
                 eg = constant
             else:  # history
-                player_eg = _player_recency_games(by_player.get(pid, []))
-                eg = player_eg if player_eg is not None else constant
+                player_rows = by_player.get(pid, [])
+                player_eg = _player_recency_games(player_rows)
+                if player_eg is None:
+                    eg = constant
+                else:
+                    eg = player_eg
+                    # Thin-history guard: floor ascending young players (few prior
+                    # played seasons) so a role-ramp history isn't read as injury
+                    # risk. Established players keep the full history discount.
+                    n_played = sum(
+                        1 for r in player_rows if int(r.get("games_played", 0) or 0) >= 1
+                    )
+                    if n_played < YOUNG_PLAYER_MAX_PRIOR_SEASONS:
+                        eg = max(eg, YOUNG_PLAYER_GAMES_FLOOR)
             out[(pid, int(target_season))] = min(eg, float(full_season))
     return out

--- a/scripts/tests/test_expected_games.py
+++ b/scripts/tests/test_expected_games.py
@@ -2,6 +2,7 @@
 
 from scripts.feature_projections.expected_games import (
     FULL_SEASON_GAMES,
+    YOUNG_PLAYER_GAMES_FLOOR,
     build_expected_games,
 )
 
@@ -28,8 +29,10 @@ def test_mode_none_returns_empty():
 def test_leakage_free_only_uses_prior_seasons():
     # Target 2023 may only see 2022 rows; rb1's 2023 (17) must not leak in.
     eg = build_expected_games(_stats(), POS_MAP, [2023], "history")
-    assert eg[("rb1", 2023)] == 16  # only 2022 season available
-    assert eg[("rb2", 2023)] == 4
+    assert eg[("rb1", 2023)] == 16  # only 2022 season available (16 > young floor)
+    # rb2 has 1 prior played season (2022=4) → thin-history guard floors it at 12,
+    # not 4. (The leakage check is rb1==16: 2023's 17 did not leak in.)
+    assert eg[("rb2", 2023)] == 12
 
 
 def test_history_is_per_player_recency_weighted():
@@ -63,3 +66,28 @@ def test_history_falls_back_to_position_constant():
     eg = build_expected_games(stats, POS_MAP, [2024], "history")
     # rb2 fell back to the RB constant (only rb1's 17 counts; rb2's 0 excluded).
     assert eg[("rb2", 2024)] == 17
+
+
+def test_thin_history_young_player_is_floored():
+    # An ascending young RB with two low (role-ramp) seasons — k=2 < 3 prior
+    # played seasons — is floored at YOUNG_PLAYER_GAMES_FLOOR, not its
+    # recency-weighted ~6 games.
+    stats = [
+        {"player_id": "young", "season": 2023, "games_played": 5},
+        {"player_id": "young", "season": 2024, "games_played": 7},
+    ]
+    eg = build_expected_games(stats, {"young": "RB"}, [2025], "history")
+    assert eg[("young", 2025)] == YOUNG_PLAYER_GAMES_FLOOR
+
+
+def test_established_chronic_player_is_not_floored():
+    # A vet with 3+ played seasons all below the floor keeps the full history
+    # discount — the guard only protects thin-history (young) players.
+    stats = [
+        {"player_id": "vet", "season": 2022, "games_played": 6},
+        {"player_id": "vet", "season": 2023, "games_played": 6},
+        {"player_id": "vet", "season": 2024, "games_played": 7},
+    ]
+    eg = build_expected_games(stats, {"vet": "RB"}, [2025], "history")
+    # Recency-weighted ~6.4 games, well below the 12 floor, and NOT floored.
+    assert eg[("vet", 2025)] < YOUNG_PLAYER_GAMES_FLOOR


### PR DESCRIPTION
## #587 c2 review: thin-history guard for the expected-games haircut

Addresses the before/after concern on #614: the pure-history availability haircut **over-penalises ascending young players**. Thin/partial game history reflects a *role ramp* (a 2nd-year QB who started 9 games as a rookie), not injury proneness — so Penix, Skattebo, Daniels etc. were getting valued like injury risks.

### Why a targeted guard (not a blunt gate)
There is **no free-lunch guard** — the thin-history cohort genuinely under-plays on average (most are backups / cut mid-season), so any lift costs games-MAE. Measured on 2022–2025:
- A blunt "young ⇒ assume full 17 games" gate worsens games-MAE **3.59 → 4.74**.
- Shrinking toward the position mean barely moves the stars (the position mean is itself low).

### The guard
Floor only players with **< 3 prior played seasons** at **12 games (≈70% availability)** (`YOUNG_PLAYER_MAX_PRIOR_SEASONS` / `YOUNG_PLAYER_GAMES_FLOOR`). Established players (≥3 seasons) keep the **full** history discount, so chronic-injury vets are unaffected.

Effect on the flagged 2026 projections: Penix/Skattebo/Daniels/Nabers lifted to 12; Watson (6.6), Purdy (11.5), Richardson (4.9) unchanged.

### Re-validation (availability-backtest, v14, leakage-free, 2022–2025)
| Mode | Avail MAE | Budget | Avail bias |
|---|---|---|---|
| none (raw rate) | 2.986 | +0.589 | −1.946 |
| history (unguarded) | 2.268 | −0.130 | −0.236 |
| **history + guard (production)** | **2.356** | **−0.042** | **−0.464** |

The guard costs a little of the win (budget −0.130 → −0.042) but stays well below the +0.589 no-modeling baseline (avail MAE −21%, bias −1.95→−0.46) — a deliberate accuracy-for-fairness trade on the young cohort that does **not** undo #587.

### Tests
Floored thin-history player, un-floored established chronic player, updated leakage test; full Python suite (200) passes.

### Sequencing
Merge this → run `just analyze` (repopulates `projected_games` with guarded values) → #614 then consumes them. (#614's web code is unchanged by this; it just reads the column.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)