### PR TITLE
docs(#626): correct stale local-build instructions; document just build as pre-push check

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -11,8 +11,8 @@ npm test             # Jest tests
 npm start            # Production server
 ```
 
-> **Worktree note:** Git worktrees share source files but not `node_modules/` or gitignored files.
-> Before building in a worktree, run `npm install` in `web/` and copy `config.json` from the main repo root.
+> **Worktree note:** Git worktrees check out tracked files (including `config.json`) but not `node_modules/` or other gitignored files.
+> Before building in a worktree, run `npm install` in `web/`. `config.json` is tracked, so no copy step is needed.
 
 ## Backend (run from project root, venv must be active)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -25,15 +25,20 @@ The repo is installed as an editable package (`pip install -e .`). The import fi
 - **Run all:** `just test-web` (runs the full suite with coverage)
 - **Run one file:** `just test-web-file <path>` — e.g. `just test-web-file __tests__/lib/session.test.ts`. Prefer this over raw `npx jest <file>` so the call is covered by the `Bash(just:*)` allowlist.
 
-### TypeScript type-checking
+### Web verification: `just typecheck` vs `just build`
 
-Use `tsc --noEmit` for local type-checking — **do not use `npm run build`** for this purpose:
+Two levels of local verification for web changes:
 
-```bash
-cd web && ./node_modules/.bin/tsc --noEmit
-```
+- **`just typecheck`** (`tsc --noEmit`) — fast, fully offline. The default check while iterating.
+  ```bash
+  just typecheck      # or: cd web && ./node_modules/.bin/tsc --noEmit
+  ```
+- **`just build`** (`next build`) — highest fidelity: full type check **plus** prerender of every route. Run this before pushing web changes. `config.json` is committed at the repo root (league constants only, no secrets), so the build resolves it without any manual copy step.
+  ```bash
+  just build
+  ```
 
-`npm run build` requires `config.json` (present in CI/production, absent in local dev) and will fail with a "Module not found" error unrelated to your changes.
+> **Offline caveat:** `next build` prerenders `app/layout.tsx`, which uses `next/font/google` (Geist) — that fetches the font from Google Fonts at build time, so the build needs network access. In a fully network-isolated sandbox `just build` fails on the font fetch (not on `config.json`); use `just typecheck` there instead.
 
 ## Key Test Files
 


### PR DESCRIPTION
## Summary

Burns down #626. **The `config.json` blocker the issue describes was already fixed by #537** — `config.json` (league constants only, **no secrets** — cross-checked against `docs/references/environment-variables.md`) is committed at the repo root and tracked by git, so local `next build` resolves it with no manual copy step. I verified the build now compiles and only fails on the Google-Fonts fetch in `layout.tsx` (a network requirement in this isolated sandbox), **not** on `config.json`.

The remaining problem was that the docs still claimed the old behavior, actively misleading agents/humans away from `just build`.

## Changes
- **`docs/TESTING.md`** — replaced the "do not use `npm run build` / config.json absent locally" warning with a two-level web-verification section:
  - `just typecheck` (`tsc --noEmit`) — fast, fully offline; the default while iterating.
  - `just build` (`next build`) — highest fidelity (type check + prerender every route); the pre-push check for web changes.
  - Documented the one real caveat: `next build` prerenders `layout.tsx`, which fetches Geist via `next/font/google`, so it needs network — use `just typecheck` in fully offline sandboxes.
- **`docs/COMMANDS.md`** — fixed the worktree note: `config.json` is tracked, so worktrees check it out automatically; the "copy config.json" step is gone.

## Acceptance criteria
- [x] `just build` succeeds from a fresh clone with no manual config steps (on a networked machine; config.json is committed)
- [x] No secret values committed — config.json is league constants only
- [x] CI/Vercel build behavior unchanged (real `config.json` already wins)
- [x] TESTING.md warning replaced; `just build` documented as the pre-push verification for web changes
- [x] Architecture/config-sync tests still pass (17 web arch tests, `tsc --noEmit`)

## Verification
- `npx jest __tests__/lib/architecture.test.ts` → 17 passed
- `tsc --noEmit` → clean
- `next build` → compiles, resolves `config.json`, fails only on Google-Fonts fetch (sandbox has no network)
- `just check-docs` → all pass

Note: a fully offline `just build` would require self-hosting the Geist font (out of scope here, and not fetchable in this sandbox). Flagged in the docs as the known caveat.

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)