### PR TITLE
fix(devcontainer): make autonomous container start reliably (GitHub IP rotation + venv/node_modules isolation)

### DIFF
--- a/.devcontainer/allowed-domains.txt
+++ b/.devcontainer/allowed-domains.txt
@@ -23,8 +23,14 @@ pypi.org
 files.pythonhosted.org
 
 # GitHub (clone/push, gh CLI, nflverse release downloads)
-github.com
-api.github.com
+# github.com / api.github.com are served from a rotating pool of IPs, so a
+# single resolved A record goes stale ("no route to host"). Pin GitHub's
+# published CIDR blocks (https://api.github.com/meta) instead — the firewall's
+# hash:net ipset accepts CIDR entries directly.
+192.30.252.0/22
+185.199.108.0/22
+140.82.112.0/20
+143.55.64.0/20
 raw.githubusercontent.com
 objects.githubusercontent.com
 codeload.github.com

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -13,14 +13,22 @@ DOMAINS_FILE="$(dirname "$0")/allowed-domains.txt"
 iptables -F OUTPUT
 iptables -F INPUT
 ipset destroy allowed-out 2>/dev/null || true
-ipset create allowed-out hash:ip
+# hash:net stores both CIDR ranges and single IPs (added as /32), so the
+# allowlist can pin a whole published range (e.g. GitHub's rotating IP pool)
+# instead of one snapshot IP that goes stale on the next DNS rotation.
+ipset create allowed-out hash:net
 
-# Resolve every allowlisted domain to IPs (re-run this script to refresh).
+# Resolve every allowlist entry. A line with a '/' is a literal CIDR/IP range
+# (added directly); otherwise it's a hostname resolved to its current A records.
 while IFS= read -r line; do
-    domain="${line%%#*}"
-    domain="$(echo "$domain" | tr -d '[:space:]')"
-    [ -z "$domain" ] && continue
-    for ip in $(dig +short A "$domain" | grep -E '^[0-9.]+$' || true); do
+    entry="${line%%#*}"
+    entry="$(echo "$entry" | tr -d '[:space:]')"
+    [ -z "$entry" ] && continue
+    if [[ "$entry" == */* ]]; then
+        ipset add allowed-out "$entry" 2>/dev/null || true
+        continue
+    fi
+    for ip in $(dig +short A "$entry" | grep -E '^[0-9.]+$' || true); do
         ipset add allowed-out "$ip" 2>/dev/null || true
     done
 done < "$DOMAINS_FILE"


### PR DESCRIPTION
Two fixes that stop the autonomous devcontainer from failing on start.

## 1. gh CLI dies on GitHub IP rotation
`github.com` / `api.github.com` are served from a rotating pool of IPs. `init-firewall.sh` resolved a single A record at container start and pinned only that one IP, so when GitHub handed out a different pool IP (e.g. `140.82.116.6`) every `gh` call failed with `no route to host`.

- Switch the ipset from `hash:ip` to `hash:net` and teach the resolve loop to add CIDR/range entries directly.
- Allowlist GitHub's four published CIDR blocks (`192.30.252.0/22`, `185.199.108.0/22`, `140.82.112.0/20`, `143.55.64.0/20`, from https://api.github.com/meta) instead of the rotation-prone hostnames. `140.82.116.6` lives in `140.82.112.0/20`, so the whole pool is now covered.

## 2. postCreateCommand fails on bind-mounted host venv
The workspace is bind-mounted from the host, so the host's **macOS** `venv/` leaked into the Linux container — its `venv/bin/python3` symlink pointed at a nonexistent host path and `python3 -m venv venv` aborted with `No such file or directory: .../venv/bin/python3`.

- Back `venv/` and `web/node_modules` with named volumes so the container builds its own Linux copies without touching (or being poisoned by) the host's.
- post-create chowns the fresh (root-owned) volumes to `vscode` before use and recreates the venv with `--clear`.

After merge, re-run `sudo bash .devcontainer/init-firewall.sh` (or rebuild the container) and `gh auth login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)