### PR TITLE
fix(devcontainer): allow claude.ai + VS Code service domains through firewall

### DIFF
--- a/.devcontainer/allowed-domains.txt
+++ b/.devcontainer/allowed-domains.txt
@@ -6,9 +6,16 @@
 # Claude Code / Anthropic
 api.anthropic.com
 statsig.anthropic.com
+statsig.com
 console.anthropic.com
+claude.ai
 sentry.io
 o1158394.ingest.sentry.io
+
+# VS Code in-container services (server updates, extension marketplace)
+update.code.visualstudio.com
+marketplace.visualstudio.com
+vscode.blob.core.windows.net
 
 # Package registries
 registry.npmjs.org


### PR DESCRIPTION
## Summary

Fixes the VS Code Claude extension side panel failing to sign in inside the devcontainer.

- The extension's Claude.ai-subscription sign-in talks to **claude.ai**, which the default-deny firewall blocked. (CLI `/login` worked because the browser leg of OAuth runs on the host and the CLI's token exchange goes through the already-allowed `console.anthropic.com`.)
- Also adds **statsig.com** and the **VS Code service domains** (`update.code.visualstudio.com`, `marketplace.visualstudio.com`, `vscode.blob.core.windows.net`) from Anthropic's reference devcontainer firewall, so in-container VS Code server updates and extension installs keep working.

The related filesystem-MCP failure is a separate, untracked-config issue: `.mcp.json` (local, contains tokens, correctly not in git) passed the macOS absolute path to the filesystem server — fixed locally by using `.` (resolved against the project cwd), which works on both host and container.

## Test plan
- After merge, inside the container: `git pull && sudo bash .devcontainer/init-firewall.sh` (idempotent, no rebuild needed), reload window, sign in to the extension panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)