### PR TITLE
fix(devcontainer): allowlist api.supabase.com so the Supabase MCP works in the container

### DIFF
--- a/.devcontainer/allowed-domains.txt
+++ b/.devcontainer/allowed-domains.txt
@@ -46,7 +46,14 @@ www.draftsharks.com
 www.fantasypros.com
 
 # Supabase (project ref rbinbcwinchphipvcfqk)
+# Data plane (PostgREST/REST — the anon-key path the Next.js app uses):
 rbinbcwinchphipvcfqk.supabase.co
+# Control plane (Management API — what the Supabase MCP server, authed with the
+# sbp_ personal access token, uses for list_projects/apply_migration/execute_sql/
+# list_tables/etc.). Without this the stdio MCP handshake still shows "connected"
+# in /mcp (it's local), but tool enumeration against the API is firewall-dropped,
+# so no Supabase tools register inside the devcontainer.
+api.supabase.com
 
 # Projection data sources (spike #651) — contracts / coaching
 # nflverse sources (coaching via import_schedules, snap counts, combine, rosters,


### PR DESCRIPTION
## Problem

Inside the autonomous devcontainer, `/mcp` shows the Supabase server **connected** but **no Supabase MCP tools are usable**.

## Root cause — control plane vs data plane

The Supabase MCP is a **local stdio** server (`npx @supabase/mcp-server-supabase`) authed with a `sbp_…` **personal access token**, which talks to the Supabase **Management API at `api.supabase.com`** (`list_projects`, `list_migrations`, `apply_migration`, `execute_sql`, `list_tables`, `get_advisors`, …).

The egress allowlist (`.devcontainer/allowed-domains.txt`) had only the project **data-plane** host `rbinbcwinchphipvcfqk.supabase.co` (PostgREST/anon-key path the Next.js app uses) — **not** the control-plane host `api.supabase.com`.

Result:
- `/mcp` reads **"connected"** because the stdio handshake is purely local (npm registry is allowlisted, so `npx` launches the process fine).
- **No tools register** because the server's tool enumeration/validation call to `api.supabase.com` is dropped by the default-deny firewall.

It's isolated to Supabase because every other MCP's backing host is already reachable (github → allowlisted GitHub CIDRs, filesystem → local, puppeteer → Playwright CDNs).

## Fix

Add `api.supabase.com` to `.devcontainer/allowed-domains.txt` (with a comment documenting the data-plane vs control-plane distinction).

## Activation (not automatic)

The firewall resolves the allowlist **once at container start**, so after merge this takes effect only after:
1. `sudo .devcontainer/init-firewall.sh` (re-resolve + re-apply the ipset) **or** a container rebuild, and
2. restarting the Supabase MCP server (or Claude Code) so it re-initializes against the now-reachable API.

Verify in-container: `curl -sI https://api.supabase.com` should return headers instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)