### PR TITLE
docs: daily harness audit 2026-06-12 + 2026-06-13

### DIFF
--- a/.claude/commands/ablation.md
+++ b/.claude/commands/ablation.md
@@ -8,7 +8,7 @@ arbitrary-band decisions Finding 2 condemned — do not use it for verdicts.
 
 // turbo
 
-1. **Identify the target model** (default: the active model `v31_depth_chart`). If the
+1. **Identify the target model** (default: the active model `v33_tuned_base`). If the
    user specifies a model, use that.
 
 2. **List the model's features** from `scripts/feature_projections/model_config.py`.

--- a/.claude/commands/compare-models.md
+++ b/.claude/commands/compare-models.md
@@ -8,8 +8,8 @@ per-player divergence inspection, never to declare a winner.
 
 // turbo
 
-1. **Parse model names from arguments** (2–3 names, e.g. `v31 v14`). Resolve
-   partial names to full names from `model_config.py` (`v31` → `v31_depth_chart`).
+1. **Parse model names from arguments** (2–3 names, e.g. `v33 v14`). Resolve
+   partial names to full names from `model_config.py` (`v33` → `v33_tuned_base`).
 
 2. **Held-out comparison (the verdict).** Score exactly the requested models
    out-of-sample on the shared window:

--- a/.claude/commands/diagnose-segment.md
+++ b/.claude/commands/diagnose-segment.md
@@ -15,14 +15,14 @@ held-out harness (`/experiment`), never on the in-sample segment numbers.
    baseline (use `venv/bin/python` directly — no `source venv/bin/activate`):
    ```bash
    venv/bin/python scripts/feature_projections/cli.py segment-analysis \
-     --models v31_depth_chart,v14_qb_starter,naive_prior_season_ppg \
+     --models v33_tuned_base,v14_qb_starter,naive_prior_season_ppg \
      --seasons 2022,2023,2024,2025
    ```
 
 3. **Run per-player diagnostics** for the player-level view:
    ```bash
    venv/bin/python scripts/feature_projections/cli.py diagnostics \
-     --model v31_depth_chart --season 2025 --top 50 \
+     --model v33_tuned_base --season 2025 --top 50 \
      --output docs/generated/player-diagnostics.md
    ```
 
@@ -38,6 +38,6 @@ held-out harness (`/experiment`), never on the in-sample segment numbers.
 
 7. **Propose improvements as hypotheses, not conclusions.** For any proposed
    feature or weight change, hand off to `/experiment` to get a held-out,
