### PR TITLE
experiment(#639): per-position base tuning — NEGATIVE (v33 stays active)

### DIFF
--- a/docs/exec-plans/projection-accuracy-improvement.md
+++ b/docs/exec-plans/projection-accuracy-improvement.md
@@ -140,6 +140,24 @@ New data sources and learned models. Expected: MAE < 2.3, R² > 0.60.
 
 Deferred (not in the accuracy plan): uncertainty-aware/Bayesian intervals (a separate decision-quality value prop, not point-MAE).
 
+### Backlog refresh (2026-06-12) — post-#589/#592, active model `v33_tuned_base`
+
+New experiment wave filed after #588/#589/#592 closed out the base-tuning and
+QB-separation axes. **Hard constraint on all of these: no FantasyPros or other
+market data as model input** — the system's value prop is generating
+upcoming-season projections early in the offseason, long before external
+projections/ADP exist. FP remains an eval-time comparator only.
+
+| # | Experiment | Status |
+|---|---|---|
+| [#639](https://github.com/alex-monroe/ottoneu-db/issues/639) | Per-position base tuning (weights, window, regression strength) | **NEGATIVE** (2026-06-12, iteration look; see experiment log). Residual thread: TE 4-season window, needs `max_history` plumbing. |
+| [#640](https://github.com/alex-monroe/ottoneu-db/issues/640) | QB rushing & pass-volume features — the new QB signal #592 asked for | open — highest-leverage new-feature bet (QB is worst-MAE position) |
+| [#641](https://github.com/alex-monroe/ottoneu-db/issues/641) | Opportunity/efficiency decomposition of the base signal | open |
+| [#642](https://github.com/alex-monroe/ottoneu-db/issues/642) | Pass-catcher ecosystem quality ("who is my QB?") from depth charts | open |
+| [#643](https://github.com/alex-monroe/ottoneu-db/issues/643) | Rank-aware training: relevance-weighted samples | open — targets the FP ordering gap (the metric downstream actually consumes) |
+| [#644](https://github.com/alex-monroe/ottoneu-db/issues/644) | Bounded bet: GBM with monotone constraints on the 8 load-bearing features | open — lottery ticket, #592-style discipline |
+| [#645](https://github.com/alex-monroe/ottoneu-db/issues/645) | Micro: Huber loss in the learned combiner | open — cheap filler between larger experiments |
+
 ---
 
 ## Pre-audit backlog (2026-05-05) — SUPERSEDED, kept for history

--- a/docs/generated/experiment-log.md
+++ b/docs/generated/experiment-log.md
@@ -37,6 +37,8 @@ the MAE verdict. "—" only for rows predating the column.
 
 | Date | Model | Change | Held-out ALL MAE | Δ vs comparator | 95% CI | Significant? | Rank Δ (ρ / top-N vs comparator) | Protocol | PR |
 |------|-------|--------|------------------|----------|--------|--------------|----------------------------------|----------|-----|
+| 2026-06-12 | v36_pos_regression | #639 per-position regression strength: v33 + regression_to_mean*position interaction (learned per-position mean-reversion) | 2.251 | +0.021 vs **v33** | [−0.009, +0.053] | **N** (p=0.18) — **NEGATIVE, stopped on iteration look**; the extra interaction columns add variance, not signal. See #639 section below | ρ ≈ (QB −0.015, RB +0.002, WR −0.005, TE −0.001); top-N unchanged | rolling 2023–24 (iteration look; confirmation window not burned) | #639 |
+| 2026-06-12 | v35_pos_tuned_base | #639 per-position base recency weights: inner-fold sweep changed only RB ([0.65,0.20,0.15]→[0.70,0.20,0.10]); QB/WR/TE kept the #589 tune | 2.245 | +0.015 vs **v33** | [−0.001, +0.032] | **N** (p=0.066, trending *worse*) — **NEGATIVE, stopped on iteration look**; RB-only Δ −0.005 (CI [−0.018, +0.008], p=0.46) — the swept RB gain is noise OOS while full-refit coefficient drift hurts elsewhere. See #639 section below | ρ ≈ (TE +0.001, RB +0.001, QB −0.003, WR −0.003); WR top-24 hit 0.458→0.417 | rolling 2023–24 (iteration look; confirmation window not burned) | #639 |
 | 2026-06-11 | v34_qb_residual | #592 QB-only residual on v33 (depth_chart, qb_backup_penalty, implied_team_total; non-QB byte-identical to v33 by construction) | QB 3.846 (ALL 2.239) | QB **+0.015** vs **v33** | [−0.016, +0.049] | **N** (p=0.36) — **NEGATIVE, bounded bet stopped on tie**; residual coefficients ≈0. See #592 section below | ≈ (non-QB identical by construction; QB ρ within noise) | rolling 2023–24 (iteration look; confirmation window not burned) | #592 |
 | 2026-06-11 | v33_tuned_base | #589 base tuning: recency weights [0.55,0.25,0.20]→[0.65,0.20,0.15] (inner-fold sweep; exponent grid confirmed 1.0); v31 otherwise unchanged | **2.241** | **−0.011** vs **v31** | [−0.022, −0.001] | **Y** (p=0.038; iteration look 2023–24: −0.016, CI [−0.027, −0.004], p=0.007) — **clears the promotion gate**. See #589 section below | ρ ≈ everywhere except QB −0.003; WR top-24 0.250→0.292, TE top-12 0.500→0.583 | rolling 2023–2025 | #589 |
 | 2026-06-11 | v32_pruned | #588 ablation: v31 minus age_curve, usage_share, draft_capital, vegas, qb_backup_penalty (13→8 features) | 2.252 | +0.020 vs **v31** | [−0.027, +0.065] | N (p=0.40) — no worse, not better; **v31 stays active**. See #588 section below | ρ ≈ (QB +0.003 … TE −0.010); WR top-24 0.333→0.250 — top-tier loss drove the no-promote call | rolling 2023–2025 | #588 |
@@ -170,6 +172,40 @@ Caveat for future base work: the win is small and concentrated at RB/WR; the
 isolated-base sweep still over-projects (bias −0.57 at the chosen cell) — the
 learned intercept absorbs level, so isolated-base bias is not a gate. The
 3-season window length and per-position weights were not swept (follow-ups).
+
+### Per-position base tuning (#639) — NEGATIVE, 2026-06-12
+
+The #589 follow-ups, swept honestly on the inner folds (2022–2024, exponent
+fixed at 1.0 per #589) with the extended `sweep_recency_weights.py`
+(`--per-position` fold-level rankings, `--windows` 2-/4-season vectors scored
+on a fixed common qualifier population):
+
+- **Per-position recency weights: the global tune is already right.** Picking
+  with the #589 guardrail (never lose an inner fold to the tuned cell), QB and
+  WR produced no dominating cell — QB's best-mean cell (the old prod default
+  [0.55, 0.25, 0.20]) loses 2/3 folds; WR's 2-season cells are competitive but
+  never dominate. Only RB ([0.70, 0.20, 0.10], −0.003) dominated, and that
+  gain is noise out-of-sample (above). **Don't re-sweep per-position weights
+  without new signal** — the position-decay hypothesis is answered: decay
+  differences between positions are smaller than fold noise.
+- **Window length: 3 seasons confirmed for QB/RB/WR.** 2-season windows lose
+  decisively everywhere (recency weighting already down-weights old seasons
+  smoothly; truncating loses information). **TE is the one open thread**: the
+  4-season cell [0.60, 0.20, 0.12, 0.08] *never loses a fold* (1.4927 vs
+  1.5006) — but adopting it requires plumbing `max_history` through
+  runner/backtest/holdout (the pipeline fetches 3 seasons), so it was not
+  wired into v35. Logged as the residual #639 follow-up; only worth the
+  plumbing as part of a TE-focused experiment.
+- **Per-position regression strength (v36): the global coefficient was
+  already right.** Expressed as `regression_to_mean*position` (in a learned
+  combiner a per-position factor ≡ a per-position coefficient); the 4 extra
+  columns only added variance (ALL +0.021, QB ρ −0.015).
+
+Both variants stopped on the iteration look (rolling 2023–24); the
+confirmation window was not burned. `v33_tuned_base` stays active. Combined
+with #589's exponent grid and #592, the base + global regression is now a
+well-defended local optimum: further base tuning is not the path — new signal
+(#640–#642) or a different objective (#643) is.
 
 ### QB-specific bounded bet (#592) — NEGATIVE, 2026-06-11
 

--- a/scripts/feature_projections/features/__init__.py
+++ b/scripts/feature_projections/features/__init__.py
@@ -6,6 +6,7 @@ All features register themselves here. The registry maps feature name -> class.
 from scripts.feature_projections.features.weighted_ppg import (
     WeightedPPGFeature,
     WeightedPPGNoQBTrajectoryFeature,
+    WeightedPPGPerPositionTunedFeature,
     WeightedPPGReliabilityNoQBFeature,
     WeightedPPGRookieGrowthFeature,
     WeightedPPGRookieGrowthNoQBFeature,
@@ -50,6 +51,7 @@ FEATURE_REGISTRY: dict[str, type] = {
     "weighted_ppg_no_qb_trajectory": WeightedPPGNoQBTrajectoryFeature,
     "weighted_ppg_reliability_no_qb": WeightedPPGReliabilityNoQBFeature,
     "weighted_ppg_tuned_no_qb": WeightedPPGTunedNoQBFeature,
+    "weighted_ppg_pos_tuned_no_qb": WeightedPPGPerPositionTunedFeature,
     "age_curve": AgeCurveFeature,
     "stat_efficiency": StatEfficiencyFeature,
     "games_played": GamesPlayedFeature,

--- a/scripts/feature_projections/features/weighted_ppg.py
+++ b/scripts/feature_projections/features/weighted_ppg.py
@@ -70,19 +70,34 @@ class WeightedPPGFeature(ProjectionFeature):
         if history_df.empty:
             return None
 
+        weights = self._recency_weights(position)
         sorted_df = history_df.sort_values("season")
-        recent = sorted_df.tail(3)
+        recent = sorted_df.tail(len(weights))
         n = len(recent)
 
         if n == 1:
             return self._rookie_trajectory(recent.iloc[0], position)
         else:
-            return self._weighted_average(recent)
+            return self._weighted_average(recent, weights)
 
-    def _weighted_average(self, recent: pd.DataFrame) -> Optional[float]:
+    def _recency_weights(self, position: str) -> list[float]:
+        """Recency weights for this player's position (most recent season first).
+
+        The vector's length is also the per-player history window: compute()
+        uses the player's len(weights) most-recent seasons. Subclasses can
+        override to vary weights (and window) by position — see
+        WeightedPPGPerPositionTunedFeature (GH #639).
+        """
+        return self.RECENCY_WEIGHTS
+
+    def _weighted_average(
+        self, recent: pd.DataFrame, weights: Optional[list[float]] = None
+    ) -> Optional[float]:
         """Veteran projection: recency-weighted, games-scaled average."""
+        if weights is None:
+            weights = self.RECENCY_WEIGHTS
         n = len(recent)
-        weights = self.RECENCY_WEIGHTS[:n]
+        weights = weights[:n]
 
         numerator = 0.0
         denominator = 0.0
@@ -200,6 +215,55 @@ class WeightedPPGTunedNoQBFeature(WeightedPPGNoQBTrajectoryFeature):
     @property
     def is_base(self) -> bool:
         return True
+
+
+class WeightedPPGPerPositionTunedFeature(WeightedPPGNoQBTrajectoryFeature):
+    """WeightedPPG (no QB/K trajectory) with per-position recency weights.
+
+    GH #639: the #589 global tune ([0.65, 0.20, 0.15]) won at RB/WR while QB/TE
+    moved slightly the wrong way, suggesting positions differ in how fast their
+    signal decays. This variant gives each position its own weight vector,
+    chosen by the per-position inner-fold sweep
+    (``sweep_recency_weights.py --per-position``, honest protocol GH #595);
+    positions without an entry fall back to the #589 global tuned weights.
+
+    A vector's length is also that position's per-player history window
+    (compute() uses the len(weights) most-recent seasons), so a 2-weight
+    entry means "use only the player's two most recent seasons". Windows
+    longer than 3 require plumbing ``max_history`` through the pipeline —
+    don't add a 4-weight entry without that (the runner only fetches 3
+    seasons of history).
+    """
+
+    # Per-position sweep winners (GH #639, inner folds 2022-2024, exponent
+    # 1.0), picked with the #589 guardrail: prefer the cell that never loses
+    # an inner fold to the #589 tuned weights over the absolute-best mean.
+    # QB/WR: no cell beat the tuned weights in >=2 folds (QB's best-mean cell,
+    # the old prod default, loses 2/3 folds) — keep the global tune. RB:
+    # [0.70, 0.20, 0.10] never loses a fold (2.4006 vs 2.4034). TE: the only
+    # dominating cell is a 4-season window ([0.60, 0.20, 0.12, 0.08], 1.4927
+    # vs 1.5006, never loses) — sweep-only until max_history is plumbed, so
+    # TE keeps the global tune here.
+    POSITION_RECENCY_WEIGHTS: dict[str, list[float]] = {
+        "QB": [0.65, 0.20, 0.15],
+        "RB": [0.70, 0.20, 0.10],
+        "WR": [0.65, 0.20, 0.15],
+        "TE": [0.65, 0.20, 0.15],
+    }
+
+    # Fallback for K / unknown positions: the #589 global tuned weights.
+    RECENCY_WEIGHTS = [0.65, 0.20, 0.15]
+
+    @property
+    def name(self) -> str:
+        return "weighted_ppg_pos_tuned_no_qb"
+
+    @property
+    def is_base(self) -> bool:
+        return True
+
+    def _recency_weights(self, position: str) -> list[float]:
+        return self.POSITION_RECENCY_WEIGHTS.get(position, self.RECENCY_WEIGHTS)
 
 
 class WeightedPPGRookieGrowthFeature(WeightedPPGFeature):

--- a/scripts/feature_projections/model_config.py
+++ b/scripts/feature_projections/model_config.py
@@ -649,7 +649,12 @@ MODELS: dict[str, ModelDefinition] = {
             "(2022-2024, honest protocol GH #595) instead of #589's single "
             "global vector. Motivated by #589's win concentrating at RB/WR "
             "while QB/TE moved slightly the wrong way. Everything else "
-            "identical to v33."
+            "identical to v33. VERDICT: NEGATIVE (stopped on iteration look, "
+            "confirmation window not burned) — the sweep only changed RB "
+            "([0.70, 0.20, 0.10], inner-fold gain −0.003), and held-out "
+            "rolling 2023-24 the RB gain is noise (Δ −0.005, p=0.46) while "
+            "full-refit coefficient drift nets ALL Δ +0.015 vs v33 "
+            "(CI [−0.001, +0.032], p=0.066 — trending worse)."
         ),
         features=[
             "weighted_ppg_pos_tuned_no_qb",
@@ -690,7 +695,11 @@ MODELS: dict[str, ModelDefinition] = {
             "position's mean-reversion strength directly instead of a "
             "hand-swept factor. regression_to_mean is the most load-bearing "
             "feature in the #588 ablation (Δ +0.075 when removed) and its "
-            "strength has never varied by position."
+            "strength has never varied by position. VERDICT: NEGATIVE "
+            "(stopped on iteration look) — held-out rolling 2023-24 ALL Δ "
+            "+0.021 vs v33 (CI [−0.009, +0.053], p=0.18) with QB ρ −0.015; "
+            "the 4 extra interaction columns add variance, not signal — the "
+            "global regression coefficient was already right."
         ),
         features=[
             "weighted_ppg_tuned_no_qb",

--- a/scripts/feature_projections/model_config.py
+++ b/scripts/feature_projections/model_config.py
@@ -638,6 +638,89 @@ MODELS: dict[str, ModelDefinition] = {
         interaction_terms=["depth_chart_position_raw^2"],
         training_filter={"positions": ["QB"]},
     ),
+    "v35_pos_tuned_base": ModelDefinition(
+        name="v35_pos_tuned_base",
+        version=1,
+        description=(
+            "Per-position base tuning (GH #639): v33_tuned_base with the base "
+            "feature swapped to weighted_ppg_pos_tuned_no_qb, which uses a "
+            "per-position recency-weight vector (and per-position history "
+            "window via vector length) chosen on the inner tuning folds "
+            "(2022-2024, honest protocol GH #595) instead of #589's single "
+            "global vector. Motivated by #589's win concentrating at RB/WR "
+            "while QB/TE moved slightly the wrong way. Everything else "
+            "identical to v33."
+        ),
+        features=[
+            "weighted_ppg_pos_tuned_no_qb",
+            "age_curve",
+            "regression_to_mean",
+            "qb_backup_penalty",
+            "usage_share_raw",
+            "target_share_raw",
+            "air_yards_share_raw",
+            "wopr_raw",
+            "racr_raw",
+            "draft_capital_raw",
+            "implied_team_total_raw",
+            "depth_chart_position_raw",
+            "role_change_raw",
+        ],
+        combiner_type="learned",
+        interaction_terms=[
+            "usage_share_raw*position",
+            "usage_share_raw*base_ppg",
+            "usage_share_raw^2",
+            "target_share_raw*position",
+            "wopr_raw*base_ppg",
+            "wopr_raw^2",
+            "draft_capital_raw*position",
+            "implied_team_total_raw*position",
+            "depth_chart_position_raw*position",
+        ],
+    ),
+    "v36_pos_regression": ModelDefinition(
+        name="v36_pos_regression",
+        version=1,
+        description=(
+            "Per-position regression strength (GH #639): v33_tuned_base plus a "
+            "regression_to_mean*position interaction. In a learned combiner a "
+            "per-position REGRESSION_FACTOR is exactly a per-position "
+            "coefficient on the regression delta, so the ridge learns each "
+            "position's mean-reversion strength directly instead of a "
+            "hand-swept factor. regression_to_mean is the most load-bearing "
+            "feature in the #588 ablation (Δ +0.075 when removed) and its "
+            "strength has never varied by position."
+        ),
+        features=[
+            "weighted_ppg_tuned_no_qb",
+            "age_curve",
+            "regression_to_mean",
+            "qb_backup_penalty",
+            "usage_share_raw",
+            "target_share_raw",
+            "air_yards_share_raw",
+            "wopr_raw",
+            "racr_raw",
+            "draft_capital_raw",
+            "implied_team_total_raw",
+            "depth_chart_position_raw",
+            "role_change_raw",
+        ],
+        combiner_type="learned",
+        interaction_terms=[
+            "usage_share_raw*position",
+            "usage_share_raw*base_ppg",
+            "usage_share_raw^2",
+            "target_share_raw*position",
+            "wopr_raw*base_ppg",
+            "wopr_raw^2",
+            "draft_capital_raw*position",
+            "implied_team_total_raw*position",
+            "depth_chart_position_raw*position",
+            "regression_to_mean*position",
+        ],
+    ),
     "naive_prior_season_ppg": ModelDefinition(
         name="naive_prior_season_ppg",
         version=1,

--- a/scripts/feature_projections/sweep_recency_weights.py
+++ b/scripts/feature_projections/sweep_recency_weights.py
@@ -1,13 +1,25 @@
-"""Sweep the WeightedPPG base feature's hyperparameters (GH #271, #589).
+"""Sweep the WeightedPPG base feature's hyperparameters (GH #271, #589, #639).
 
-Grid-searches the two real knobs of the production base feature
+Grid-searches the real knobs of the production base feature
 (``weighted_ppg_no_qb_trajectory`` — every model since v12 uses the no-QB/K
 trajectory base):
 
-- **Recency weights** — the 3-season blend, most recent first.
+- **Recency weights** — the recency blend, most recent first. The vector's
+  length is also the per-player history window (compute() uses the
+  len(weights) most-recent seasons), so 2- and 4-weight variants sweep the
+  window-length axis (#639). 4-weight cells answer "would a 4th season help?"
+  — adopting one in production additionally requires plumbing ``max_history``
+  through the pipeline (the runner fetches 3 seasons).
 - **Games-reliability exponent** — the per-season reliability factor is
   ``(games_played / 17) ** exponent``; >1.0 down-weights partial seasons
   harder (v28 tried 1.5 at the model level, judged on leaked data).
+
+``--per-position`` (#639) additionally prints, for each of QB/RB/WR/TE, the
+cells ranked by that position's MAE with per-fold values — positions plausibly
+differ in signal decay, and the #589 global tune won at RB/WR while QB/TE
+moved slightly the wrong way. Cells are scored on a common qualifier
+population (players with a season in the production 3-year window) so
+different window lengths stay comparable.
 
 Each (weights, exponent) cell scores the *isolated* base feature against
 next-season actuals. Tuning runs on the **inner folds** (default
@@ -54,13 +66,33 @@ WEIGHT_VARIANTS = [
     [0.50, 0.30, 0.20],
     [0.55, 0.30, 0.15],
     [0.60, 0.25, 0.15],
-    [0.65, 0.20, 0.15],
+    [0.65, 0.20, 0.15],  # #589 tuned production value
     [0.60, 0.30, 0.10],
     [0.70, 0.20, 0.10],
+    [0.75, 0.15, 0.10],
     [0.80, 0.15, 0.05],  # near prior-season-only
 ]
 
+# Window-length axis (#639). A 2-weight vector uses only the player's two
+# most-recent seasons; a 4-weight vector reaches back four (sweep-only until
+# max_history is plumbed — see module docstring).
+WINDOW_VARIANTS = [
+    [0.60, 0.40],
+    [0.65, 0.35],
+    [0.70, 0.30],
+    [0.75, 0.25],
+    [0.80, 0.20],
+    [0.50, 0.25, 0.15, 0.10],
+    [0.55, 0.20, 0.15, 0.10],
+    [0.60, 0.20, 0.12, 0.08],
+    [0.45, 0.25, 0.20, 0.10],
+]
+
 DEFAULT_EXPONENTS = [1.0, 1.25, 1.5, 2.0]
+
+# Positions reported individually in --per-position mode. K is excluded —
+# essentially random year-over-year and not the target of base tuning.
+SWEEP_POSITIONS = ["QB", "RB", "WR", "TE"]
 
 
 def _compute_metrics(projected: list[float], actual: list[float]) -> dict:
@@ -86,9 +118,13 @@ def _compute_metrics(projected: list[float], actual: list[float]) -> dict:
 
 def _fetch_season_data(
     seasons: list[int],
-    max_history: int = 3,
+    max_history: int = 4,
 ) -> tuple[dict[str, str], dict[int, pd.DataFrame], dict[int, dict[str, float]]]:
     """Fetch everything the sweep needs once, so the grid loop is in-memory only.
+
+    Fetches one season beyond the production 3-year window so 4-weight cells
+    can be scored; ≤3-weight cells slice back down to the production window
+    per player in _run_projections.
 
     Returns (position map, {season: history_df}, {season: {player_id: actual_ppg}}).
     """
@@ -140,6 +176,14 @@ def _run_projections(
     WeightedPPGFeature.GAMES_RELIABILITY_EXPONENT = exponent
     feature = WeightedPPGNoQBTrajectoryFeature()
 
+    # Production-faithful window: ≤3-weight cells only see the 3-year fetch
+    # window; 4-weight cells reach one season further back. Either way the
+    # qualifier population is fixed to players with a season inside the
+    # production 3-year window, so cells with different window lengths score
+    # the same players (a window-4 cell must not "win" by adding stale-history
+    # players the others never see).
+    window = max(len(weights), 3)
+
     all_results: dict[int, dict[str, dict]] = {}
 
     for target_season in seasons:
@@ -163,9 +207,15 @@ def _run_projections(
             if not position:
                 continue
 
+            if not (player_history["season"] >= target_season - 3).any():
+                continue  # outside the common qualifier population
+            window_history = player_history[
+                player_history["season"] >= target_season - window
+            ]
+
             # Compute base feature only (no nfl_stats needed for weighted_ppg)
             projected = feature.compute(
-                player_id_str, position, player_history, pd.DataFrame(), {}
+                player_id_str, position, window_history, pd.DataFrame(), {}
             )
             if projected is None:
                 continue
@@ -205,6 +255,69 @@ def _weighted_avg(results: dict[int, dict[str, dict]], pos: str, metric: str) ->
     return sum(v * w for v, w in pairs) / sum(w for _, w in pairs)
 
 
+def _print_per_position_tables(
+    grid_results: list[tuple[list[float], float, dict[int, dict[str, dict]]]],
+    seasons: list[int],
+    top_n: int = 12,
+) -> None:
+    """Per-position cell ranking with per-fold MAEs (#639).
+
+    The 'vs tuned' column counts inner folds where the cell's position MAE is
+    <= the #589 tuned production cell ([0.65, 0.20, 0.15] exp 1.0) — the #589
+    guardrail prefers a cell that never loses a fold over the absolute-best
+    mean (grid-overfit protection).
+    """
+    ref = next(
+        (r for w, e, r in grid_results if w == [0.65, 0.20, 0.15] and e == 1.0),
+        None,
+    )
+
+    for pos in SWEEP_POSITIONS:
+        rows = []
+        for weights, exponent, results in grid_results:
+            mae = _weighted_avg(results, pos, "mae")
+            if mae is None:
+                continue
+            fold_maes = [
+                results.get(s, {}).get(pos, {}).get("mae") for s in seasons
+            ]
+            folds_won = None
+            if ref is not None:
+                won, total = 0, 0
+                for s in seasons:
+                    cell_m = results.get(s, {}).get(pos, {}).get("mae")
+                    ref_m = ref.get(s, {}).get(pos, {}).get("mae")
+                    if cell_m is not None and ref_m is not None:
+                        total += 1
+                        if cell_m <= ref_m:
+                            won += 1
+                folds_won = f"{won}/{total}"
+            n = sum(
+                results.get(s, {}).get(pos, {}).get("n", 0) or 0 for s in seasons
+            )
+            rows.append((mae, weights, exponent, fold_maes, folds_won, n))
+
+        rows.sort(key=lambda r: r[0])
+
+        print(f"\n--- {pos} — top {top_n} cells by weighted MAE ---")
+        fold_hdr = " ".join(f"{s:>8}" for s in seasons)
+        print(f"{'Weights':<28} {'Exp':>5} {'MAE':>8} {fold_hdr} {'vs tuned':>9} {'N':>5}")
+        for mae, weights, exponent, fold_maes, folds_won, n in rows[:top_n]:
+            label = f"[{', '.join(f'{w:.2f}' for w in weights)}]"
+            marker = ""
+            if weights == CURRENT_WEIGHTS and exponent == CURRENT_EXPONENT:
+                marker = " (prod default)"
+            elif weights == [0.65, 0.20, 0.15] and exponent == 1.0:
+                marker = " (#589 tuned)"
+            folds = " ".join(
+                f"{m:>8.4f}" if m is not None else f"{'—':>8}" for m in fold_maes
+            )
+            print(
+                f"{label:<28} {exponent:>5.2f} {mae:>8.4f} {folds} "
+                f"{folds_won or '—':>9} {n:>5}{marker}"
+            )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Sweep WeightedPPG base hyperparameters (recency weights × reliability exponent)"
@@ -221,13 +334,28 @@ def main() -> None:
         help="Comma-separated games-reliability exponents to grid over "
              f"(default: {','.join(str(e) for e in DEFAULT_EXPONENTS)})",
     )
+    parser.add_argument(
+        "--per-position",
+        action="store_true",
+        help="Print per-position (QB/RB/WR/TE) cell rankings with per-fold MAEs (#639)",
+    )
+    parser.add_argument(
+        "--windows",
+        action="store_true",
+        help="Include 2- and 4-season window variants in the grid (#639). "
+             "4-weight cells are sweep-only until max_history is plumbed.",
+    )
     args = parser.parse_args()
     seasons = [int(s.strip()) for s in args.seasons.split(",")]
     exponents = [float(e.strip()) for e in args.exponents.split(",")]
     warn_on_confirmation_overlap(seasons)
 
+    weight_variants = list(WEIGHT_VARIANTS)
+    if args.windows:
+        weight_variants += WINDOW_VARIANTS
+
     print(
-        f"Grid: {len(WEIGHT_VARIANTS)} weight variants × {len(exponents)} exponents "
+        f"Grid: {len(weight_variants)} weight variants × {len(exponents)} exponents "
         f"across seasons {seasons} (base: weighted_ppg_no_qb_trajectory)\n"
     )
 
@@ -236,7 +364,7 @@ def main() -> None:
 
     grid_results: list[tuple[list[float], float, dict[int, dict[str, dict]]]] = []
 
-    for weights in WEIGHT_VARIANTS:
+    for weights in weight_variants:
         for exponent in exponents:
             results = _run_projections(
                 weights, exponent, seasons, pos_map, history_by_season, actuals_by_season
@@ -298,6 +426,12 @@ def main() -> None:
             rmse = _weighted_avg(best_results, pos, "rmse")
             if mae is not None:
                 print(f"{pos:<10} {mae:>8.4f} {bias:>+8.4f} {r_sq:>8.4f} {rmse:>8.4f}")
+
+    if args.per_position:
+        print(f"\n{'='*88}")
+        print("PER-POSITION RANKINGS (#639)")
+        print(f"{'='*88}")
+        _print_per_position_tables(grid_results, seasons)
 
     # Restore the production values patched during the sweep
     WeightedPPGFeature.RECENCY_WEIGHTS = CURRENT_WEIGHTS

--- a/scripts/tests/test_feature_projections.py
+++ b/scripts/tests/test_feature_projections.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from scripts.feature_projections.features.weighted_ppg import (
     WeightedPPGFeature,
+    WeightedPPGPerPositionTunedFeature,
     WeightedPPGRookieGrowthFeature,
     WeightedPPGRookieGrowthNoQBFeature,
     WeightedPPGTunedNoQBFeature,
@@ -174,6 +175,83 @@ class TestWeightedPPGTunedNoQBFeature:
         """The tuned subclass overrides, not mutates, the parent's weights."""
         assert WeightedPPGFeature.RECENCY_WEIGHTS == [0.55, 0.25, 0.20]
         assert WeightedPPGTunedNoQBFeature.RECENCY_WEIGHTS == [0.65, 0.20, 0.15]
+
+
+# ---------------------------------------------------------------------------
+# WeightedPPGPerPositionTunedFeature (#639)
+# ---------------------------------------------------------------------------
+
+class TestWeightedPPGPerPositionTunedFeature:
+    """Tests for the per-position tuned base feature (GH #639)."""
+
+    def setup_method(self):
+        self.feature = WeightedPPGPerPositionTunedFeature()
+
+    def test_name(self):
+        assert self.feature.name == "weighted_ppg_pos_tuned_no_qb"
+        assert self.feature.is_base is True
+
+    def test_uses_position_weights(self):
+        """Each position blends with its own weight vector."""
+        df = make_history_df([
+            {"season": 2022, "ppg": 10.0, "games_played": 17},
+            {"season": 2023, "ppg": 15.0, "games_played": 17},
+            {"season": 2024, "ppg": 20.0, "games_played": 17},
+        ])
+        for pos in ["QB", "RB", "WR", "TE"]:
+            weights = self.feature.POSITION_RECENCY_WEIGHTS[pos]
+            recent = [20.0, 15.0, 10.0][: len(weights)]
+            expected = sum(p * w for p, w in zip(recent, weights)) / sum(weights)
+            result = self.feature.compute("p1", pos, df, pd.DataFrame(), {})
+            assert result == pytest.approx(expected), pos
+
+    def test_fallback_for_unmapped_position(self):
+        """K (no per-position entry) falls back to the #589 global tuned weights."""
+        df = make_history_df([
+            {"season": 2022, "ppg": 10.0, "games_played": 17},
+            {"season": 2023, "ppg": 15.0, "games_played": 17},
+            {"season": 2024, "ppg": 20.0, "games_played": 17},
+        ])
+        result = self.feature.compute("p1", "K", df, pd.DataFrame(), {})
+        w = self.feature.RECENCY_WEIGHTS
+        expected = (20.0 * w[0] + 15.0 * w[1] + 10.0 * w[2]) / sum(w)
+        assert result == pytest.approx(expected)
+
+    def test_two_weight_vector_uses_two_season_window(self):
+        """A 2-weight entry must ignore the third-most-recent season entirely."""
+        df = make_history_df([
+            {"season": 2022, "ppg": 100.0, "games_played": 17},  # would dominate if leaked in
+            {"season": 2023, "ppg": 15.0, "games_played": 17},
+            {"season": 2024, "ppg": 20.0, "games_played": 17},
+        ])
+        original = WeightedPPGPerPositionTunedFeature.POSITION_RECENCY_WEIGHTS
+        try:
+            WeightedPPGPerPositionTunedFeature.POSITION_RECENCY_WEIGHTS = {
+                **original, "RB": [0.70, 0.30],
+            }
+            result = self.feature.compute("p1", "RB", df, pd.DataFrame(), {})
+            assert result == pytest.approx(20.0 * 0.70 + 15.0 * 0.30)
+        finally:
+            WeightedPPGPerPositionTunedFeature.POSITION_RECENCY_WEIGHTS = original
+
+    def test_no_qb_trajectory_inherited(self):
+        """QB single-season keeps plain PPG (no H2/H1 snap multiplier)."""
+        df = make_history_df([{
+            "season": 2024, "ppg": 12.0, "games_played": 17,
+            "h1_snaps": 200, "h1_games": 8,
+            "h2_snaps": 360, "h2_games": 9,
+        }])
+        result = self.feature.compute("p1", "QB", df, pd.DataFrame(), {})
+        assert result == pytest.approx(12.0)
+
+    def test_does_not_mutate_parents(self):
+        assert WeightedPPGFeature.RECENCY_WEIGHTS == [0.55, 0.25, 0.20]
+        assert WeightedPPGTunedNoQBFeature.RECENCY_WEIGHTS == [0.65, 0.20, 0.15]
+        for weights in WeightedPPGPerPositionTunedFeature.POSITION_RECENCY_WEIGHTS.values():
+            assert len(weights) <= 3, (
+                "windows longer than 3 require max_history plumbing in the "
+                "runner/backtest/holdout pipeline — see GH #639"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Held-out verdict (the gate) — both candidates NEGATIVE, stopped on iteration look

Rolling-origin protocol, eval folds 2023–24 (**iteration look — the 2025 confirmation window was not burned**), player-clustered paired bootstrap vs the active `v33_tuned_base`:

| Model | Held-out ALL MAE | Δ vs v33 | 95% CI | p | Verdict |
|---|---|---|---|---|---|
| `v35_pos_tuned_base` (per-position recency weights) | 2.245 | **+0.015** | [−0.001, +0.032] | 0.066 | **NOT significant — trending worse. NEGATIVE.** |
| `v36_pos_regression` (regression_to_mean*position) | 2.251 | **+0.021** | [−0.009, +0.053] | 0.18 | **NOT significant. NEGATIVE.** |
| `v33_tuned_base` (active) | 2.230 | — | — | — | stays active |

Segment check for v35 (its only change is RB): RB-only Δ **−0.005**, CI [−0.018, +0.008], p=0.46 — the swept RB gain is noise out-of-sample, while full-refit coefficient drift nudges other positions worse.

**Ranking quality (#598/#638):** ≈ everywhere — v35: TE ρ +0.001, QB −0.003, WR −0.003 (WR top-24 hit 0.458→0.417); v36: QB ρ −0.015, rest ±0.005. No ordering-motivated rescue.

## What the inner-fold sweep established (2022–2024, exponent 1.0 per #589)

- **Per-position recency weights: the #589 global tune is already right.** With the never-lose-a-fold guardrail, QB and WR produce no dominating cell; only RB ([0.70, 0.20, 0.10], −0.003) dominates, and it doesn't survive held-out. Position-decay differences are smaller than fold noise — don't re-sweep without new signal.
- **Window length: 3 seasons confirmed for QB/RB/WR.** 2-season windows lose decisively everywhere. **TE's 4-season cell [0.60, 0.20, 0.12, 0.08] never loses a fold** (1.4927 vs 1.5006) but needs `max_history` plumbed through runner/backtest/holdout — left as the residual #639 follow-up.
- **Per-position regression strength: the global coefficient was already right** (v36's 4 extra interaction columns add variance, not signal).

Net: base + global regression is now a well-defended local optimum (#589 exponent grid, #592, this). Next bets are new signal (#640–#642) or a different objective (#643).

## Changes

- `sweep_recency_weights.py`: `--per-position` fold-level rankings with a vs-tuned fold-win column; `--windows` axis (2-/4-season vectors) scored on a fixed common qualifier population so window lengths stay comparable
- `weighted_ppg.py`: per-player window now derives from `len(weights)` (byte-identical at length 3); `_recency_weights(position)` hook; new `WeightedPPGPerPositionTunedFeature` (`weighted_ppg_pos_tuned_no_qb`) with the sweep winners
- `model_config.py`: `v35_pos_tuned_base` + `v36_pos_regression` registered with NEGATIVE verdicts in their descriptions (kept per the do-not-retry convention, like v32/v34)
- Tests: `TestWeightedPPGPerPositionTunedFeature` (per-position weights, K fallback, 2-season window semantics, ≤3-window guard pending `max_history` plumbing); 186 passed
- Experiment log: two rows (with the new Rank Δ column from #638) + a #639 findings section; backlog refresh in the exec plan listing #639–#645 with the no-market-inputs constraint

**No promotion** — `v33_tuned_base` remains active; no production behavior changes in this PR.

Stacked on #638 (experiment-log Rank Δ column); will retarget to `main` automatically when that merges.

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)