### PR TITLE
docs: daily harness audit 2026-06-15 + 2026-06-16

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,11 +50,14 @@ docs/
 ├── GIT_WORKFLOW.md                    # Branch strategy, PR requirements
 ├── TESTING.md                         # Python + web test setup and CI
 ├── exec-plans/
+│   ├── [data-acquisition-spike-651.md](docs/exec-plans/data-acquisition-spike-651.md)  # Spike #651: next data-acquisition lever — coaching change built→TIE, FA/contract next
 │   ├── [feature-projections.md](docs/exec-plans/feature-projections.md)         # Feature-based player projection system
 │   ├── [market-projections.md](docs/exec-plans/market-projections.md)          # Market-based projection system (DEFERRED)
 │   ├── [projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md)  # 4-phase accuracy improvement roadmap
 │   ├── [projection-methodology-audit.md](docs/exec-plans/projection-methodology-audit.md)  # ML-quality audit: train/test leakage + eval findings (#571–#577)
 │   ├── [projection-system-review.md](docs/exec-plans/projection-system-review-2026-06.md)  # 2026-06 expert review + implementation plan (#594–#599, waves for #587–#592)
+│   ├── [structural-projection-levers-667.md](docs/exec-plans/structural-projection-levers-667.md)  # Spike #667 CLOSED: structural levers — L4 ranking gate built; L3 EB pooling (v44) SIGNIFICANT QB win (promotion deferred); L1/L5 efficiency reframes tie/negative; L2 feasible-but-deprioritized
+│   ├── [python-312-upgrade-spike.md](docs/exec-plans/python-312-upgrade-spike.md)  # Spike: Py3.9→3.12 + pandas 2.x — GO verdict + nfl_data_py blocker (#627)
 │   ├── [qb-usage-share.md](docs/exec-plans/qb-usage-share.md)              # QB Usage Share findings and next steps
 │   └── [season-cycle.md](docs/exec-plans/season-cycle.md)                # Cross-season data & UI scheme (date-driven season-cycle resolver)
 ├── generated/
