### PR TITLE
feat(harness): autonomous-operation layers — allowlist, permission-prompt metrics, devcontainer

### DIFF
--- a/.claude/commands/review-permission-gates.md
+++ b/.claude/commands/review-permission-gates.md
@@ -70,3 +70,4 @@ Display the table from Step 3, then list concrete proposed changes:
 - This output feeds directly into the retro Step 2 table — surface impactful items as `approval-gate` friction points.
 - Do not flag commands that are already in the allowlist — only flag ones that actually needed manual approval.
 - Prefer `just` targets over raw allowlist entries for anything that wraps a complex or project-specific command. Prefer raw allowlist entries for simple, safe system utilities (e.g. `which`, `mkdir`).
+- **Cross-session data:** this skill scans only the current session. For the historical view (weekly prompt rate, top prompted families across all sessions, regression check), run `just permission-report` — permission prompts are logged by the Notification hook to `~/.claude/metrics/ottoneu_db/permission_prompts.jsonl`. See [docs/references/autonomous-operation.md](../../docs/references/autonomous-operation.md).

--- a/.claude/hooks/log_permission_prompt.py
+++ b/.claude/hooks/log_permission_prompt.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Notification-hook logger: records every permission prompt Claude Code shows.
+
+Registered under the "Notification" hook event in .claude/settings.local.json.
+Claude Code fires a Notification whenever it needs the user's permission to run
+a tool. Approved prompts leave no trace in transcripts (only denials do), so
+this hook is the only durable record of approval friction.
+
+Each event is appended as one JSON line to
+~/.claude/metrics/ottoneu_db/permission_prompts.jsonl, enriched with the tool
+name and input of the pending tool call (recovered from the transcript tail).
+
+Aggregate with `just permission-report` (.claude/hooks/permission_report.py).
+
+Stdlib only; must stay compatible with Python 3.9 (macOS system python3).
+Never raises: a broken metrics hook must not block real work.
+"""
+import datetime
+import json
+import os
+import sys
+
+LOG_DIR = os.path.expanduser("~/.claude/metrics/ottoneu_db")
+LOG_FILE = os.path.join(LOG_DIR, "permission_prompts.jsonl")
+
+
+def last_pending_tool_use(transcript_path):
+    """Return (tool_name, tool_input) of the most recent tool_use in the transcript.
+
+    When a permission prompt fires, the pending call is the last assistant
+    tool_use block written to the transcript, so the tail is enough.
+    """
+    try:
+        with open(transcript_path, "rb") as f:
+            f.seek(0, os.SEEK_END)
+            f.seek(max(0, f.tell() - 256 * 1024))
+            tail = f.read().decode("utf-8", errors="replace").splitlines()
+    except OSError:
+        return None, None
+    for line in reversed(tail):
+        try:
+            rec = json.loads(line)
+        except ValueError:
+            continue
+        content = (rec.get("message") or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        for block in reversed(content):
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                return block.get("name"), block.get("input")
+    return None, None
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except ValueError:
+        return
+    message = payload.get("message") or ""
+    # Notification also fires for idle reminders etc. — keep permission prompts only.
+    if "permission" not in message.lower():
+        return
+
+    tool_name, tool_input = last_pending_tool_use(payload.get("transcript_path") or "")
+    event = {
+        "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "session_id": payload.get("session_id"),
+        "cwd": payload.get("cwd"),
+        "message": message,
+        "tool_name": tool_name,
+        "tool_input": tool_input,
+    }
+    os.makedirs(LOG_DIR, exist_ok=True)
+    with open(LOG_FILE, "a") as f:
+        f.write(json.dumps(event) + "\n")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass

--- a/.claude/hooks/permission_report.py
+++ b/.claude/hooks/permission_report.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Permission-friction report: prompts per 100 tool calls, trend, regressions.
+
+Joins two data sources:
+  numerator   ~/.claude/metrics/ottoneu_db/permission_prompts.jsonl
+              (written by log_permission_prompt.py — one line per permission
+              prompt Claude Code showed)
+  denominator ~/.claude/projects/-Users-alexmonroe-dev-ottoneu-db/*.jsonl
+              (Claude Code transcripts — every tool_use, prompted or not)
+
+Usage:
+  just permission-report                # last 56 days, markdown to stdout
+  just permission-report --days 14
+  just permission-report --check       # exit 2 if the trailing-7d prompt rate
+                                       # regressed >1.5x vs the prior-28d baseline
+
+Stdlib only; Python 3.9 compatible (macOS system python3).
+"""
+import argparse
+import datetime
+import glob
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+
+EVENTS_FILE = os.path.expanduser("~/.claude/metrics/ottoneu_db/permission_prompts.jsonl")
+TRANSCRIPTS_GLOB = os.path.expanduser(
+    "~/.claude/projects/-Users-alexmonroe-dev-ottoneu-db/*.jsonl"
+)
+REGRESSION_FACTOR = 1.5
+REGRESSION_MIN_PROMPTS = 10
+
+
+def parse_ts(value):
+    if not value:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def load_prompt_events(since):
+    events = []
+    if not os.path.exists(EVENTS_FILE):
+        return events
+    with open(EVENTS_FILE) as f:
+        for line in f:
+            try:
+                ev = json.loads(line)
+            except ValueError:
+                continue
+            ts = parse_ts(ev.get("ts"))
+            if ts and ts >= since:
+                ev["_ts"] = ts
+                events.append(ev)
+    return events
+
+
+def load_tool_call_counts(since):
+    """Per-day counts of all tool_use blocks (and Bash specifically) from transcripts."""
+    per_day = defaultdict(lambda: {"tools": 0, "bash": 0})
+    for path in glob.glob(TRANSCRIPTS_GLOB):
+        try:
+            if datetime.datetime.fromtimestamp(
+                os.path.getmtime(path), tz=datetime.timezone.utc
+            ) < since:
+                continue
+        except OSError:
+            continue
+        with open(path, errors="replace") as f:
+            for line in f:
+                if '"tool_use"' not in line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except ValueError:
+                    continue
+                ts = parse_ts(rec.get("timestamp"))
+                if not ts or ts < since:
+                    continue
+                content = (rec.get("message") or {}).get("content")
+                if not isinstance(content, list):
+                    continue
+                day = ts.date().isoformat()
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        per_day[day]["tools"] += 1
+                        if block.get("name") == "Bash":
+                            per_day[day]["bash"] += 1
+    return per_day
+
+
+def command_family(ev):
+    """Group a prompted Bash command by its first meaningful words."""
+    tool = ev.get("tool_name")
+    if tool and tool != "Bash":
+        return tool
+    cmd = ((ev.get("tool_input") or {}).get("command") or "").strip()
+    if not cmd:
+        return "Bash(unknown)"
+    first = cmd.splitlines()[0]
+    words = re.split(r"\s+", first)
+    return " ".join(words[:2])[:60] or "Bash(unknown)"
+
+
+def weekly_rollup(events, per_day):
+    weeks = defaultdict(lambda: {"prompts": 0, "tools": 0, "bash": 0})
+    for ev in events:
+        weeks[ev["_ts"].date().isocalendar()[:2]]["prompts"] += 1
+    for day, counts in per_day.items():
+        key = datetime.date.fromisoformat(day).isocalendar()[:2]
+        weeks[key]["tools"] += counts["tools"]
+        weeks[key]["bash"] += counts["bash"]
+    return weeks
+
+
+def window_rate(events, per_day, start, end):
+    prompts = sum(1 for ev in events if start <= ev["_ts"] < end)
+    tools = sum(
+        c["tools"]
+        for d, c in per_day.items()
+        if start.date().isoformat() <= d < end.date().isoformat()
+    )
+    rate = 100.0 * prompts / tools if tools else 0.0
+    return prompts, tools, rate
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--days", type=int, default=56, help="lookback window (default 56)")
+    ap.add_argument("--check", action="store_true", help="exit 2 on regression")
+    args = ap.parse_args()
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    since = now - datetime.timedelta(days=args.days)
+    events = load_prompt_events(since)
+    per_day = load_tool_call_counts(since)
+
+    print("# Permission-Prompt Friction Report")
+    print()
+    print(
+        "Generated {} | window: last {} days | prompts logged: {}".format(
+            now.date().isoformat(), args.days, len(events)
+        )
+    )
+    print()
+    if not events and not os.path.exists(EVENTS_FILE):
+        print(
+            "No prompt events recorded yet ({} missing).\n"
+            "The Notification hook in .claude/settings.local.json writes it — "
+            "events accumulate from the first session after that hook landed.".format(
+                EVENTS_FILE
+            )
+        )
+        print()
+
+    print("## Weekly trend (prompts per 100 tool calls)")
+    print()
+    print("| ISO week | Prompts | Tool calls | Bash calls | Prompt rate |")
+    print("|----------|--------:|-----------:|-----------:|------------:|")
+    weeks = weekly_rollup(events, per_day)
+    for key in sorted(weeks):
+        row = weeks[key]
+        rate = 100.0 * row["prompts"] / row["tools"] if row["tools"] else 0.0
+        print(
+            "| {}-W{:02d} | {} | {} | {} | {:.1f} |".format(
+                key[0], key[1], row["prompts"], row["tools"], row["bash"], rate
+            )
+        )
+    print()
+
+    if events:
+        print("## Top prompted command families (window)")
+        print()
+        print("| Family | Prompts |")
+        print("|--------|--------:|")
+        for fam, n in Counter(command_family(ev) for ev in events).most_common(20):
+            print("| `{}` | {} |".format(fam.replace("|", "\\|"), n))
+        print()
+        print("Use these rows to pick the next allowlist entry or `just` recipe")
+        print("(see docs/references/autonomous-operation.md).")
+        print()
+
+    # Regression check: trailing 7d vs the 28d before that.
+    p7, t7, r7 = window_rate(events, per_day, now - datetime.timedelta(days=7), now)
+    p28, t28, r28 = window_rate(
+        events, per_day, now - datetime.timedelta(days=35), now - datetime.timedelta(days=7)
+    )
+    print("## Regression check")
+    print()
+    print(
+        "- trailing 7d: {} prompts / {} tool calls = {:.1f} per 100".format(p7, t7, r7)
+    )
+    print(
+        "- prior 28d baseline: {} prompts / {} tool calls = {:.1f} per 100".format(
+            p28, t28, r28
+        )
+    )
+    regressed = (
+        p7 >= REGRESSION_MIN_PROMPTS and r28 > 0 and r7 > REGRESSION_FACTOR * r28
+    )
+    if regressed:
+        print(
+            "- **REGRESSION**: trailing rate is >{}x the baseline. Run "
+            "/review-permission-gates and check recent settings/Justfile changes.".format(
+                REGRESSION_FACTOR
+            )
+        )
+    else:
+        print("- OK: no regression detected.")
+    if args.check and regressed:
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -98,7 +98,37 @@
       "mcp__supabase__list_tables",
       "mcp__puppeteer__puppeteer_click",
       "mcp__puppeteer__puppeteer_evaluate",
