### PR TITLE
fix(devcontainer): chown ~/.claude volume so extension login can persist tokens

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
     "DEVCONTAINER": "true"
   },
   "postCreateCommand": "bash .devcontainer/post-create.sh",
-  "postStartCommand": "sudo bash .devcontainer/init-firewall.sh",
+  "postStartCommand": "sudo chown -R vscode:vscode /home/vscode/.claude && sudo bash .devcontainer/init-firewall.sh",
   "customizations": {
     "vscode": {
       "extensions": ["anthropic.claude-code", "dbaeumer.vscode-eslint"],


### PR DESCRIPTION
## Summary

Extension side-panel login inside the devcontainer was failing **after** a successful OAuth exchange. Extension logs show:

```
[ERROR] Failed to save OAuth tokens: permission denied, mkdir '/home/vscode/.claude/.storage-write.lock'
[ERROR] Failed to backup config: EACCES: permission denied, mkdir '/home/vscode/.claude/backups'
[error] Error processing client request: Error: Failed to retrieve auth status after login
```

Root cause: the `ottoneu-claude-config` named volume mounted at `/home/vscode/.claude` is created **root-owned** by Docker, so the `vscode` user can't write into it. Tokens can't persist → auth status check fails → panel loops back to sign-in. (Same EACCES also broke sessions, SessionStart hooks, and plugin cache under `~/.claude`.)

Fix: `postStartCommand` now chowns the volume to `vscode` on every container start, before applying the firewall.

Note from the same logs: the filesystem MCP server now connects successfully (the `.mcp.json` relative-path fix), and the firewall domains from #633 are confirmed working — the OAuth code exchange itself succeeded.

## Test plan
- Existing container: `sudo chown -R vscode:vscode /home/vscode/.claude`, reload window, sign in — no rebuild needed (same command this PR automates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)