-   significance-tested verdict vs `v31_depth_chart` before trusting it. Be alert to
+   significance-tested verdict vs `v33_tuned_base` before trusting it. Be alert to
    the level-vs-ordering split (#579/#598): a segment can be biased in level while
    still ranked correctly, which changes whether a fix is even worth making.

--- a/.claude/commands/experiment.md
+++ b/.claude/commands/experiment.md
@@ -51,7 +51,7 @@ point-estimate delta.
    ```
 
 6. **State the verdict** from the significance test, not an MAE band:
-   - **SIGNIFICANT WIN** — the 95% CI for MAE(NEW) − MAE(v31_depth_chart) lies
+   - **SIGNIFICANT WIN** — the 95% CI for MAE(NEW) − MAE(ACTIVE_MODEL) lies
      entirely below 0. Only this clears the bar to consider promotion.
    - **NOT SIGNIFICANT** — CI spans 0. The gap is sampling noise; do not promote
      on it, regardless of the point estimate.

--- a/.claude/commands/feature-importance.md
+++ b/.claude/commands/feature-importance.md
@@ -8,7 +8,7 @@ place, cross-check with held-out ablation (`/ablation`, #588), not these numbers
 
 // turbo
 
-1. **Identify the learned model** (default: the active model `v31_depth_chart`,
+1. **Identify the learned model** (default: the active model `v33_tuned_base`,
    itself a learned Ridge model whose coefficients are inspectable). Only the
    additive models — e.g. `v14_qb_starter` — have no learned coefficients to
    inspect; pick a learned model if the user names an additive one. Use the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,14 +129,14 @@ Run `just check-arch` to validate these rules locally.
 
 When any task modifies the projection system — including `scripts/feature_projections/`, `scripts/projection_methods.py`, `scripts/update_projections.py`, or `model_config.py` — you MUST validate it on the **leakage-free held-out harness**. The in-sample `accuracy-report` scores learned models on the seasons they trained on (methodology audit, Findings 1 & 2); it is a **secondary diagnostic only** and must never be the gate or the basis for a promote decision. Use `/experiment` to run this flow.
 
-1. **Run the held-out re-rank** against production (`v31_depth_chart`) and the naïve baselines, on the rolling-origin protocol (#594). Learned models retrain out-of-sample inside the sandbox; additive/external models need their held-out projections generated first (`just project <name> 2023,2024,2025`). The cache (#597) makes re-runs fast.
+1. **Run the held-out re-rank** against production (`v33_tuned_base`) and the naïve baselines, on the rolling-origin protocol (#594). Learned models retrain out-of-sample inside the sandbox; additive/external models need their held-out projections generated first (`just project <name> 2023,2024,2025`). The cache (#597) makes re-runs fast.
    ```
    just holdout-eval --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021 \
-     --models <name>,v31_depth_chart,naive_prior_season_ppg,position_mean_baseline
+     --models <name>,v33_tuned_base,naive_prior_season_ppg,position_mean_baseline
    ```
 2. **Test significance vs the active model** (player-clustered paired bootstrap). This is the gate — a point-estimate MAE delta is **not** a result:
    ```
-   just significance <name> v31_depth_chart --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
+   just significance <name> v33_tuned_base --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
    ```
    Availability-touching changes additionally run `just availability-backtest` and report **both** rate and availability MAE (#574).
 3. **In the PR description**, lead with the held-out ranking + significance verdict (and the per-position Ranking-quality rows, #598). Include the in-sample `accuracy-report` table only if labelled "in-sample diagnostic — not the ranking".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,14 +133,14 @@ Run `just check-arch` to validate these rules locally.
 
 When any task modifies the projection system — including `scripts/feature_projections/`, `scripts/projection_methods.py`, `scripts/update_projections.py`, or `model_config.py` — you MUST validate it on the **leakage-free held-out harness**. The in-sample `accuracy-report` scores learned models on the seasons they trained on (methodology audit, Findings 1 & 2); it is a **secondary diagnostic only** and must never be the gate or the basis for a promote decision. Use `/experiment` to run this flow.
 
-1. **Run the held-out re-rank** against production (`v31_depth_chart`) and the naïve baselines, on the rolling-origin protocol (#594). Learned models retrain out-of-sample inside the sandbox; additive/external models need their held-out projections generated first (`just project <name> 2023,2024,2025`). The cache (#597) makes re-runs fast.
+1. **Run the held-out re-rank** against production (`v33_tuned_base`) and the naïve baselines, on the rolling-origin protocol (#594). Learned models retrain out-of-sample inside the sandbox; additive/external models need their held-out projections generated first (`just project <name> 2023,2024,2025`). The cache (#597) makes re-runs fast.
    ```
    just holdout-eval --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021 \
-     --models <name>,v31_depth_chart,naive_prior_season_ppg,position_mean_baseline
+     --models <name>,v33_tuned_base,naive_prior_season_ppg,position_mean_baseline
    ```
 2. **Test significance vs the active model** (player-clustered paired bootstrap). This is the gate — a point-estimate MAE delta is **not** a result:
    ```
-   just significance <name> v31_depth_chart --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
+   just significance <name> v33_tuned_base --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
    ```
    Availability-touching changes additionally run `just availability-backtest` and report **both** rate and availability MAE (#574).
 3. **In the PR description**, lead with the held-out ranking + significance verdict (and the per-position Ranking-quality rows, #598). Include the in-sample `accuracy-report` table only if labelled "in-sample diagnostic — not the ranking".

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -107,6 +107,7 @@ just check-db           # Verify database contents
 just check-arch         # Architectural/structural tests (includes check-migrations)
 just check-migrations   # Lint migrations/ naming + sequence (offline; see migrations/README.md)
 just check-docs         # Documentation freshness check
+just permission-report [--days N] [--check]  # Permission-prompt rate + top families; --check exits 2 on 7d-vs-28d regression (see docs/references/autonomous-operation.md)
 just ci                 # Full CI suite (lint + typecheck + tests + doc checks)
 just roster-context [season]  # Build the roster-question context pack (live league data); season defaults to 2026
 

--- a/docs/exec-plans/projection-system-review-2026-06.md
+++ b/docs/exec-plans/projection-system-review-2026-06.md
@@ -235,10 +235,11 @@ Every Wave 3 DoD, the `/experiment`, `/ablation`, `/compare-models`,
 experiment-log warning header all still name **`v14_qb_starter`** as the
 production/comparator model. That is now false. The active model is resolved
 dynamically from `projection_models.is_active`; the *docs* lag. Before running
-any experiment, the significance gate must compare against **`v31_depth_chart`**
-(or, better, against `fetchActiveProjectionModel()`'s answer at run time). The
-experiment-log header's "the additive `v14_qb_starter` is the honest best and is
-in production" is stale and contradicts the held-out doc.
+any experiment, the significance gate must compare against the active model
+(`v33_tuned_base` post-#618; `v31_depth_chart` when this section was first
+written) — or, better, against `fetchActiveProjectionModel()`'s answer at run
+time. The experiment-log header's "the additive `v14_qb_starter` is the honest
+best and is in production" is stale and contradicts the held-out doc.
 
 ### Per-issue disposition
 
@@ -296,4 +297,5 @@ the rolling-origin held-out harness with player-clustered significance.
 5. ~~#590 delta-anchored~~ — shelved (premise reversed).
 6. ~~#591 level-matched window~~ — shelved (premise resolved by #599).
 
-All gates compare against **`v31_depth_chart`** (the active model), not `v14`.
+All gates now compare against **`v33_tuned_base`** (the post-Wave-3 active model,
+promoted from `v31_depth_chart` in #618), not `v14`.

--- a/docs/references/autonomous-operation.md
+++ b/docs/references/autonomous-operation.md
@@ -146,11 +146,11 @@ needs credentials for it). Mitigations: prefer read-only keys for exploratory
 work, rely on PR review for migrations, and remember `fp_*` tables are
 off-limits (see CLAUDE.md).
 
-Host caveats: the venv is created inside the container (Linux) — it coexists
-with the macOS `venv/` only if the container uses its own checkout/volume;
-with a bind mount, re-run `venv/bin/pip install -e .` when switching sides.
-Production promotion actions should still run from the host main repo per
-CLAUDE.md worktree notes.
+Host caveats: `venv/` and `web/node_modules/` are backed by named volumes
+(`ottoneu-venv`, `ottoneu-web-node-modules` — see `.devcontainer/devcontainer.json`,
+#637), so the container builds its own Linux copies without colliding with the
+host's macOS `venv/`. Production promotion actions should still run from the
+host main repo per CLAUDE.md worktree notes.
 
 ## Is the metric worth it? (decision record)
 


### PR DESCRIPTION
Rolled today's (2026-06-13) audit into this still-open PR rather than opening a duplicate.

## 2026-06-12 — commits reviewed (original audit)

| PR | Title | Doc impact |
|----|-------|------------|
| #633 | fix(devcontainer): allow claude.ai + VS Code service domains | — (allowlist file only) |
| #632 | fix(devcontainer): drop stale yarn apt repo | — (Dockerfile only) |
| #631 | feat(harness): autonomous-operation layers — allowlist, prompt-rate metrics, devcontainer | `just permission-report` was missing from `docs/COMMANDS.md` |
| #630 | feat(arch): mechanically enforce Supabase pagination on large tables | Already updated CLAUDE.md + `docs/TESTING.md` in the PR — no follow-up |
| #619 | feat(projections): QB-only residual bounded bet — negative result (`v34_qb_residual`) | Already updated review + experiment-log — no follow-up |
| #618 | feat(projections): tune base weighted_ppg recency weights → **`v33_tuned_base` promoted to active** | **Comparator drift**: CLAUDE.md, AGENTS.md, the projection-system-review, and the `/experiment`-family skills still named `v31_depth_chart` as the comparator. Fixed below. |
| #617 | feat(projections): honest feature ablation of `v31_depth_chart` (`v32_pruned`) | Already updated experiment-log + review — no follow-up |
| #616 | docs: daily harness audit 2026-06-11 | n/a |

## 2026-06-13 — commits reviewed (since this PR was opened)

| PR | Title | Doc impact |
|----|-------|------------|
| #648 | experiment(#640): QB volume features — NEGATIVE, v33 stays active | Experiment-log + accuracy-improvement updated in-PR; v33 stays active so no comparator flip — no follow-up |
| #647 | fix: re-land #646 (#639 experiment) — stacked merge missed main | Same — non-promoted experiments (`v35_pos_tuned_base`, `v36_pos_regression`), self-documenting |
| #638 | docs: make rank-quality (Spearman/top-N) a required experiment-log column | Rewrote `experiment.md` to use the durable `ACTIVE_MODEL` placeholder + rank-quality column; conflicts with this PR's literal `v33_tuned_base` substitution — **resolved on rebase below** |
| #637 | fix(devcontainer): isolate venv + node_modules in named volumes | `docs/references/autonomous-operation.md` "Host caveats" paragraph now stale — fixed below |
| #636 | fix(devcontainer): pin GitHub CIDR ranges so `gh` CLI survives IP rotation | Implementation detail covered by existing "default-deny egress firewall" prose — no follow-up |
| #635 | fix(devcontainer): chown the ~/.claude volume so OAuth tokens persist | Implementation detail covered by existing "named volume for `~/.claude`" prose — no follow-up |

## Changes in this PR

**Comparator flip `v31_depth_chart` → `v33_tuned_base`** (from 2026-06-12; #618 promoted the tuned-base model to active):

- `CLAUDE.md` + `AGENTS.md` — Projection Model Update Requirements: the example `holdout-eval` and `significance` invocations now name `v33_tuned_base`.
- `.claude/commands/experiment.md` — rebased onto #638's `ACTIVE_MODEL` placeholder pattern (more durable than hardcoding); the verdict text now reads `MAE(ACTIVE_MODEL)` instead of `MAE(v31_depth_chart)`.
- `.claude/commands/ablation.md` — "default: the active model …".
- `.claude/commands/feature-importance.md` — "default: the active model …".
- `.claude/commands/diagnose-segment.md` — example `cli.py segment-analysis` and `cli.py diagnostics` invocations + the significance-test verdict line.
- `.claude/commands/compare-models.md` — partial-name-resolution example (`v33` → `v33_tuned_base`).
- `docs/exec-plans/projection-system-review-2026-06.md` — "Comparator flip is mandatory" paragraph + the closing "All gates compare against …" line both now point at `v33_tuned_base`, with the `v31_depth_chart` history preserved as context.

**Missing recipe in `docs/COMMANDS.md`** (from 2026-06-12):

- Added `just permission-report [--days N] [--check]` to the recipe listing (shipped in #631, documented in `docs/references/autonomous-operation.md` and the CLAUDE.md map but missing from the canonical command index).

**Stale devcontainer caveat in `docs/references/autonomous-operation.md`** (new for 2026-06-13):

- "Host caveats" paragraph rewritten: `venv/` and `web/node_modules/` are now backed by named volumes (`ottoneu-venv`, `ottoneu-web-node-modules`) per #637, so the prior "re-run `venv/bin/pip install -e .` when switching sides" advice is obsolete.

## Items NOT changed (intentional)

- `docs/generated/db-schema.md` — verified against `migrations/028–030`; `depth_charts` + `player_projections.projected_games` (migration 030) are both already covered. Table count of 22 still matches the listed rows. No new migrations since the prior audit.
- `docs/generated/experiment-log.md`, `projection-holdout-eval*.md`, `projection-methodology-audit.md` — historical records of v31-as-active; leaving them as-is preserves the timeline.
- New trained-model JSON files (`v35_pos_tuned_base.json`, `v36_pos_regression.json`, `v37_qb_volume.json`) — none promoted; `v33_tuned_base` remains active.

## Items flagged for human follow-up

- None — the only new drift since 2026-06-12 was one stale devcontainer paragraph, fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)