-      "mcp__puppeteer__puppeteer_screenshot"
+      "mcp__puppeteer__puppeteer_screenshot",
+      "Read(//Users/alexmonroe/.claude/**)",
+      "Bash(cd:*)",
+      "Bash(echo:*)",
+      "Bash(printf:*)",
+      "Bash(sed -n:*)",
+      "Bash(pgrep:*)",
+      "Bash(ps:*)",
+      "Bash(time:*)",
+      "Bash(timeout:*)",
+      "Bash(touch:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)",
+      "Bash(tr:*)",
+      "Bash(cut:*)",
+      "Bash(date:*)",
+      "Bash(basename:*)",
+      "Bash(dirname:*)",
+      "Bash(true)",
+      "Bash(node:*)",
+      "Bash(python3:*)",
+      "Bash(venv/bin/python:*)",
+      "Bash(/Users/alexmonroe/dev/ottoneu_db/venv/bin/python:*)",
+      "Bash(/Users/alexmonroe/dev/ottoneu_db/venv/bin/pytest:*)",
+      "Bash(venv/bin/pip install:*)",
+      "Bash(/Users/alexmonroe/dev/ottoneu_db/venv/bin/pip install:*)"
+    ],
+    "deny": [
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(sudo:*)"
     ]
   },
   "enabledMcpjsonServers": [
@@ -108,6 +138,17 @@
     "github"
   ],
   "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/log_permission_prompt.py\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+# Python 3.9 to match the project's target version (CLAUDE.md: no 3.10+ syntax).
