### PR TITLE
fix(devcontainer): drop stale yarn apt repo that breaks apt-get update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,10 @@
 # Python 3.9 to match the project's target version (CLAUDE.md: no 3.10+ syntax).
 FROM mcr.microsoft.com/devcontainers/python:3.9-bookworm
 
+# The base image ships a yarn apt repo whose GPG key has rotated, which breaks
+# every apt-get update (NO_PUBKEY 62D54FD4003F6525). We're npm-only — drop it.
+RUN rm -f /etc/apt/sources.list.d/yarn.list
+
 # Firewall tooling + just (build runner used by every project recipe)
 RUN apt-get update \
     && apt-get install -y --no-install-recommends iptables ipset dnsutils \


### PR DESCRIPTION
## Summary

Re-lands the devcontainer build fix that was mistakenly pushed to the already-merged #631 branch.

The `mcr.microsoft.com/devcontainers/python:3.9-bookworm` base image ships a preconfigured Yarn apt repository (`dl.yarnpkg.com`) whose GPG signing key has rotated upstream (`NO_PUBKEY 62D54FD4003F6525`), which fails every `apt-get update` — the first Dockerfile layer died on "Reopen in Container". The project is npm-only, so the Dockerfile now removes `/etc/apt/sources.list.d/yarn.list` before updating.

## Test plan
- `docker build .devcontainer` locally: completes successfully (previously failed at layer 2 with exit 100).
- Full validation: "Dev Containers: Rebuild and Reopen in Container" after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)