### PR TITLE
enh(#628): add 'just preflight' fast local gate + opt-in pre-push hook; drop CI coverage

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,19 +32,14 @@ jobs:
     - name: Install dependencies (from pinned lock)
       run: time uv pip install --system -r requirements.txt
 
-    - name: Run pytest with coverage
-      run: |
-        python -m pytest --cov=. --cov-report=term-missing --cov-report=html:coverage-html
+    # Coverage was computed and uploaded but never gated on or read (#628), so
+    # it was pure runtime cost — dropped. Run coverage locally via
+    # `just test-python` when you want it.
+    - name: Run pytest
+      run: python -m pytest --no-cov
 
     - name: Check documentation freshness
       run: python scripts/check_docs_freshness.py
-
-    - name: Upload Python coverage report
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: python-coverage
-        path: coverage-html/
 
   web-tests:
     runs-on: ubuntu-latest
@@ -70,12 +65,7 @@ jobs:
     - name: ESLint
       run: npm run lint
       
-    - name: Run Jest tests with coverage
-      run: npx jest --coverage --ci
-
-    - name: Upload web coverage report
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: web-coverage
-        path: web/coverage/
+    # Coverage dropped from CI (#628) — never gated on or read. Run it locally
+    # with `just test-web` when needed.
+    - name: Run Jest tests
+      run: npx jest --ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ Run `just check-arch` to validate these rules locally.
 - **Update documentation:** Always try to update the agent documentation after completing a task. Update existing documents or add new documents and sections as needed to reflect architectural or contextual changes.
 - **Never commit directly to `main`.** All changes go through pull requests.
 - **Always create a PR.** Every task must end with `gh pr create --fill`.
+- **Run `just preflight` before pushing.** It mirrors CI's pass/fail (lint + typecheck + both test suites without coverage + doc checks) in ~9s, so failures surface locally instead of in a multi-minute CI round-trip. `just install-hooks` installs it as an opt-in pre-push hook (`git push --no-verify` to skip a WIP push).
 - **Start from updated main:** `git checkout main && git pull origin main` before branching.
 - **Bash cwd persists between calls.** A `cd web && …` leaves the shell in `web/`, so a later repo-root-relative path (e.g. `git add web/next.config.ts`) silently fails. Prefer absolute paths, `git -C <repo-root>`, or re-`cd` explicitly rather than assuming the working directory.
 - See [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md) for full details.

--- a/Justfile
+++ b/Justfile
@@ -118,6 +118,19 @@ check-schema:
 permission-report *args:
     python3 .claude/hooks/permission_report.py {{args}}
 
+# Fast pre-PR gate (<30s): lint + typecheck + both test suites (no coverage) + doc checks.
+# Mirrors CI's pass/fail so failures are caught locally, not in a multi-minute runner round-trip.
+preflight: lint typecheck
+    {{pytest}} --no-cov
+    cd web && npx jest --no-coverage --ci
+    {{python}} scripts/check_docs_freshness.py
+
+# Install the opt-in pre-push hook that runs `just preflight` (skip a push with --no-verify)
+install-hooks:
+    cp scripts/git-hooks/pre-push "$(git rev-parse --git-common-dir)/hooks/pre-push"
+    chmod +x "$(git rev-parse --git-common-dir)/hooks/pre-push"
+    @echo "Installed pre-push hook. Skip a push with: git push --no-verify  (or SKIP_PREFLIGHT=1 git push)"
+
 # Full CI suite (lint + typecheck + tests + doc checks)
 ci: lint typecheck test check-docs
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -110,6 +110,8 @@ just check-migrations   # Lint migrations/ naming + sequence (offline; see migra
 just check-docs         # Documentation freshness check
 just check-schema       # DB schema drift: live DB vs types + db-schema.md (read-only; on-demand, post-migration)
 just permission-report [--days N] [--check]  # Permission-prompt rate + top families; --check exits 2 on 7d-vs-28d regression (see docs/references/autonomous-operation.md)
+just preflight          # Fast pre-PR gate (~9s): lint + typecheck + both test suites (no coverage) + doc checks
+just install-hooks      # Install the opt-in pre-push hook that runs `just preflight` (skip a push with --no-verify)
 just ci                 # Full CI suite (lint + typecheck + tests + doc checks)
 just roster-context [season]  # Build the roster-question context pack (live league data); season defaults to 2026
 

--- a/docs/GIT_WORKFLOW.md
+++ b/docs/GIT_WORKFLOW.md
@@ -27,7 +27,15 @@ Before beginning ANY new task or change, always follow this workflow:
    git commit -m "Clear description of changes"
    ```
 
-4. **Push the branch and create a pull request:**
+4. **Run `just preflight` before pushing:**
+   ```bash
+   just preflight   # lint + typecheck + both test suites (no coverage) + doc checks, ~9s
+   ```
+   This mirrors CI's pass/fail locally so failures are caught here instead of in a
+   multi-minute CI round-trip. Optionally install it as a pre-push hook once with
+   `just install-hooks` (opt-in; skip a WIP push with `git push --no-verify`).
+
+5. **Push the branch and create a pull request:**
    ```bash
    git push -u origin descriptive-branch-name
    gh pr create --fill

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Opt-in pre-push gate — installed by `just install-hooks` (#628).
+#
+# Runs `just preflight` (lint + typecheck + both test suites without coverage +
+# doc checks) before a push so failures are caught locally instead of in a
+# multi-minute CI round-trip.
+#
+# Skip a WIP push:  git push --no-verify   (or:  SKIP_PREFLIGHT=1 git push)
+set -euo pipefail
+
+if [ "${SKIP_PREFLIGHT:-}" = "1" ]; then
+  echo "pre-push: SKIP_PREFLIGHT=1 — skipping preflight."
+  exit 0
+fi
+
+# Linked worktrees use the main checkout's venv (absolute path) and shouldn't be
+# blocked by this hook — skip there. Detect via the git dir path.
+case "$(git rev-parse --git-dir 2>/dev/null)" in
+  */worktrees/*)
+    echo "pre-push: linked worktree — skipping preflight (run it from the main checkout)."
+    exit 0
+    ;;
+esac
+
+echo "pre-push: running 'just preflight' (skip with SKIP_PREFLIGHT=1 or git push --no-verify)…"
+exec just preflight


### PR DESCRIPTION
## Summary

Burns down #628. Failures that the full local check catches were routinely found in CI, costing a multi-minute runner round-trip per fix.

### `just preflight` — fast pre-PR gate (~9s)
`lint + typecheck + both test suites (no coverage) + doc checks` — mirrors CI's pass/fail so failures surface locally.
```
Test Suites: 26 passed, 26 total · Tests: 260 passed (web) + full Python suite
real    0m8.6s     ← well under the 30s target
```

### `just install-hooks` — opt-in pre-push hook
Installs `scripts/git-hooks/pre-push` (committed + reviewable) which runs `just preflight`. **Opt-in**, not enforced:
- self-skips in **linked worktrees** (they use the main checkout's venv), so worktree agents aren't blocked
- honors `git push --no-verify` and `SKIP_PREFLIGHT=1` for quick WIP pushes

### Coverage decision: removed from CI
Both CI jobs computed and uploaded coverage artifacts that were never gated on or read — pure runtime cost. **Dropped** from `run-tests.yml` (pytest `--no-cov`, jest without `--coverage`, both upload steps removed). Coverage stays available locally via `just test-python` / `just test-web` (the pyproject addopts still enable it there).

### Docs
- `CLAUDE.md` critical rules + `docs/GIT_WORKFLOW.md` step 4: run `just preflight` before pushing.
- Recipes added to `docs/COMMANDS.md`.

## Acceptance criteria
- [x] `just preflight` exists, passes on clean main, <30s (8.6s)
- [x] Hook installer is opt-in and documented
- [x] Coverage decision made + implemented (removed from CI)
- [x] CLAUDE.md / GIT_WORKFLOW.md updated

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)