+FROM mcr.microsoft.com/devcontainers/python:3.9-bookworm
+
+# Firewall tooling + just (build runner used by every project recipe)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends iptables ipset dnsutils \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+       | bash -s -- --to /usr/local/bin
+
+# Playwright/Chromium system dependencies for the scraping pipeline
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
+       libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+       libgbm1 libasound2 libpango-1.0-0 libcairo2 \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/allowed-domains.txt
+++ b/.devcontainer/allowed-domains.txt
@@ -1,0 +1,36 @@
+# Egress allowlist for init-firewall.sh — one domain per line, comments with '#'.
+# The firewall resolves each domain at container start and allows only those IPs.
+# Wildcards are NOT supported: list the concrete host (e.g. your Supabase project
+# host, found in SUPABASE_URL in .env — looks like abcdefgh.supabase.co).
+
+# Claude Code / Anthropic
+api.anthropic.com
+statsig.anthropic.com
+console.anthropic.com
+sentry.io
+o1158394.ingest.sentry.io
+
+# Package registries
+registry.npmjs.org
+pypi.org
+files.pythonhosted.org
+
+# GitHub (clone/push, gh CLI, nflverse release downloads)
+github.com
+api.github.com
+raw.githubusercontent.com
+objects.githubusercontent.com
+codeload.github.com
+release-assets.githubusercontent.com
+
+# Playwright browser download (post-create)
+cdn.playwright.dev
+playwright.azureedge.net
+
+# Project data sources (scrapers)
+ottoneu.fangraphs.com
+www.draftsharks.com
+www.fantasypros.com
+
+# Supabase — REPLACE with your project host from SUPABASE_URL in .env
+# <project-ref>.supabase.co