@@ -106,7 +109,7 @@ These rules are mechanically enforced by structural tests in `scripts/tests/test
 
 - **No hardcoded constants:** Import league constants from `scripts.config` (Python) or `@/lib/config` (TypeScript). Never use literal values like `309`, `400`, etc.
 - **Use the shared Supabase client:** Always use `get_supabase_client()` from `scripts.config` — never call `create_client()` directly.
-- **Config sync:** When adding a key to `config.json`, also add it to `scripts/config.py` AND `web/lib/config.ts`.
+- **Config codegen:** `config.json` is the single source of truth. After adding/changing a key, run `just gen-config` — it regenerates the marked constant blocks in `scripts/config.py` and `web/lib/config.ts` (do not hand-edit those blocks). `TestConfigCodegen` fails with "run `just gen-config`" if they're stale.
 - **Dependency direction:** Analysis scripts must NOT import from `scripts/tasks/`. Query the database instead.
 - **Frontend layers:** `web/lib/` must NOT import from `web/components/`. Flow: types → config → lib → components → pages.
 - **Shared types:** Define interfaces in `web/lib/types.ts`, not in component files.
@@ -120,11 +123,12 @@ Run `just check-arch` to validate these rules locally.
 - **Always use `just <recipe>`** instead of invoking Python, pytest, or npm scripts directly. This ensures the correct venv and flags are used, and keeps the agent allowlist minimal. Run `just --list` to see available recipes. Common ones: `just typecheck`, `just lint`, `just test-web`, `just test-python`, `just train MODEL`, `just project MODEL`, `just backtest MODEL`, `just promote MODEL`, `just accuracy-report`, `just diagnostics`, `just segment-analysis`, `just analyze` (runs `update_projections.py` — re-projects the active model + promotes to `player_projections` + rookie fallback), `just backfill-nfl-stats`, `just backfill-draft-capital`, `just backfill-vegas`, `just backfill-depth-charts`, `just seed-win-totals`, `just scrape-draft-sharks`, `just dev` / `just dev-stop` (start/stop the Next.js dev server — use `dev-stop` instead of raw `pkill`). For ad-hoc DB inspection use `just py "<snippet>"`.
 - **When something is off, run `just doctor` first.** It diagnoses the known environment traps (stale editable mapping, broken venv, missing `.env` keys, stale `web/node_modules`, stale `.cache/holdout`) offline in ~1s and prints the fix for each.
 - **Editable install can run stale `scripts/` code.** If a `scripts/*.py` edit doesn't take effect via `venv/bin/python scripts/foo.py` (but works via `python -c`), the editable install is likely pinned to a stale `.claude/worktrees/` path — `just doctor` flags this; the fix is `venv/bin/pip install -e .` from the project root. See [docs/TESTING.md](docs/TESTING.md#gotcha-editable-install-can-pin-scripts-to-a-stale-worktree).
-- **New DB tables need a TS type + the config contract is enforced.** After adding a table (e.g. via `mcp__supabase__apply_migration` or Supabase dashboard), hand-add its `Row`/`Insert`/`Update` block to `web/types/supabase.ts` or `npx tsc` fails — hand-add rather than fully regenerating to avoid churning the `fp_*` tables. Separately, every key in `config.json` must be consumed by **both** `scripts/config.py` and `web/lib/config.ts` (and vice versa); this bidirectional contract is enforced by `scripts/tests/test_architecture.py`, so add/remove keys in all three places.
+- **New DB tables need a TS type + the config contract is enforced.** After adding a table (e.g. via `mcp__supabase__apply_migration` or Supabase dashboard), hand-add its `Row`/`Insert`/`Update` block to `web/types/supabase.ts` or `npx tsc` fails — hand-add rather than fully regenerating to avoid churning the `fp_*` tables. Separately, every key in `config.json` is rendered into the generated constant blocks of `scripts/config.py` and `web/lib/config.ts` by `just gen-config`; `scripts/tests/test_architecture.py` (`TestConfigCodegen`) fails if those blocks are stale. So to add/remove a key: edit `config.json`, then run `just gen-config`.
 - **Do not touch `fp_*` tables.** The Supabase project is shared with the `fantasy-pulse` app. Tables whose names start with `fp_` (currently `fp_notes`, `fp_user_integrations`, `fp_leagues`, `fp_teams`, but the prefix is the rule, not the list) are owned by that other codebase. Do not read from, write to, alter, drop, or migrate them from this repo. They will appear in `list_tables` output and in regenerated Supabase TS types — ignore them. See [docs/generated/db-schema.md](docs/generated/db-schema.md#shared-database--hands-off-fp_).
 - **Update documentation:** Always try to update the agent documentation after completing a task. Update existing documents or add new documents and sections as needed to reflect architectural or contextual changes.
 - **Never commit directly to `main`.** All changes go through pull requests.
 - **Always create a PR.** Every task must end with `gh pr create --fill`.
+- **Run `just preflight` before pushing.** It mirrors CI's pass/fail (lint + typecheck + both test suites without coverage + doc checks) in ~9s, so failures surface locally instead of in a multi-minute CI round-trip. `just install-hooks` installs it as an opt-in pre-push hook (`git push --no-verify` to skip a WIP push).
 - **Start from updated main:** `git checkout main && git pull origin main` before branching.
 - **Bash cwd persists between calls.** A `cd web && …` leaves the shell in `web/`, so a later repo-root-relative path (e.g. `git add web/next.config.ts`) silently fails. Prefer absolute paths, `git -C <repo-root>`, or re-`cd` explicitly rather than assuming the working directory.
 - See [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md) for full details.
@@ -142,6 +146,7 @@ When any task modifies the projection system — including `scripts/feature_proj
    ```
    just significance <name> v33_tuned_base --protocol rolling --eval-seasons 2023,2024,2025 --min-train-season 2021
    ```
+   **Ranking gate (#667 L4):** add `--metric spearman --position <QB|RB|WR|TE>` to bootstrap the **Spearman-ρ delta** instead of the MAE delta — the within-position *ordering* gate the downstream consumers (VORP, surplus, auction, keepers) actually care about (#598). The ranking signal is larger than the MAE signal, so this gate detects ordering wins/losses the underpowered MAE bootstrap is blind to (it confirmed FP significantly out-orders v33 at QB, ρ 0.71 vs 0.81, p=0.001). For ordering-targeted changes, gate on ρ and require MAE not significantly regress; for level changes, the reverse.
    Availability-touching changes additionally run `just availability-backtest` and report **both** rate and availability MAE (#574).
 3. **In the PR description**, lead with the held-out ranking + significance verdict (and the per-position Ranking-quality rows, #598). Include the in-sample `accuracy-report` table only if labelled "in-sample diagnostic — not the ranking".
 4. **Promotion requires a *significant* held-out win over the active model** (CI excludes 0), never a point-estimate delta. Promote via `just promote <model>` (or `cli.py promote --model <name>`) — `update_projections.py` reads `projection_models.is_active` dynamically (no hardcoded `ACTIVE_MODEL`). Methodology copy on `/projections`, `/arbitration` (projected mode), and `/projection-accuracy` is rendered live by `<ActiveModelCard>` (`web/components/ActiveModelCard.tsx`) from `fetchActiveProjectionModel()`, so do **not** hardcode model names or feature lists in page copy.
@@ -170,6 +175,7 @@ After creating a new migration file in `migrations/` (numbered as the current hi
 1. **Regenerate TypeScript types** using `mcp__supabase__generate_typescript_types` (or `npx supabase gen types typescript`).
 2. **Update `web/types/supabase.ts`** with the regenerated output so the Supabase client recognizes the new table.
 3. **Update `docs/generated/db-schema.md`** — add the new table to the table list and increment the table count.
+4. **Verify with `just check-schema`** — a read-only, on-demand drift check that introspects the live DB and diffs it against `web/types/supabase.ts` and `docs/generated/db-schema.md` (ignoring `fp_*`). It catches a skipped step 2 or 3 (table or column missing from types/docs) immediately instead of as a later confusing `tsc` error, and exits nonzero on drift.
 
 Skipping step 2 will cause TypeScript errors like `Argument of type '"new_table"' is not assignable to parameter of type '...'` when querying the new table.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -151,6 +151,8 @@ just backfill-nfl-stats [--seasons ...] [--dry-run]    # Backfill nfl_stats from
 just backfill-draft-capital [--since YYYY] [--dry-run] # Backfill draft_capital from nflverse draft_picks
 just backfill-vegas [--since YYYY | --current] [--dry-run]  # Backfill team_vegas_lines from nflverse games.csv (--current = projection season only)
 just backfill-depth-charts [--since YYYY] [--until YYYY] [--current] [--dry-run]  # Backfill depth_charts (opening-day depth tier) from nflverse (--current = projection season only)
+just backfill-red-zone [--seasons ...] [--dry-run]     # Backfill red_zone_usage (RZ/goal-line carries/targets) from nflverse PBP — issue #671
+just backfill-ngs [--seasons ...] [--dry-run]          # Backfill ngs_passing (QB Next Gen Stats: CPOE, aggressiveness, air-yards-to-sticks, …) from nflverse — issue #674
 just seed-win-totals --season YYYY                     # Upsert preseason sportsbook win totals (implied_total left NULL until schedule drops)
 just scrape-draft-sharks [--season YYYY] [--positions qb rb wr te] [--dry-run]  # Scrape Draft Sharks Half-PPR Superflex auction values (stored ×2 for the $400 cap)
 just scrape-calendar [--dry-run]                      # Scrape the Ottoneu finances Calendar into league_calendar (drives the season-cycle resolver)

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -97,7 +97,7 @@ All public tables have RLS enabled. Server-side code uses the Supabase **service
 
 **Tables with an anon SELECT policy** (web reads via the anon client): `players`, `player_stats`, `nfl_stats`, `league_prices`, `transactions`, `surplus_adjustments`, `player_projections`, `projection_models`, `model_projections`, `backtest_results`, `arbitration_progress`, `arbitration_progress_teams`, `arbitration_allocation_details`, `team_vegas_lines`, `draft_sharks_values`, `league_calendar`, `depth_charts`.
 
-**Tables with no anon policy** (server-only, anon fully blocked): `users`, `arbitration_plans`, `arbitration_plan_allocations`, `scraper_jobs`, `draft_capital`.
+**Tables with no anon policy** (server-only, anon fully blocked): `users`, `arbitration_plans`, `arbitration_plan_allocations`, `scraper_jobs`, `draft_capital`, `team_coaching`, `red_zone_usage`, `ngs_passing`.
 
 When adding a new table, decide upfront: does the web frontend read from it via the anon `supabase` client (see `web/lib/supabase.ts`)? If yes, the migration must `ENABLE ROW LEVEL SECURITY` *and* add a `FOR SELECT TO anon USING (true)` policy. If no, just enable RLS — server writes via the service key still work, and anon is locked out. The Supabase advisor (`mcp__supabase__get_advisors --type security`) will flag `rls_disabled_in_public` as a critical ERROR if either step is skipped. See migrations 015 and 026 for the canonical pattern.
 


### PR DESCRIPTION
## Summary

Cumulative harness-doc audit covering merges since the 2026-06-14 audit (#657). Per the "don't open a second daily audit PR" rule, today's (2026-06-16) findings are stacked onto this PR rather than a new one.

---

## 2026-06-15 audit (original PR)

Eleven new commits on `main` since #657 (#658, #659, #660, #661, #662, #663, #664, #665, #668, #669) updated `CLAUDE.md`, `docs/`, and the `Justfile` — but `AGENTS.md` had drifted in five places. Re-sync:

| Commit | What it touched |
|---|---|
| 17d3db5 exp(#667): L5 QB volume×efficiency + L2 → close spike (#669) | spike doc + experiment log |
| b5be328 spike(#667): L4 ranking gate + L1 xFP + L3 EB pooling v44 (#668) | CLAUDE.md ranking gate, spike doc |
| 269fdee enh(#651): coaching-change acquisition (#665) | `team_coaching` table (migration 031), db-schema |
| 6113f34 docs(#651): data-acquisition spike + devcontainer (#664) | new spike doc, allowlist |
| 0325096 enh(#627): Python 3.12 + pandas 2.x (#663) | Python version refs across all root docs |
| 88faa83 docs(#627): 3.12 upgrade spike findings (#662) | new spike doc |
| bb40aed enh(#624): `just gen-config` codegen (#661) | CLAUDE.md config rule, CODE_ORGANIZATION |
| e98e74e enh(#628): `just preflight` + drop CI coverage (#660) | CLAUDE.md, GIT_WORKFLOW, COMMANDS |
| 7bafbe9 enh(#629): worktree-shared holdout cache (#659) | env-vars, COMMANDS, experiment skill |
| fbda7e2 feat(#625): `just check-schema` (#658) | CLAUDE.md migration step 4, COMMANDS |
| 0697c4e docs: daily harness audit 2026-06-14 (#657) | yesterday's audit (baseline) |

**Changes** (`AGENTS.md` only):

1. **Documentation Map** — add the three new exec-plan spikes (`data-acquisition-spike-651.md`, `structural-projection-levers-667.md`, `python-312-upgrade-spike.md`).
2. **Architectural Rules** — replace the stale "Config sync" three-file bullet with the `just gen-config` codegen rule from #661.
3. **Critical Rules** — rewrite the second half of the "New DB tables / config contract" bullet to point at codegen + `TestConfigCodegen`; add a new "Run `just preflight` before pushing" bullet from #660.
4. **Projection Model Update Requirements** — add the `--metric spearman --position <p>` Spearman-ρ ranking-significance gate from #667 / #668.
5. **Database migration workflow** — add step 4: verify with `just check-schema` (#658).

---

## 2026-06-16 follow-up (this rebase)

Four more commits landed on `main` between the original PR opening and this morning:

| Commit | What it touched |
|---|---|
| cb430d1 fix(devcontainer): allowlist api.supabase.com for the Supabase MCP server (#676) | devcontainer only — no doc impact |
| fee5cb2 exp(#674): NGS QB skill signals stacked on v44 — NEGATIVE/TIE (#677) | new `ngs_passing` table (migration 033), `just backfill-ngs`, experiment log |
| c3bd6bc exp(#671): red-zone xFP (Phase 2) — NEGATIVE (#673) | experiment log only |
| 2fe3af9 enh(#671): red-zone usage acquisition Phase 1 — table + PBP backfill (#672) | new `red_zone_usage` table (migration 032), `just backfill-red-zone` |

**Drift fixed** in the follow-up commit:

1. `docs/generated/db-schema.md` — the **"Tables with no anon policy"** list at the bottom of the RLS section never picked up the three RLS-no-anon tables added since the last audit: `team_coaching` (#665), `red_zone_usage` (#672), `ngs_passing` (#677). Each migration explicitly enables RLS without a SELECT-to-anon policy. Added all three so the list stays the canonical anon-access map.
2. `docs/COMMANDS.md` — the "Backfills / seeds" block listed `backfill-depth-charts` but not the two new recipes added in #672 / #677. Added `just backfill-red-zone` and `just backfill-ngs` next to their cousins so agents reading the doc don't have to discover them from `just --list`.

Per-table descriptions for `red_zone_usage` / `ngs_passing` are already on `main` (added inline by the feature commits); only the bottom-of-file RLS summary and the `COMMANDS.md` backfill list were stale.

---

## Other things checked, no action needed

- Schema doc table count (24) matches reality; the new `team_coaching` / `red_zone_usage` / `ngs_passing` rows are present.
- No new migrations after 033.
- `docs/exec-plans/` — issues #671 and #674 don't have their own exec-plans (they're tracked in `experiment-log.md` and as follow-ups under spike #667), so nothing to add to the Documentation Map.
- `docs/COMMANDS.md` already covers `just check-schema`, `just preflight`, `just install-hooks`, `just clear-holdout-cache`, `just gen-config`.
- `docs/references/environment-variables.md` — `OTTONEU_HOLDOUT_CACHE` documented (#659).
- `.claude/commands/experiment.md` — points at the shared holdout cache + `just clear-holdout-cache` (#659).
- `docs/TESTING.md`, `docs/ARCHITECTURE.md`, `docs/references/autonomous-operation.md`, `README.md` — Python version refs already at 3.12 (#663).
- `.claude/commands/*.md` — 14 skill files match CLAUDE.md's Documentation Map.
- `python3 scripts/check_docs_freshness.py` — all checks pass.

## Items flagged for human follow-up

None this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019cyPE6MQnKZxRhVwKTbiXr)_