### PR TITLE
docs(#627): Python 3.12 + pandas 2.x upgrade spike findings (GO verdict)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ docs/
 │   ├── [projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md)  # 4-phase accuracy improvement roadmap
 │   ├── [projection-methodology-audit.md](docs/exec-plans/projection-methodology-audit.md)  # ML-quality audit: train/test leakage + eval findings (#571–#577)
 │   ├── [projection-system-review.md](docs/exec-plans/projection-system-review-2026-06.md)  # 2026-06 expert review + implementation plan (#594–#599, waves for #587–#592)
+│   ├── [python-312-upgrade-spike.md](docs/exec-plans/python-312-upgrade-spike.md)  # Spike: Py3.9→3.12 + pandas 2.x — GO verdict + nfl_data_py blocker (#627)
 │   ├── [qb-usage-share.md](docs/exec-plans/qb-usage-share.md)              # QB Usage Share findings and next steps
 │   └── [season-cycle.md](docs/exec-plans/season-cycle.md)                # Cross-season data & UI scheme (date-driven season-cycle resolver)
 ├── generated/

--- a/docs/exec-plans/python-312-upgrade-spike.md
+++ b/docs/exec-plans/python-312-upgrade-spike.md
@@ -1,0 +1,87 @@
+# Spike: Python 3.9 → 3.12 + pandas 1.5 → 2.x (GH #627)
+
+**Status:** Spike complete (2026-06-14). **Verdict: GO**, conditional on replacing the
+`nfl_data_py==0.3.3` pin. The follow-up upgrade PR is not yet done.
+
+## Method
+
+Timeboxed spike in a throwaway environment, no changes to the tracked repo:
+
+- Installed a standalone CPython **3.12.13** via `uv python install 3.12`.
+- Built a fresh venv and resolved the project's dependency set **unpinned**.
+- Ran the **full Python test suite** against it.
+- Probed the `nfl_data_py` ↔ pandas 2.x compatibility directly (the issue's gating question).
+
+## Findings
+
+### 1. Gating blocker — `nfl_data_py==0.3.3` hard-pins `pandas==1.5.3`
+
+This is the one real blocker. `nfl_data_py==0.3.3` declares an **exact** `pandas==1.5.3`
+dependency. On Python 3.12 that pin fails outright: pandas 1.5.3 ships no 3.12 wheels and
+its sdist build breaks (3.12 removed `distutils`/`pkg_resources` assumptions). So the
+current pin and the upgrade are mutually exclusive.
+
+Resolution options (pick in the upgrade PR):
+
+| Option | Change | Pros | Cons |
+|---|---|---|---|
+| **A. Pin `nfl_data_py==0.3.2`** | one-line dep change | smallest diff; **same API** (`import_*` functions); allows modern pandas | 0.3.2 is older; verify the data it returns is unchanged vs 0.3.3 |
+| **B. Migrate to `nflreadpy`** | rewrite scraper/backfill calls | actively maintained successor; future-proof | **polars-based**, different API — a real rewrite across `scripts/tasks/` + backfills |
+
+`nfl_data_py==0.3.2` resolves cleanly with both pandas 2.3.3 and 3.0.3 and imports on
+3.12 with all `import_*` functions present. **Recommended: start with Option A** (relax to
+0.3.2 + pin pandas to 2.x), and treat the `nflreadpy` migration as a separate, later effort.
+
+### 2. The rest of the stack is already 3.12-ready
+
+With `nfl_data_py==0.3.2` and `pandas>=2.2,<3` (resolved to **pandas 2.3.3**, numpy 2.x),
+the full project dependency set — `playwright`, `supabase`, `python-dotenv`,
+`scikit-learn`, `requests`, `beautifulsoup4`, `lxml`, `pytest` — installed cleanly on 3.12.
+
+### 3. Test suite is green on 3.12 + pandas 2.3.3
+
+```
+1451 passed, 67 skipped in 4.81s
+```
+
+Only two warnings, neither version-blocking:
+
+- `DeprecationWarning: datetime.datetime.utcnow()` at `scripts/feature_projections/train_model.py:464`
+  (the project has **2** `utcnow()` call sites total) — switch to
+  `datetime.now(timezone.utc)` in the upgrade PR.
+- A pre-existing `RankWarning` from `np.polyfit` in `projection_methods.py` — unrelated to the version bump.
+
+### 4. Not yet verified in the spike (do in the upgrade PR)
+
+The spike covered the gating question (deps + unit suite). Still to confirm before merge,
+per the issue's acceptance criteria:
+
+- **Numerical equivalence**: one `just backtest <active>` and one
+  `just holdout-eval --protocol rolling …` on the new stack, compared against the active
+  model — projection outputs must not silently change (pandas 2.x groupby/NA/dtype
+  semantics differ). Rerun the holdout gate as confirmation.
+- One **scraper dry-run** (`nfl_data_py` 0.3.2 fetch path) end-to-end.
+- **pandas perf claim**: the issue cites 2.x speedups on backtests/holdout/sweeps — measure
+  the actual wall-clock on a real backtest before/after rather than assuming.
+
+## Recommended upgrade PR scope (when scheduled)
+
+1. `pyproject.toml`: `requires-python = ">=3.12"`, `nfl_data_py==0.3.2`, `pandas>=2.2,<3`
+   (deliberately stay on 2.x, not the brand-new 3.0), bump `numpy`. `just lock`.
+2. CI: `python-version` → 3.12 across `run-tests.yml`, `update-projections.yml`,
+   `offseason-data-refresh.yml`. Devcontainer base image → 3.12.
+3. Fix the two `datetime.utcnow()` call sites.
+4. `just doctor` resolves the editable-finder path under `venv/lib/python3.9/...` — update
+   the version-specific glob (it already globs `python*`, but re-verify) and any docs that
+   hardcode `python3.9` (TESTING.md gotcha section references the 3.9 finder filename).
+5. **Delete the "Python Style / target 3.9 / no `X | Y`" section from CLAUDE.md** — the
+   recurring agent-correction tax this issue calls out goes away.
+6. Confirmation: full suite + one experiment loop green; holdout numbers vs active model
+   unchanged or deltas explained; venv rebuild (`just install`) documented.
+
+## One-line verdict
+
+**GO.** Python 3.12 + pandas 2.x is viable with no code rewrite — the only blocker is the
+`nfl_data_py==0.3.3` `pandas==1.5.3` pin; relax to `0.3.2`. The full unit suite passes on
+3.12/pandas 2.3.3; remaining work is numerical-equivalence confirmation + the dep/CI/style
+cleanup, sized as a normal medium PR rather than the original "high" estimate.


### PR DESCRIPTION
## Summary

Delivers the **spike** half of #627 (acceptance #1: "Spike findings posted before any upgrade PR"). Verdict: **GO**.

> **Does not close #627** — this PR is findings only. The actual upgrade (deps/CI/devcontainer bump, numerical-equivalence verification, CLAUDE.md style-section removal) is the follow-up that satisfies the issue's remaining criteria. Leaving #627 open to track it.

### Method
Standalone CPython **3.12.13** via `uv python install`, throwaway venv, fresh **unpinned** dependency resolve, full Python test suite. No changes to the tracked runtime.

### Key results
- **Gating blocker (the `nfl_data_py` verdict):** `nfl_data_py==0.3.3` **hard-pins `pandas==1.5.3`**, which can't build on Python 3.12. Relax to **`nfl_data_py==0.3.2`** (looser pandas pin, same `import_*` API) — or migrate to the polars-based `nflreadpy` later. This is the only real blocker.
- With `0.3.2` + `pandas>=2.2,<3` (→ **2.3.3**, numpy 2.x), the **full dep set installs cleanly on 3.12** and the **suite is green: `1451 passed, 67 skipped`**. Only a `datetime.utcnow()` deprecation (2 sites) and a pre-existing polyfit `RankWarning`.
- **Verdict: GO** — no code rewrite needed; sizes as a normal **medium** PR, not the original "high" estimate.

### Deliverable
- `docs/exec-plans/python-312-upgrade-spike.md` — full findings + recommended upgrade-PR scope.
- Findings also [posted on #627](https://github.com/alex-monroe/ottoneu-db/issues/627#issuecomment-4702621682).
- Linked from CLAUDE.md's exec-plans map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)