--- a/.devcontainer/allowed-domains.txt
+++ b/.devcontainer/allowed-domains.txt
@@ -32,5 +32,5 @@ ottoneu.fangraphs.com
 www.draftsharks.com
 www.fantasypros.com
 
-# Supabase — REPLACE with your project host from SUPABASE_URL in .env
-# <project-ref>.supabase.co
+# Supabase (project ref rbinbcwinchphipvcfqk)
+rbinbcwinchphipvcfqk.supabase.co

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "ottoneu-db autonomous",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=ottoneu-claude-config,target=/home/vscode/.claude,type=volume"
+  ],
+  "containerEnv": {
+    "DEVCONTAINER": "true"
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "postStartCommand": "sudo bash .devcontainer/init-firewall.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": ["anthropic.claude-code", "dbaeumer.vscode-eslint"]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,11 @@
   "postStartCommand": "sudo bash .devcontainer/init-firewall.sh",
   "customizations": {
     "vscode": {
-      "extensions": ["anthropic.claude-code", "dbaeumer.vscode-eslint"]
+      "extensions": ["anthropic.claude-code", "dbaeumer.vscode-eslint"],
+      "settings": {
+        "claudeCode.allowDangerouslySkipPermissions": true,
+        "claudeCode.initialPermissionMode": "bypassPermissions"
+      }
     }
   }
 }

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Default-deny egress firewall for the autonomous devcontainer.
+# Adapted from Anthropic's claude-code reference devcontainer: resolves the
+# domains in allowed-domains.txt into an ipset and drops all other outbound
+# traffic. This is the safety boundary that makes
+# `claude --dangerously-skip-permissions` reasonable to run in here.
+#
+# Run as root (postStartCommand does `sudo bash .devcontainer/init-firewall.sh`).
+set -euo pipefail
+
+DOMAINS_FILE="$(dirname "$0")/allowed-domains.txt"
+
+iptables -F OUTPUT
+iptables -F INPUT
+ipset destroy allowed-out 2>/dev/null || true
+ipset create allowed-out hash:ip
+
+# Resolve every allowlisted domain to IPs (re-run this script to refresh).
+while IFS= read -r line; do
+    domain="${line%%#*}"
+    domain="$(echo "$domain" | tr -d '[:space:]')"
+    [ -z "$domain" ] && continue
+    for ip in $(dig +short A "$domain" | grep -E '^[0-9.]+$' || true); do
+        ipset add allowed-out "$ip" 2>/dev/null || true
+    done
+done < "$DOMAINS_FILE"
+
+# Loopback + established flows
+iptables -A INPUT  -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+iptables -A INPUT  -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# DNS (needed to resolve the allowlisted hosts at request time)
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+
+# Host gateway (devcontainer plumbing: VS Code server, port forwarding)
+GATEWAY="$(ip route | awk '/default/ {print $3; exit}')"
+if [ -n "$GATEWAY" ]; then
+    iptables -A OUTPUT -d "$GATEWAY" -j ACCEPT
+fi
+
+# Allowlisted destinations only
+iptables -A OUTPUT -m set --match-set allowed-out dst -j ACCEPT
+
+# Everything else: reject outbound, drop unsolicited inbound
+iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
+iptables -P INPUT DROP
+
+echo "Firewall active: $(ipset list allowed-out | grep -c '^[0-9]') IPs allowed."
+echo "Verify: 'curl -sI https://api.anthropic.com' should work; 'curl -sI https://example.com' should fail."

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# One-time container setup: Claude Code CLI + project dependencies.
+set -euo pipefail
+
+npm install -g @anthropic-ai/claude-code
+
+# Mirror `just install` (Justfile) — venv lives inside the container workspace.
+python3 -m venv venv
+venv/bin/pip install --upgrade pip
+venv/bin/pip install -r requirements.txt
+venv/bin/pip install -e .
+venv/bin/playwright install chromium || echo "WARN: playwright chromium download blocked — add cdn.playwright.dev to allowed-domains.txt and re-run"
+(cd web && npm install)
+
+echo
+echo "Setup complete. Authenticate once with 'claude' (credentials persist in the"
+echo "ottoneu-claude-config volume), then run:"
+echo "  claude --dangerously-skip-permissions"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Comprehensive database and analytics platform for Ottoneu Fantasy Football Leagu
 - **Ottoneu rules:** See [docs/references/ottoneu-rules.md](docs/references/ottoneu-rules.md) for scoring, roster, salary cap, and arbitration rules
 - **Ottoneu strategy:** See [docs/references/ottoneu-strategy.md](docs/references/ottoneu-strategy.md) for format economics (surplus value, raise treadmill, Superflex QB premium, arbitration tax) and the reasoning checklist used by the `/ottoneu-roster-question` skill. Use the `/ottoneu-roster-question` skill (which loads this + live data via `just roster-context`) to answer advanced keeper/trade/auction/arbitration questions.
 - **Environment:** See [docs/references/environment-variables.md](docs/references/environment-variables.md) for `.env` setup
