### PR TITLE
fix(devcontainer): isolate venv + node_modules in named volumes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,9 @@
   "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
   "remoteUser": "vscode",
   "mounts": [
-    "source=ottoneu-claude-config,target=/home/vscode/.claude,type=volume"
+    "source=ottoneu-claude-config,target=/home/vscode/.claude,type=volume",
+    "source=ottoneu-venv,target=${containerWorkspaceFolder}/venv,type=volume",
+    "source=ottoneu-web-node-modules,target=${containerWorkspaceFolder}/web/node_modules,type=volume"
   ],
   "containerEnv": {
     "DEVCONTAINER": "true"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,8 +4,14 @@ set -euo pipefail
 
 npm install -g @anthropic-ai/claude-code
 
+# venv/ and web/node_modules are backed by named volumes (see devcontainer.json)
+# so the host's macOS binaries (bind-mounted via the workspace) don't leak into
+# this Linux container. Fresh volumes mount root-owned, so claim them before use.
+sudo chown vscode:vscode venv web/node_modules
+
 # Mirror `just install` (Justfile) — venv lives inside the container workspace.
-python3 -m venv venv
+# --clear recreates cleanly if the volume carries a stale venv from a prior build.
+python3 -m venv --clear venv
 venv/bin/pip install --upgrade pip
 venv/bin/pip install -r requirements.txt
 venv/bin/pip install -e .


### PR DESCRIPTION
Follow-up to #636 (this commit landed on that branch after it merged, so it never reached main).

The workspace is bind-mounted from the host, so the host's **macOS** `venv/` leaked into the Linux container — its `venv/bin/python3` symlink pointed at a nonexistent host path and `python3 -m venv venv` aborted postCreateCommand with `No such file or directory: .../venv/bin/python3`.

- Back `venv/` and `web/node_modules` with named volumes so the container builds its own Linux copies without touching (or being poisoned by) the host's.
- post-create chowns the fresh (root-owned) volumes to `vscode` before use and recreates the venv with `--clear`.

Requires a container **rebuild** to take effect (changes volume mounts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)