+- **Autonomous operation:** See [docs/references/autonomous-operation.md](docs/references/autonomous-operation.md) for the permission-friction strategy — allowlist design, prompt-rate metrics (`just permission-report`), and the `.devcontainer/` for safely running `claude --dangerously-skip-permissions`
 - **Season cycle:** See [docs/exec-plans/season-cycle.md](docs/exec-plans/season-cycle.md) — the site rolls between Ottoneu seasons from the `league_calendar` table; the current season is resolved at runtime via `scripts/season.py` and `web/lib/season.ts`, not from static config
 - **Projection Accuracy Plan:** See [docs/exec-plans/projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md) for the 4-phase accuracy improvement roadmap (Issues #271-#285)
 - **Projection Accuracy:** The gate for any projection change is the **leakage-free held-out harness** — `just holdout-eval` (#572/#594) + `just significance` (#573/#594), not the in-sample `just accuracy-report` (which is a secondary diagnostic only). See Projection Model Update Requirements below.
@@ -69,6 +70,7 @@ docs/
 │   ├── [rookie-backtest.md](docs/generated/rookie-backtest.md)             # Rookie (0-history) projection backtest — draft_capital vs baselines
 │   └── [segment-analysis.md](docs/generated/segment-analysis.md)            # Segmented projection accuracy analysis
 ├── references/
+│   ├── [autonomous-operation.md](docs/references/autonomous-operation.md)        # Permission-friction strategy: allowlist, prompt metrics, devcontainer
 │   ├── environment-variables.md       # .env and .env.local variable reference
 │   ├── ottoneu-rules.md               # Scoring, roster, salary cap, arbitration rules
 │   └── ottoneu-strategy.md            # Format economics + AI reasoning checklist for roster construction

--- a/Justfile
+++ b/Justfile
@@ -99,6 +99,10 @@ check-migrations:
 check-docs:
     {{python}} scripts/check_docs_freshness.py
 
+# Permission-friction report: prompt rate trend + regression check (see docs/references/autonomous-operation.md)
+permission-report *args:
+    python3 .claude/hooks/permission_report.py {{args}}
+
 # Full CI suite (lint + typecheck + tests + doc checks)
 ci: lint typecheck test check-docs
 

--- a/docs/references/autonomous-operation.md
+++ b/docs/references/autonomous-operation.md
@@ -1,0 +1,160 @@
+# Autonomous Operation — Permissions, Metrics, and Isolation
+
+Goal: Claude Code sessions that run **safely with no human intervention**. This
+document describes the layered approach, how approval friction is measured, and
+how to interpret/act on the metrics.
+
+## The layered model
+
+A permission allowlist alone cannot deliver "safe + zero prompts": any list
+broad enough to never prompt is broad enough to be no security boundary at all
+(this repo already allowlists `just:*`, and `just py "<snippet>"` runs
+arbitrary Python — so arbitrary code execution is *already* granted). The
+allowlist is therefore treated as **friction control**, and actual safety comes
+from outer layers:
+
+| Layer | Mechanism | What it buys |
+|-------|-----------|--------------|
+| 1 | Allowlist + `just`-first habits (`.claude/settings.local.json`, `Justfile`) | Few prompts in normal supervised sessions |
+| 2 | Prompt-rate instrumentation (`.claude/hooks/`, `just permission-report`) | Visibility: measure friction, catch regressions |
+| 3 | Claude Code native sandbox (`sandbox.enabled` in settings) | OS-level (Seatbelt) containment on the host — optional middle ground |
+| 4 | Devcontainer + egress firewall (`.devcontainer/`) | True isolation: run `claude --dangerously-skip-permissions` safely |
+
+What the allowlist deliberately does **not** auto-approve, at any layer below 4:
+`rm`, `sed -i`, non-localhost `curl`, `brew`, and anything matching the deny
+list (`git push --force`, `sudo`). Production-data blast radius
+(`mcp__supabase__execute_sql` / `apply_migration`) is allowlisted for workflow
+reasons — if that ever feels wrong, move those two to an `ask` list.
+
+## Layer 1 — Allowlist design notes
+
+Transcript mining (June 2026, 31 sessions, ~1,650 Bash calls) showed ~80% of
+prompts came from a handful of innocuous patterns:
+
+- **`cd <repo> && …` compound commands** — Claude Code permission-checks every
+  segment of a compound command, and `cd` was not allowlisted, so *every*
+  `cd X && <allowed command>` prompted. This was the single largest source.
+- `echo`/`printf` banners, `sed -n` (read-only paging), `pgrep`, `time`,
+  `timeout`, `tr`, `cut`, `date`.
+- Ad-hoc `venv/bin/python …` invocations not matching the old narrow prefixes
+  (probe scripts, heredocs, absolute paths from worktrees).
+
+All of these are now allowlisted. `venv/bin/python:*` and `node:*` are broad,
+but per the layered model they add no capability beyond the pre-existing
+`just py` escape hatch. Denials in 31 sessions of history: 3 — prompts here are
+nearly pure friction, not safety catches.
+
+Rules of thumb when extending:
+
+- Project-specific or multi-step command → **new `just` recipe** (auto-approved
+  via `just:*`, self-documenting, shows up in `just --list`).
+- Simple safe utility → **allowlist entry** in `.claude/settings.local.json`
+  (which is checked in — extend it via PR like any other change).
+- Keep `rm`, `sed -i`, external `curl` gated; they prompt rarely and the prompt
+  is the point.
+- Shell `for`/`until`/`while` loops still prompt (no clean pattern exists).
+  Habit fix: do iteration inside `just py` / a script instead of shell loops.
+
+## Layer 2 — Measuring approval friction
+
+**Why a hook is required:** approved permission prompts leave *no trace* in
+transcripts (only denials do). The only durable record is the `Notification`
+hook, which Claude Code fires whenever it needs permission.
+
+Components:
+
+- `.claude/hooks/log_permission_prompt.py` — Notification hook (registered in
+  `.claude/settings.local.json`). Appends one JSON line per prompt to
+  `~/.claude/metrics/ottoneu_db/permission_prompts.jsonl`, enriched with the
+  pending tool name + input recovered from the transcript tail.
+- `.claude/hooks/permission_report.py` — aggregator. Numerator: logged prompts.
+  Denominator: total `tool_use` blocks mined from
+  `~/.claude/projects/-Users-alexmonroe-dev-ottoneu-db/*.jsonl`.
+
+**The metric: prompts per 100 tool calls**, weekly. Raw prompt counts mislead —
+a heavy week prompts more in absolute terms even if friction per unit of work
+improved.
+
+Usage:
+
+```
+just permission-report              # weekly trend + top prompted families
+just permission-report --days 14
+just permission-report --check      # exit 2 if trailing-7d rate > 1.5x prior-28d baseline
+```
+
+Workflow:
+
+- The **"Top prompted command families"** table is the backlog: each row is a
+  candidate `just` recipe or allowlist entry. `/review-permission-gates`
+  evaluates the current session the same way.
+- The **regression check** catches drift (a new tool/habit/Claude Code release
+  reintroducing prompts). Run it after settings or Justfile changes and
+  periodically (e.g., as part of `/retro`).
+
+Known limitations: events accrue only from the date the hook landed (no
+retroactive data); background/bypass-permission sessions generate tool calls
+but no prompts, which deflates the rate — trends still hold as long as the mix
+of session types is roughly stable; the hook is host-local (the devcontainer
+volume keeps its own log).
+
+## Layer 3 — Native sandbox (optional)
+
+`.claude/settings.local.json` currently sets `sandbox.enabled: false`. Setting
+`"enabled": true` with `"autoAllowBashIfSandboxed": true` makes Claude Code run
+Bash under macOS Seatbelt and auto-approve commands the sandbox can contain
+(filesystem-read-only, no network), prompting only on escalation. It's the
+middle ground when working on the host outside the devcontainer. Tradeoff:
+some legitimate commands (DB writes, scrapers) escalate and still prompt, and
+sandbox quirks can break commands in confusing ways. Try it for a week and
+check the effect with `just permission-report`.
+
+## Layer 4 — Devcontainer for full autonomy
+
+`.devcontainer/` gives an isolated Linux container with:
+
+- Python 3.9 (matches the project floor), Node 20, `gh`, `just`, Playwright
+  Chromium deps;
+- a **default-deny egress firewall** (`init-firewall.sh`, adapted from
+  Anthropic's reference devcontainer) allowing only the domains in
+  `allowed-domains.txt` — Anthropic, GitHub, npm/PyPI, the project's scrapers,
+  and your Supabase host (**add your `<project-ref>.supabase.co` before first
+  use** — find it in `SUPABASE_URL` in `.env`);
+- a named volume for `~/.claude` so login and history persist across rebuilds.
+
+Usage (VS Code: "Reopen in Container", or `devcontainer up` CLI):
+
+1. First boot runs `post-create.sh` (installs Claude Code + project deps) and
+   `init-firewall.sh` (applies the firewall — also re-applied on every start).
+2. Copy `.env` / `web/.env.local` into the workspace if not already present.
+3. Run `claude` once to authenticate, then:
+
+```
+claude --dangerously-skip-permissions
+```
+
+Inside the container that flag is reasonable: worst case is scoped to the
+workspace copy, the container, and the allowlisted endpoints. **The remaining
+real risk is the production Supabase database** (the container legitimately
+needs credentials for it). Mitigations: prefer read-only keys for exploratory
+work, rely on PR review for migrations, and remember `fp_*` tables are
+off-limits (see CLAUDE.md).
+
+Host caveats: the venv is created inside the container (Linux) — it coexists
+with the macOS `venv/` only if the container uses its own checkout/volume;
+with a bind mount, re-run `venv/bin/pip install -e .` when switching sides.
+Production promotion actions should still run from the host main repo per
+CLAUDE.md worktree notes.
+
+## Is the metric worth it? (decision record)
+
+Yes, with eyes open. The instrumentation is ~150 lines of stdlib Python, zero
+external services, and answers questions that are otherwise unanswerable
+(approved prompts are invisible in transcripts). The risks to keep in mind:
+
+- **Goodhart**: the cheapest way to drive the rate to zero is allowlisting
+  everything — which destroys the signal prompts provide in supervised
+  sessions. The metric's purpose is to find *recipe-shaped* gaps and catch
+  regressions, not to hit zero. Zero-prompt operation is what Layer 4 is for.
+- **Denominator drift**: more background-job usage lowers the rate without any
+  real improvement. Compare like-for-like periods.

--- a/docs/references/autonomous-operation.md
+++ b/docs/references/autonomous-operation.md
@@ -133,6 +133,12 @@ Usage (VS Code: "Reopen in Container", or `devcontainer up` CLI):
 claude --dangerously-skip-permissions
 ```
 
+The **VS Code extension panel** works too: `devcontainer.json` sets
+`claudeCode.allowDangerouslySkipPermissions` (adds "Bypass permissions" to the
+extension's mode selector) and `claudeCode.initialPermissionMode:
+"bypassPermissions"` (starts every conversation in it) — scoped via
+devcontainer customizations, so host VS Code keeps normal prompting.
+
 Inside the container that flag is reasonable: worst case is scoped to the
 workspace copy, the container, and the allowlisted endpoints. **The remaining
 real risk is the production Supabase database** (the container legitimately


### PR DESCRIPTION
## Summary

Moves the harness toward **safe, zero-intervention operation** in three layers, plus instrumentation to measure progress. Full strategy + decision record in `docs/references/autonomous-operation.md`.

### Evidence (transcript mining: 31 sessions, ~1,650 Bash calls)
- ~80% of permission prompts came from innocuous command families, dominated by `cd <repo> && …` compound commands (Claude Code checks every segment; `cd` wasn't allowlisted → ~700 prompts).
- Explicit user denials across all history: **3**. Prompts here are nearly pure friction, not safety catches.

### Layer 1 — Allowlist (`.claude/settings.local.json`)
- Add `cd`, `echo`, `printf`, `sed -n`, `pgrep`, `ps`, `time`, `timeout`, `touch`, `cp`, `mv`, `tr`, `cut`, `date`, `node`, `python3`, broad `venv/bin/python` (+ absolute-path variants for worktrees).
- Honest framing: `venv/bin/python:*` adds no capability beyond the pre-existing `just py` escape hatch — the allowlist is friction control, not the security boundary.
- New **deny** list: `git push --force`/`-f`, `sudo`. `rm`, `sed -i`, external `curl` stay gated on purpose.

### Layer 2 — Instrumentation (the metrics ask)
- `.claude/hooks/log_permission_prompt.py` — **Notification hook** (approved prompts leave no trace in transcripts; a hook is the only durable record). Logs each prompt + the pending tool call to `~/.claude/metrics/ottoneu_db/permission_prompts.jsonl`.
- `.claude/hooks/permission_report.py` + `just permission-report` — **prompts per 100 tool calls**, weekly trend (denominator mined from transcripts), top prompted command families (= the backlog for the next allowlist entry / just recipe), and a trailing-7d vs prior-28d **regression check** (`--check` exits 2).
- Verified end-to-end with a simulated hook event; denominator mining confirmed against real transcripts (1,931 tool calls last 7d).

### Layer 4 — Devcontainer (`.devcontainer/`)
- Python 3.9 (project floor) + Node 20 + `just` + `gh` + Playwright deps.
- **Default-deny egress firewall** (Anthropic reference pattern): only domains in `allowed-domains.txt` are reachable. Add your `<project-ref>.supabase.co` before first use.
- Makes `claude --dangerously-skip-permissions` reasonable: blast radius = workspace copy + container + allowlisted endpoints. Residual risk is prod Supabase creds — documented with mitigations.

### Docs
- New `docs/references/autonomous-operation.md` (layered model, metric definition, Goodhart caveat, sandbox Layer-3 option left opt-in since it's explicitly disabled in settings today).
- CLAUDE.md quick-reference + doc map; `review-permission-gates` skill now points at the cross-session data.

## Test plan
- `pytest scripts/tests/test_architecture.py scripts/tests/test_migrations.py` — 25 passed (doc-existence checks cover the new doc).
- `scripts/check_docs_freshness.py` — all checks pass.
- Hook simulated end-to-end (event logged with tool name + full command, recovered from transcript tail); report runs with and without event data; `bash -n` on firewall/post-create; JSON validated.
- Not tested: full devcontainer build (no Docker run in this session) — first `Reopen in Container` will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)