### PR TITLE
feat: league explorer — survey other public Ottoneu leagues into local SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ build/
 
 # Python editable-install build metadata
 *.egg-info/
+
+# League explorer local artifacts (SQLite DB + raw page cache)
+data/league_explorer/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Comprehensive database and analytics platform for Ottoneu Fantasy Football Leagu
 - **Ottoneu rules:** See [docs/references/ottoneu-rules.md](docs/references/ottoneu-rules.md) for scoring, roster, salary cap, and arbitration rules
 - **Ottoneu strategy:** See [docs/references/ottoneu-strategy.md](docs/references/ottoneu-strategy.md) for format economics (surplus value, raise treadmill, Superflex QB premium, arbitration tax) and the reasoning checklist used by the `/ottoneu-roster-question` skill. Use the `/ottoneu-roster-question` skill (which loads this + live data via `just roster-context`) to answer advanced keeper/trade/auction/arbitration questions.
 - **Environment:** See [docs/references/environment-variables.md](docs/references/environment-variables.md) for `.env` setup
+- **League Explorer:** See [docs/references/league-explorer.md](docs/references/league-explorer.md) for the cross-league survey tool (`just league-explorer`) — scrapes other public Ottoneu leagues (settings, standings history, champions, roster/salary snapshots) into a local SQLite DB at `data/league_explorer/`, separate from Supabase
 - **Autonomous operation:** See [docs/references/autonomous-operation.md](docs/references/autonomous-operation.md) for the permission-friction strategy — allowlist design, prompt-rate metrics (`just permission-report`), and the `.devcontainer/` for safely running `claude --dangerously-skip-permissions`
 - **Season cycle:** See [docs/exec-plans/season-cycle.md](docs/exec-plans/season-cycle.md) — the site rolls between Ottoneu seasons from the `league_calendar` table; the current season is resolved at runtime via `scripts/season.py` and `web/lib/season.ts`, not from static config
 - **Projection Accuracy Plan:** See [docs/exec-plans/projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md) for the 4-phase accuracy improvement roadmap (Issues #271-#285)
@@ -75,6 +76,7 @@ docs/
 ├── references/
 │   ├── [autonomous-operation.md](docs/references/autonomous-operation.md)        # Permission-friction strategy: allowlist, prompt metrics, devcontainer
 │   ├── environment-variables.md       # .env and .env.local variable reference
+│   ├── [league-explorer.md](docs/references/league-explorer.md)             # Cross-league survey: other Ottoneu leagues → local SQLite (just league-explorer)
 │   ├── ottoneu-rules.md               # Scoring, roster, salary cap, arbitration rules
 │   └── ottoneu-strategy.md            # Format economics + AI reasoning checklist for roster construction
 └── superpowers/

--- a/Justfile
+++ b/Justfile
@@ -97,6 +97,12 @@ check-db:
 roster-context season="2026":
     {{python}} scripts/roster_context_pack.py --season {{season}}
 
+# Explore other public Ottoneu leagues → local SQLite (discover | scrape | report | query)
+# e.g. just league-explorer discover ; just league-explorer scrape --discovered
+# See docs/references/league-explorer.md
+league-explorer *args:
+    {{python}} scripts/league_explorer/cli.py {{args}}
+
 # ──────────────────────────────────────────────
 # Harness checks
 # ──────────────────────────────────────────────

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -115,6 +115,7 @@ just preflight          # Fast pre-PR gate (~9s): lint + typecheck + both test s
 just install-hooks      # Install the opt-in pre-push hook that runs `just preflight` (skip a push with --no-verify)
 just ci                 # Full CI suite (lint + typecheck + tests + doc checks)
 just roster-context [season]  # Build the roster-question context pack (live league data); season defaults to 2026
+just league-explorer <cmd>    # Explore other public Ottoneu leagues → local SQLite (discover | scrape | report | query); see docs/references/league-explorer.md
 
 # Projection CLI
 just list-models                                    # List available models

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -115,7 +115,7 @@ just preflight          # Fast pre-PR gate (~9s): lint + typecheck + both test s
 just install-hooks      # Install the opt-in pre-push hook that runs `just preflight` (skip a push with --no-verify)
 just ci                 # Full CI suite (lint + typecheck + tests + doc checks)
 just roster-context [season]  # Build the roster-question context pack (live league data); season defaults to 2026
-just league-explorer <cmd>    # Explore other public Ottoneu leagues → local SQLite (discover | scrape | report | query); see docs/references/league-explorer.md
+just league-explorer <cmd>    # Explore other public Ottoneu leagues → local SQLite (scan | discover | scrape | report | query); see docs/references/league-explorer.md
 
 # Projection CLI
 just list-models                                    # List available models

--- a/docs/references/league-explorer.md
+++ b/docs/references/league-explorer.md
@@ -7,7 +7,9 @@ explored by scripts and AI agents without touching the shared Supabase
 project.
 
 ```bash
+just league-explorer scan                           # enumerate ALL leagues (full ID sweep + activity check)
 just league-explorer discover                       # find leagues linked from our players' cards
+just league-explorer scrape --active                # full-scrape every active league
 just league-explorer scrape --discovered            # scrape every discovered league
 just league-explorer scrape --league-ids 33,74      # or scrape specific leagues
 just league-explorer report                         # canned cross-league summaries
@@ -17,14 +19,28 @@ just league-explorer query "SELECT ... "            # ad-hoc SQL (add --csv for 
 All artifacts live under `data/league_explorer/` (gitignored):
 `league_explorer.db` (SQLite) plus `cache/` (raw fetched pages).
 
-## How discovery works
+## Finding leagues: `scan` (complete) and `discover` (incremental)
 
-Ottoneu player cards show "trades in other leagues" links. `discover` reads
-our league's roster CSV, walks the rostered players' cards
-(`--max-players`, default 75), and records every `/football/{id}/` league it
-sees into `discovered_leagues`. Discovery compounds: scraping more popular
-players surfaces more leagues, and you can re-seed from any league with
-`--seed-league`.
+**`scan` enumerates the entire platform.** Football league IDs are small
+sequential integers (the space currently tops out around ~340); deleted or
+never-created IDs 307-redirect to `/football/?invalidLeague=1`, which the
+fetcher treats as "dead" (it never follows redirects). `scan` walks IDs from
+`--start`, auto-stopping after `--stop-after-misses` (default 120)
+consecutive dead IDs — new leagues each season push the ceiling up, so the
+auto-stop keeps future sweeps complete. For each live league it stores the
+settings row plus a cheap activity probe (2 extra requests): the current
+rosters CSV snapshot and the latest completed season's standings.
+
+**A league is "active"** if it played the latest completed season AND
+currently has rostered players (`ACTIVE_LEAGUES_SQL` in `cli.py`). `report`
+prints the count, and `scrape --active` full-scrapes exactly that set.
+
+**`discover` is the incremental alternative:** Ottoneu player cards show
+"trades in other leagues" links. `discover` reads our league's roster CSV,
+walks the rostered players' cards (`--max-players`, default 75), and records
+every `/football/{id}/` league it sees into `discovered_leagues`. Useful for
+finding the leagues most connected to ours; `scan` supersedes it for
+completeness.
 
 ## What gets scraped per league (~25 requests, 1 req/s)
 
@@ -86,7 +102,8 @@ GROUP BY 1,2 HAVING titles > 1 ORDER BY titles DESC;
 
 ## Limitations / future work
 
-- Private leagues and 404s are recorded as skipped, not scraped.
+- Pages that redirect (dead league IDs, login-gated pages) are treated as
+  unavailable and skipped; the fetcher never follows redirects.
 - Champions come from team trophy cases; a team deleted from a league takes
   its trophies with it.
 - Historical *rosters* (as opposed to standings) are not retroactively

--- a/docs/references/league-explorer.md
+++ b/docs/references/league-explorer.md
@@ -1,0 +1,97 @@
+# League Explorer — surveying other Ottoneu football leagues
+
+`scripts/league_explorer/` scrapes the **public** pages of other Ottoneu
+football leagues into a local SQLite database, so trends across the platform
+(salary structure, format mix, what league winners' rosters look like) can be
+explored by scripts and AI agents without touching the shared Supabase
+project.
+
+```bash
+just league-explorer discover                       # find leagues linked from our players' cards
+just league-explorer scrape --discovered            # scrape every discovered league
+just league-explorer scrape --league-ids 33,74      # or scrape specific leagues
+just league-explorer report                         # canned cross-league summaries
+just league-explorer query "SELECT ... "            # ad-hoc SQL (add --csv for CSV output)
+```
+
+All artifacts live under `data/league_explorer/` (gitignored):
+`league_explorer.db` (SQLite) plus `cache/` (raw fetched pages).
+
+## How discovery works
+
+Ottoneu player cards show "trades in other leagues" links. `discover` reads
+our league's roster CSV, walks the rostered players' cards
+(`--max-players`, default 75), and records every `/football/{id}/` league it
+sees into `discovered_leagues`. Discovery compounds: scraping more popular
+players surfaces more leagues, and you can re-seed from any league with
+`--seed-league`.
+
+## What gets scraped per league (~25 requests, 1 req/s)
+
+| Page | Data | History? |
+|---|---|---|
+| `/football/{id}/settings` | name, tier, points system (PPR type), roster type (Superflex vs Two Flex), #teams, established year, private flag | n/a |
+| `/football/{id}/standings/{year}` | W-L-T, PF/PA, division per team | ✅ every season since the league was established |
+| `/football/{id}/team/{tid}` | manager username + **trophy case** (champion / runner-up / third place, per season) | ✅ full title history |
+| `/football/{id}/finances` | per-team salary totals, cap penalties, loans, free cap space | snapshot per run |
+| `/football/{id}/csv/rosters` | every rostered player with position and salary | snapshot per run |
+
+Two kinds of history:
+
+- **Truly historical:** standings and trophies go back to each league's
+  founding — winners over time are available immediately.
+- **Snapshot-accrued:** rosters/salaries and finances are only published as
+  *current* state, so `roster_slots` and `finances` are keyed by
+  `snapshot_date`. Re-running `scrape` (e.g. monthly, or before/after keeper
+  deadlines and arbitration) builds the salary-evolution time series going
+  forward. Per-player salary history also exists on player cards
+  (transaction log) but is not scraped in v1 — it's the natural next lever
+  if deeper history is needed.
+
+## SQLite schema
+
+- `leagues` — settings + format metadata, one row per league
+- `teams` — team id/name/manager per league
+- `trophies` — (league, team, season, place) with `place` ∈ `champion | runner_up | third_place`
+- `standings` — (league, season, team) records and points
+- `roster_slots` — (snapshot_date, league, team, player) with position + salary
+- `finances` — (snapshot_date, league, team) cap totals
+- `discovered_leagues` — crawl frontier with provenance (`seed`, `player_card:{pid}`)
+
+Example agent queries:
+
+```sql
+-- Do champions pay more at QB in superflex leagues?
+SELECT l.roster_settings, ROUND(AVG(rs.salary),1) avg_qb_salary
+FROM roster_slots rs
+JOIN leagues l USING (league_id)
+WHERE rs.positions = 'QB'
+GROUP BY 1;
+
+-- Repeat winners
+SELECT league_id, team_id, COUNT(*) titles
+FROM trophies WHERE place='champion'
+GROUP BY 1,2 HAVING titles > 1 ORDER BY titles DESC;
+```
+
+## Politeness & caching
+
+- Descriptive User-Agent, default 1 request/second (`--delay`), retries with
+  backoff; `robots.txt` only restricts AI-training crawlers, and this is a
+  personal research tool hitting public pages.
+- Every fetched page is cached on disk. Completed-season standings are
+  immutable (cached forever); mutable pages (rosters, finances, settings)
+  expire after hours-to-weeks, and `scrape --refresh` forces a refetch.
+  Re-parsing after a parser change is therefore free and offline.
+
+## Limitations / future work
+
+- Private leagues and 404s are recorded as skipped, not scraped.
+- Champions come from team trophy cases; a team deleted from a league takes
+  its trophies with it.
+- Historical *rosters* (as opposed to standings) are not retroactively
+  available; only snapshots accrue. Player-card transaction logs are the
+  next data source if per-player salary history across leagues is wanted.
+- Eventually some of this could feed the sofa-db website (cross-league
+  salary benchmarks on player pages); that would mean promoting a curated
+  subset into Supabase — out of scope for v1 deliberately.

--- a/scripts/league_explorer/__init__.py
+++ b/scripts/league_explorer/__init__.py
@@ -1,0 +1,10 @@
+"""Explorer for public Ottoneu football league pages across the platform.
+
+Discovers other leagues from player-card trade links, scrapes their public
+pages (settings, standings history, trophies, finances, rosters) into a local
+SQLite database, and offers canned cross-league reports plus ad-hoc SQL for
+agents and scripts.
+
+Entirely separate from the Supabase pipeline: writes only to
+data/league_explorer/ (gitignored). See docs/references/league-explorer.md.
+"""

--- a/scripts/league_explorer/cli.py
+++ b/scripts/league_explorer/cli.py
@@ -3,6 +3,9 @@
 Usage (via `just league-explorer <args>`):
 
     discover   Find league IDs from player-card trade links in a seed league
+    scan       Enumerate the entire league-ID space (IDs are small sequential
+               ints; dead IDs redirect) and record every live league plus a
+               cheap activity check
     scrape     Scrape league settings, standings history, trophies, finances,
                and roster snapshots into the local SQLite DB
     report     Canned cross-league summaries (formats, champions, how winners
@@ -39,6 +42,30 @@ PLAYER_CARD_MAX_AGE = 24 * 7   # discovery links accrete slowly
 def _fetcher(args) -> Fetcher:
     return Fetcher(cache_dir=DEFAULT_CACHE, delay_seconds=args.delay,
                    refresh=getattr(args, "refresh", False))
+
+
+def latest_completed_season(today: date | None = None) -> int:
+    """Most recent fully played season (season Y runs Sep Y – Jan Y+1)."""
+    today = today or date.today()
+    return today.year - 1 if today.month >= 2 else today.year - 2
+
+
+# "Active" = fielded the latest completed season AND currently has players
+# rostered. Both signals are captured by `scan` (and by a full `scrape`).
+ACTIVE_LEAGUES_SQL = """
+    SELECT l.league_id FROM leagues l
+    WHERE EXISTS (SELECT 1 FROM standings s
+                   WHERE s.league_id = l.league_id AND s.season = :season)
+      AND EXISTS (SELECT 1 FROM roster_slots r
+                   WHERE r.league_id = l.league_id)
+    ORDER BY l.league_id
+"""
+
+
+def active_league_ids(conn) -> list[int]:
+    return [r["league_id"] for r in
+            conn.execute(ACTIVE_LEAGUES_SQL,
+                         {"season": latest_completed_season()})]
 
 
 def _print_table(headers: list[str], rows: list[tuple]) -> None:
@@ -84,6 +111,81 @@ def cmd_discover(args) -> int:
     print(f"Done. {len(found)} leagues linked from this run; "
           f"{total} total in discovered_leagues.")
     print("Next: just league-explorer scrape --discovered")
+    return 0
+
+
+def _scan_league(fetcher: Fetcher, conn, league_id: int,
+                 check_activity: bool = True) -> str | None:
+    """Record one league if it exists. Returns a status string, or None for a
+    dead ID (deleted/never created — Ottoneu redirects those)."""
+    settings_html = fetcher.get(f"/football/{league_id}/settings",
+                                max_age_hours=SETTINGS_MAX_AGE)
+    if settings_html is None:
+        return None
+    settings = parsers.parse_settings(settings_html)
+    if settings["league_id"] != league_id:
+        return "unparseable settings page"
+    store.upsert_league(conn, settings)
+    store.record_discovered(conn, league_id, "scan")
+    if not check_activity:
+        conn.commit()
+        return "live"
+
+    csv_text = fetcher.get(f"/football/{league_id}/csv/rosters",
+                           max_age_hours=SNAPSHOT_MAX_AGE)
+    roster_rows = parsers.parse_rosters_csv(csv_text) if csv_text else []
+    store.snapshot_rosters(conn, league_id, roster_rows)
+
+    season = latest_completed_season()
+    standings_html = fetcher.get(f"/football/{league_id}/standings/{season}",
+                                 max_age_hours=None)
+    standings_rows = parsers.parse_standings(standings_html) if standings_html else []
+    standings_rows = [r for r in standings_rows
+                      if (r["wins"] or r["losses"] or r["ties"]
+                          or (r["points_for"] or 0) > 0)]
+    if standings_rows:
+        store.replace_standings(conn, league_id, season, standings_rows)
+    conn.commit()
+
+    played = f"played {season}" if standings_rows else f"did not play {season}"
+    return f"live — {len(roster_rows)} roster slots, {played}"
+
+
+def cmd_scan(args) -> int:
+    fetcher = _fetcher(args)
+    conn = store.connect(args.db)
+
+    live = dead = 0
+    miss_run = 0
+    league_id = args.start - 1
+    while True:
+        league_id += 1
+        if args.end and league_id > args.end:
+            break
+        if not args.end and miss_run >= args.stop_after_misses:
+            print(f"Stopping: {args.stop_after_misses} consecutive dead IDs "
+                  f"(last live ID: {league_id - miss_run - 1}).")
+            break
+        try:
+            status = _scan_league(fetcher, conn, league_id,
+                                  check_activity=not args.no_activity_check)
+        except FetchError as e:
+            print(f"  league {league_id}: FAILED: {e}", file=sys.stderr)
+            miss_run = 0  # a fetch failure is not evidence the ID space ended
+            continue
+        if status is None:
+            dead += 1
+            miss_run += 1
+            continue
+        live += 1
+        miss_run = 0
+        print(f"  league {league_id}: {status}")
+
+    active = len(active_league_ids(conn))
+    print(f"\nScan complete: {live} live leagues, {dead} dead IDs "
+          f"({fetcher.requests_made} requests, {fetcher.cache_hits} cache hits).")
+    print(f"Active (played {latest_completed_season()} + currently rostered): "
+          f"{active} — full-scrape them with: just league-explorer scrape --active")
     return 0
 
 
@@ -146,10 +248,13 @@ def cmd_scrape(args) -> int:
 
     if args.league_ids:
         league_ids = [int(x) for x in args.league_ids.split(",") if x.strip()]
+    elif args.active:
+        league_ids = active_league_ids(conn)
     elif args.discovered:
         league_ids = store.discovered_league_ids(conn)
     else:
-        print("Provide --league-ids 33,74,... or --discovered", file=sys.stderr)
+        print("Provide --league-ids 33,74,..., --active, or --discovered",
+              file=sys.stderr)
         return 1
     if args.max_leagues:
         league_ids = league_ids[: args.max_leagues]
@@ -170,6 +275,13 @@ def cmd_scrape(args) -> int:
 
 def cmd_report(args) -> int:
     conn = store.connect(args.db)
+
+    season = latest_completed_season()
+    totals = conn.execute(
+        "SELECT COUNT(*) AS n FROM leagues").fetchone()["n"]
+    active = len(active_league_ids(conn))
+    print(f"{totals} leagues known; {active} active "
+          f"(played {season} + currently rostered players)\n")
 
     print("## Leagues scraped\n")
     rows = conn.execute(
@@ -282,9 +394,24 @@ def main(argv: list[str] | None = None) -> int:
                    help="How many rostered players' cards to scan (default 75)")
     p.set_defaults(func=cmd_discover)
 
+    p = sub.add_parser("scan", parents=[common],
+                       help="Enumerate all league IDs and record live leagues")
+    p.add_argument("--start", type=int, default=1, help="First league ID (default 1)")
+    p.add_argument("--end", type=int, default=0,
+                   help="Last league ID (default: auto-stop on a long dead run)")
+    p.add_argument("--stop-after-misses", type=int, default=120,
+                   help="Without --end, stop after this many consecutive dead IDs "
+                        "(default 120)")
+    p.add_argument("--no-activity-check", action="store_true",
+                   help="Settings only (1 request/league) — skip rosters + "
+                        "latest-season standings")
+    p.set_defaults(func=cmd_scan)
+
     p = sub.add_parser("scrape", parents=[common],
                        help="Scrape leagues into the local DB")
     p.add_argument("--league-ids", help="Comma-separated Ottoneu league IDs")
+    p.add_argument("--active", action="store_true",
+                   help="Scrape every active league (per the scan's activity check)")
     p.add_argument("--discovered", action="store_true",
                    help="Scrape every league in discovered_leagues")
     p.add_argument("--max-leagues", type=int, default=0,

--- a/scripts/league_explorer/cli.py
+++ b/scripts/league_explorer/cli.py
@@ -1,0 +1,313 @@
+"""CLI for exploring other public Ottoneu football leagues.
+
+Usage (via `just league-explorer <args>`):
+
+    discover   Find league IDs from player-card trade links in a seed league
+    scrape     Scrape league settings, standings history, trophies, finances,
+               and roster snapshots into the local SQLite DB
+    report     Canned cross-league summaries (formats, champions, how winners
+               allocate salary by position)
+    query      Ad-hoc SQL against the local DB (for agents and scripts)
+
+The DB lives at data/league_explorer/league_explorer.db; raw pages are cached
+under data/league_explorer/cache/ so re-runs are cheap and offline-friendly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from datetime import date
+from pathlib import Path
+
+from scripts.config import LEAGUE_ID
+from scripts.league_explorer import parsers, store
+from scripts.league_explorer.fetcher import Fetcher, FetchError
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DB = PROJECT_ROOT / store.DEFAULT_DB_PATH
+DEFAULT_CACHE = PROJECT_ROOT / "data/league_explorer/cache"
+
+# Cache lifetimes (hours). Completed-season standings are immutable (None).
+SNAPSHOT_MAX_AGE = 12          # rosters, finances, current standings
+SETTINGS_MAX_AGE = 24 * 7      # league settings rarely change
+TEAM_PAGE_MAX_AGE = 24 * 30    # owner + trophies change ~once a season
+PLAYER_CARD_MAX_AGE = 24 * 7   # discovery links accrete slowly
+
+
+def _fetcher(args) -> Fetcher:
+    return Fetcher(cache_dir=DEFAULT_CACHE, delay_seconds=args.delay,
+                   refresh=getattr(args, "refresh", False))
+
+
+def _print_table(headers: list[str], rows: list[tuple]) -> None:
+    widths = [max(len(str(h)), *(len(str(r[i])) for r in rows)) if rows else len(str(h))
+              for i, h in enumerate(headers)]
+    print("  ".join(str(h).ljust(w) for h, w in zip(headers, widths)))
+    print("  ".join("-" * w for w in widths))
+    for r in rows:
+        print("  ".join(str(v if v is not None else "").ljust(w) for v, w in zip(r, widths)))
+
+
+def cmd_discover(args) -> int:
+    fetcher = _fetcher(args)
+    conn = store.connect(args.db)
+    seed = args.seed_league
+
+    csv_text = fetcher.get(f"/football/{seed}/csv/rosters", max_age_hours=SNAPSHOT_MAX_AGE)
+    if not csv_text:
+        print(f"Could not fetch rosters CSV for seed league {seed}", file=sys.stderr)
+        return 1
+    roster = parsers.parse_rosters_csv(csv_text)
+    player_ids = list(dict.fromkeys(
+        r["ottoneu_player_id"] for r in roster if r["ottoneu_player_id"]
+    ))[: args.max_players]
+
+    store.record_discovered(conn, seed, "seed")
+    found: set[int] = set()
+    for i, pid in enumerate(player_ids, 1):
+        html = fetcher.get(f"/football/{seed}/player_card/nfl/{pid}",
+                           max_age_hours=PLAYER_CARD_MAX_AGE)
+        if not html:
+            continue
+        ids = parsers.parse_league_ids_from_player_card(html, exclude=seed)
+        for lid in ids:
+            store.record_discovered(conn, lid, f"player_card:{pid}")
+        found |= ids
+        if i % 10 == 0 or i == len(player_ids):
+            print(f"  [{i}/{len(player_ids)}] player cards scanned, "
+                  f"{len(found)} distinct leagues linked so far")
+    conn.commit()
+
+    total = len(store.discovered_league_ids(conn))
+    print(f"Done. {len(found)} leagues linked from this run; "
+          f"{total} total in discovered_leagues.")
+    print("Next: just league-explorer scrape --discovered")
+    return 0
+
+
+def _scrape_league(fetcher: Fetcher, conn, league_id: int) -> str:
+    """Scrape one league end-to-end. Returns a short status string."""
+    settings_html = fetcher.get(f"/football/{league_id}/settings",
+                                max_age_hours=SETTINGS_MAX_AGE)
+    if settings_html is None:
+        return "not found (404)"
+    settings = parsers.parse_settings(settings_html)
+    if settings["league_id"] != league_id:
+        # Private/inaccessible leagues bounce to a page without a settings table.
+        return "no public settings (private league?)"
+    store.upsert_league(conn, settings)
+
+    csv_text = fetcher.get(f"/football/{league_id}/csv/rosters",
+                           max_age_hours=SNAPSHOT_MAX_AGE)
+    roster_rows = parsers.parse_rosters_csv(csv_text) if csv_text else []
+    store.snapshot_rosters(conn, league_id, roster_rows)
+
+    finances_html = fetcher.get(f"/football/{league_id}/finances",
+                                max_age_hours=SNAPSHOT_MAX_AGE)
+    if finances_html:
+        store.snapshot_finances(conn, league_id, parsers.parse_finances(finances_html))
+
+    team_ids = sorted({r["team_id"] for r in roster_rows})
+    for tid in team_ids:
+        team_html = fetcher.get(f"/football/{league_id}/team/{tid}",
+                                max_age_hours=TEAM_PAGE_MAX_AGE)
+        if not team_html:
+            continue
+        team = parsers.parse_team_page(team_html)
+        store.upsert_team(conn, league_id, tid, team["name"], team["owner"])
+        store.replace_trophies(conn, league_id, tid, team["trophies"])
+
+    first_season = settings["established_year"] or date.today().year
+    seasons_stored = 0
+    for season in range(first_season, date.today().year + 1):
+        immutable = season < date.today().year
+        html = fetcher.get(f"/football/{league_id}/standings/{season}",
+                           max_age_hours=None if immutable else SNAPSHOT_MAX_AGE)
+        if not html:
+            continue
+        rows = parsers.parse_standings(html)
+        # An unplayed season renders all-zero records; don't store it.
+        rows = [r for r in rows if (r["wins"] or r["losses"] or r["ties"]
+                                    or (r["points_for"] or 0) > 0)]
+        if rows:
+            store.replace_standings(conn, league_id, season, rows)
+            seasons_stored += 1
+
+    conn.commit()
+    return (f"ok — {len(roster_rows)} roster slots, {len(team_ids)} teams, "
+            f"{seasons_stored} seasons of standings")
+
+
+def cmd_scrape(args) -> int:
+    fetcher = _fetcher(args)
+    conn = store.connect(args.db)
+
+    if args.league_ids:
+        league_ids = [int(x) for x in args.league_ids.split(",") if x.strip()]
+    elif args.discovered:
+        league_ids = store.discovered_league_ids(conn)
+    else:
+        print("Provide --league-ids 33,74,... or --discovered", file=sys.stderr)
+        return 1
+    if args.max_leagues:
+        league_ids = league_ids[: args.max_leagues]
+
+    print(f"Scraping {len(league_ids)} league(s)...")
+    failures = 0
+    for i, lid in enumerate(league_ids, 1):
+        try:
+            status = _scrape_league(fetcher, conn, lid)
+        except FetchError as e:
+            status = f"FAILED: {e}"
+            failures += 1
+        print(f"  [{i}/{len(league_ids)}] league {lid}: {status}")
+    print(f"Done ({fetcher.requests_made} requests, {fetcher.cache_hits} cache hits). "
+          f"DB: {args.db}")
+    return 1 if failures == len(league_ids) and league_ids else 0
+
+
+def cmd_report(args) -> int:
+    conn = store.connect(args.db)
+
+    print("## Leagues scraped\n")
+    rows = conn.execute(
+        """SELECT l.league_id, l.name, l.tier, l.points_system, l.roster_settings,
+                  l.num_teams, l.established_year,
+                  (SELECT t.name FROM trophies tr JOIN teams t
+                     ON t.league_id = tr.league_id AND t.team_id = tr.team_id
+                    WHERE tr.league_id = l.league_id AND tr.place = 'champion'
+                    ORDER BY tr.season DESC LIMIT 1) AS latest_champion
+             FROM leagues l ORDER BY l.league_id"""
+    ).fetchall()
+    _print_table(
+        ["id", "name", "tier", "points", "rosters", "teams", "est", "latest champ"],
+        [tuple(r) for r in rows],
+    )
+
+    print("\n## Format mix\n")
+    rows = conn.execute(
+        """SELECT points_system, roster_settings, COUNT(*) AS leagues
+             FROM leagues GROUP BY 1, 2 ORDER BY leagues DESC"""
+    ).fetchall()
+    _print_table(["points", "rosters", "leagues"], [tuple(r) for r in rows])
+
+    print("\n## Champions by season\n")
+    rows = conn.execute(
+        """SELECT tr.season, tr.league_id, lg.name AS league, t.name AS team, t.owner
+             FROM trophies tr
+             JOIN teams t ON t.league_id = tr.league_id AND t.team_id = tr.team_id
+             JOIN leagues lg ON lg.league_id = tr.league_id
+            WHERE tr.place = 'champion'
+            ORDER BY tr.season DESC, tr.league_id LIMIT ?""",
+        (args.limit,),
+    ).fetchall()
+    _print_table(["season", "league_id", "league", "team", "owner"],
+                 [tuple(r) for r in rows])
+
+    print("\n## Current roster salary by position: reigning champions vs everyone\n")
+    rows = conn.execute(
+        """WITH latest AS (
+               SELECT league_id, MAX(snapshot_date) AS snapshot_date
+                 FROM roster_slots GROUP BY league_id
+           ),
+           slots AS (
+               SELECT rs.*, CASE WHEN instr(rs.positions, '/') > 0
+                                 THEN substr(rs.positions, 1, instr(rs.positions, '/') - 1)
+                                 ELSE rs.positions END AS pos,
+                      EXISTS (
+                          SELECT 1 FROM trophies tr
+                           WHERE tr.league_id = rs.league_id
+                             AND tr.team_id = rs.team_id
+                             AND tr.place = 'champion'
+                             AND tr.season = (SELECT MAX(season) FROM trophies
+                                               WHERE league_id = rs.league_id
+                                                 AND place = 'champion')
+                      ) AS is_champ
+                 FROM roster_slots rs
+                 JOIN latest USING (league_id, snapshot_date)
+           )
+           SELECT pos,
+                  ROUND(AVG(CASE WHEN is_champ THEN salary END), 1) AS champ_avg,
+                  ROUND(SUM(CASE WHEN is_champ THEN salary ELSE 0 END) * 100.0 /
+                        NULLIF(SUM(SUM(CASE WHEN is_champ THEN salary ELSE 0 END)) OVER (), 0), 1)
+                      AS champ_spend_pct,
+                  ROUND(AVG(salary), 1) AS all_avg,
+                  ROUND(SUM(salary) * 100.0 /
+                        NULLIF(SUM(SUM(salary)) OVER (), 0), 1) AS all_spend_pct
+             FROM slots
+            WHERE pos IN ('QB', 'RB', 'WR', 'TE', 'K')
+            GROUP BY pos
+            ORDER BY all_spend_pct DESC"""
+    ).fetchall()
+    _print_table(["pos", "champ avg $", "champ spend %", "all avg $", "all spend %"],
+                 [tuple(r) for r in rows])
+    print("\n(Champion = winner of each league's most recent completed season; "
+          "salaries are from the latest roster snapshot.)")
+    return 0
+
+
+def cmd_query(args) -> int:
+    conn = store.connect(args.db)
+    cur = conn.execute(args.sql)
+    headers = [d[0] for d in cur.description] if cur.description else []
+    rows = cur.fetchall()
+    if args.csv:
+        writer = csv.writer(sys.stdout)
+        writer.writerow(headers)
+        writer.writerows([tuple(r) for r in rows])
+    else:
+        _print_table(headers, [tuple(r) for r in rows])
+        print(f"\n({len(rows)} rows)")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="league-explorer",
+        description="Explore public Ottoneu football leagues into a local SQLite DB.",
+    )
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--db", default=str(DEFAULT_DB), help="SQLite DB path")
+    common.add_argument("--delay", type=float, default=1.0,
+                        help="Seconds between HTTP requests (default 1.0)")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("discover", parents=[common],
+                       help="Find league IDs via player-card trade links")
+    p.add_argument("--seed-league", type=int, default=LEAGUE_ID,
+                   help="League whose player cards to scan (default: our league)")
+    p.add_argument("--max-players", type=int, default=75,
+                   help="How many rostered players' cards to scan (default 75)")
+    p.set_defaults(func=cmd_discover)
+
+    p = sub.add_parser("scrape", parents=[common],
+                       help="Scrape leagues into the local DB")
+    p.add_argument("--league-ids", help="Comma-separated Ottoneu league IDs")
+    p.add_argument("--discovered", action="store_true",
+                   help="Scrape every league in discovered_leagues")
+    p.add_argument("--max-leagues", type=int, default=0,
+                   help="Cap the number of leagues scraped this run")
+    p.add_argument("--refresh", action="store_true",
+                   help="Refetch mutable pages even if cached copies are fresh")
+    p.set_defaults(func=cmd_scrape)
+
+    p = sub.add_parser("report", parents=[common],
+                       help="Cross-league summary report")
+    p.add_argument("--limit", type=int, default=40,
+                   help="Max champion rows to list (default 40)")
+    p.set_defaults(func=cmd_report)
+
+    p = sub.add_parser("query", parents=[common],
+                       help="Run ad-hoc SQL against the local DB")
+    p.add_argument("sql", help="SQL statement to execute")
+    p.add_argument("--csv", action="store_true", help="Emit CSV instead of a table")
+    p.set_defaults(func=cmd_query)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/league_explorer/fetcher.py
+++ b/scripts/league_explorer/fetcher.py
@@ -58,7 +58,12 @@ class Fetcher:
         self._last_request_at = time.monotonic()
 
     def get(self, path: str, max_age_hours: float | None = None) -> str | None:
-        """Fetch BASE_URL + path, returning page text or None on HTTP 404.
+        """Fetch BASE_URL + path, returning page text or None if unavailable.
+
+        Returns None on HTTP 404 and on any redirect (redirects are not
+        followed: Ottoneu 307s deleted/nonexistent league URLs to
+        /football/?invalidLeague=1 and gated pages to a login screen, so a
+        redirect always means "no public page here").
 
         max_age_hours=None means the cached copy never expires (immutable
         pages like past-season standings). refresh=True bypasses the cache
@@ -78,12 +83,13 @@ class Fetcher:
                 time.sleep(retry_delay)
             self._throttle()
             try:
-                resp = self.session.get(BASE_URL + path, timeout=30)
+                resp = self.session.get(BASE_URL + path, timeout=30,
+                                        allow_redirects=False)
             except requests.RequestException as e:
                 last_error = e
                 continue
             self.requests_made += 1
-            if resp.status_code == 404:
+            if resp.status_code == 404 or 300 <= resp.status_code < 400:
                 return None
             if resp.status_code >= 500:
                 last_error = FetchError(f"HTTP {resp.status_code} for {path}")

--- a/scripts/league_explorer/fetcher.py
+++ b/scripts/league_explorer/fetcher.py
@@ -1,0 +1,94 @@
+"""Polite HTTP fetcher with an on-disk cache for public Ottoneu pages.
+
+Every network request is rate-limited (default 1 req/s) and sent with a
+descriptive User-Agent. Successful responses are cached under
+data/league_explorer/cache/ so re-runs and re-parses are free; pages that can
+never change (e.g. completed-season standings) are cached forever, while
+current-state pages honor a max_age.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+
+import requests
+
+BASE_URL = "https://ottoneu.fangraphs.com"
+USER_AGENT = (
+    "ottoneu-db-league-explorer/0.1 "
+    "(personal research tool; github.com/alex-monroe/ottoneu-db)"
+)
+DEFAULT_CACHE_DIR = Path("data/league_explorer/cache")
+RETRY_DELAYS = [2, 5, 10]
+
+_SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+class FetchError(Exception):
+    """Raised when a page cannot be fetched after retries (non-404 failure)."""
+
+
+class Fetcher:
+    def __init__(
+        self,
+        cache_dir: Path | str = DEFAULT_CACHE_DIR,
+        delay_seconds: float = 1.0,
+        refresh: bool = False,
+    ):
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.delay_seconds = delay_seconds
+        self.refresh = refresh
+        self._last_request_at = 0.0
+        self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
+        self.requests_made = 0
+        self.cache_hits = 0
+
+    def _cache_path(self, path: str) -> Path:
+        slug = _SLUG_RE.sub("_", path.strip("/")) or "root"
+        return self.cache_dir / slug
+
+    def _throttle(self) -> None:
+        wait = self._last_request_at + self.delay_seconds - time.monotonic()
+        if wait > 0:
+            time.sleep(wait)
+        self._last_request_at = time.monotonic()
+
+    def get(self, path: str, max_age_hours: float | None = None) -> str | None:
+        """Fetch BASE_URL + path, returning page text or None on HTTP 404.
+
+        max_age_hours=None means the cached copy never expires (immutable
+        pages like past-season standings). refresh=True bypasses the cache
+        for mutable pages but still trusts immutable ones.
+        """
+        cache_file = self._cache_path(path)
+        if cache_file.exists():
+            age_hours = (time.time() - cache_file.stat().st_mtime) / 3600
+            immutable = max_age_hours is None
+            if immutable or (not self.refresh and age_hours <= max_age_hours):
+                self.cache_hits += 1
+                return cache_file.read_text()
+
+        last_error: Exception | None = None
+        for attempt, retry_delay in enumerate([0] + RETRY_DELAYS):
+            if retry_delay:
+                time.sleep(retry_delay)
+            self._throttle()
+            try:
+                resp = self.session.get(BASE_URL + path, timeout=30)
+            except requests.RequestException as e:
+                last_error = e
+                continue
+            self.requests_made += 1
+            if resp.status_code == 404:
+                return None
+            if resp.status_code >= 500:
+                last_error = FetchError(f"HTTP {resp.status_code} for {path}")
+                continue
+            resp.raise_for_status()
+            cache_file.write_text(resp.text)
+            return resp.text
+        raise FetchError(f"Failed to fetch {path}: {last_error}")

--- a/scripts/league_explorer/parsers.py
+++ b/scripts/league_explorer/parsers.py
@@ -1,0 +1,208 @@
+"""HTML/CSV parsers for public Ottoneu football league pages.
+
+Pure functions (markup in, plain dicts out) so they can be unit-tested on
+fixture snippets and reused by any caller. Page shapes verified against live
+pages in July 2026:
+
+- /football/{id}/settings        key/value table of league configuration
+- /football/{id}/standings/{yr}  per-season standings with division rows
+- /football/{id}/team/{tid}      team header, manager, trophy case
+- /football/{id}/finances        cap/salary table per team
+- /football/{id}/csv/rosters     CSV export of all current rosters
+- /football/{id}/player_card/... trade links into other leagues (discovery)
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+
+from bs4 import BeautifulSoup
+
+_RECORD_RE = re.compile(r"^(\d+)-(\d+)-(\d+)$")
+_YEAR_RE = re.compile(r"(\d{4})")
+_MONEY_RE = re.compile(r"-?\d+")
+_FOOTBALL_LEAGUE_RE = re.compile(r"/football/(\d+)/")
+_TROPHY_RE = re.compile(r"(\d{4})\s+(.*)")
+
+TROPHY_PLACES = {
+    "Champion": "champion",
+    "Runner-Up": "runner_up",
+    "Third Place": "third_place",
+}
+
+
+def _soup(html: str) -> BeautifulSoup:
+    return BeautifulSoup(html, "lxml")
+
+
+def _money(text: str) -> int | None:
+    m = _MONEY_RE.search(text.replace(",", ""))
+    return int(m.group()) if m else None
+
+
+def parse_league_name(html: str) -> str | None:
+    """League name from the <title>: 'Ottoneu Fantasy Football - {name} - {page}'."""
+    soup = _soup(html)
+    if not soup.title:
+        return None
+    parts = [p.strip() for p in soup.title.get_text().split(" - ")]
+    if len(parts) < 3:
+        return None
+    return " - ".join(parts[1:-1])
+
+
+def parse_settings(html: str) -> dict:
+    """League configuration from the settings page's key/value table."""
+    soup = _soup(html)
+    raw: dict[str, str] = {}
+    for tr in soup.find_all("tr"):
+        cells = tr.find_all(["th", "td"])
+        if len(cells) >= 2:
+            label = cells[0].get_text(" ", strip=True)
+            value = cells[1].get_text(" ", strip=True)
+            if label and label != "Setting":
+                raw[label] = value
+
+    established = raw.get("Established", "")
+    year_match = _YEAR_RE.search(established)
+    num_teams = raw.get("Number of Teams", "")
+    return {
+        "league_id": int(raw["ID"]) if raw.get("ID", "").isdigit() else None,
+        "name": parse_league_name(html),
+        "established": established or None,
+        "established_year": int(year_match.group(1)) if year_match else None,
+        "tier": raw.get("Tier"),
+        "is_private": raw.get("Private League?", "").strip().lower() == "yes",
+        "num_teams": int(num_teams) if num_teams.isdigit() else None,
+        "points_system": raw.get("Points System"),
+        "roster_settings": raw.get("Roster Settings"),
+        "playoff_settings": raw.get("Playoff Settings"),
+    }
+
+
+def parse_standings(html: str) -> list[dict]:
+    """Standings rows with division labels; division header rows repeat one
+    value across every column, which is how they are detected."""
+    soup = _soup(html)
+    rows: list[dict] = []
+    division = None
+    for tr in soup.find_all("tr"):
+        cells = tr.find_all("td")
+        if not cells:
+            continue
+        texts = [c.get_text(" ", strip=True) for c in cells]
+        if len(set(texts)) == 1 and texts[0]:
+            division = texts[0]
+            continue
+        if len(texts) < 4:
+            continue
+        record = _RECORD_RE.match(texts[1])
+        if not record:
+            continue
+        link = cells[0].find("a", href=_FOOTBALL_LEAGUE_RE)
+        team_id = None
+        if link:
+            id_match = re.search(r"/team/(\d+)", link["href"])
+            team_id = int(id_match.group(1)) if id_match else None
+        rows.append(
+            {
+                "team_id": team_id,
+                "team_name": texts[0],
+                "division": division,
+                "wins": int(record.group(1)),
+                "losses": int(record.group(2)),
+                "ties": int(record.group(3)),
+                "points_for": float(texts[2]) if texts[2] else None,
+                "points_against": float(texts[3]) if texts[3] else None,
+            }
+        )
+    return rows
+
+
+def parse_team_page(html: str) -> dict:
+    """Team name, manager username, and trophy history from a team page."""
+    soup = _soup(html)
+    name = None
+    for h1 in soup.find_all("h1"):
+        if "ottoneu-logo" in (h1.get("class") or []):
+            continue
+        text = h1.get_text(" ", strip=True)
+        if text:
+            name = text
+            break
+
+    owner_link = soup.find("a", href=re.compile(r"^/user/"))
+    owner = owner_link.get_text(strip=True) if owner_link else None
+
+    trophies = []
+    case = soup.select_one(".trophy-case")
+    if case:
+        for icon in case.find_all("i"):
+            m = _TROPHY_RE.match(icon.get("title", ""))
+            if not m:
+                continue
+            place = TROPHY_PLACES.get(m.group(2).strip())
+            if place:
+                trophies.append({"season": int(m.group(1)), "place": place})
+
+    return {"name": name, "owner": owner, "trophies": trophies}
+
+
+def parse_finances(html: str) -> list[dict]:
+    """Per-team salary/cap rows from the finances page."""
+    soup = _soup(html)
+    for table in soup.find_all("table"):
+        headers = [th.get_text(" ", strip=True) for th in table.find_all("th")]
+        if "Salaries" not in headers or "Team" not in headers:
+            continue
+        idx = {h: i for i, h in enumerate(headers)}
+        rows = []
+        for tr in table.find_all("tr"):
+            cells = [td.get_text(" ", strip=True) for td in tr.find_all("td")]
+            if len(cells) < len(headers):
+                continue
+            rows.append(
+                {
+                    "team_name": cells[idx["Team"]],
+                    "players": _money(cells[idx["Players"]]),
+                    "spots": _money(cells[idx["Spots"]]),
+                    "salaries": _money(cells[idx["Salaries"]]),
+                    "cap_penalties": _money(cells[idx["Cap Penalties"]]),
+                    "incoming_loans": _money(cells[idx["Incoming Loans"]]),
+                    "outgoing_loans": _money(cells[idx["Outgoing Loans"]]),
+                    "free_cap_space": _money(cells[idx["Free Cap Space"]]),
+                }
+            )
+        return rows
+    return []
+
+
+def parse_rosters_csv(text: str) -> list[dict]:
+    """Rows from the /csv/rosters export (current rosters + salaries)."""
+    reader = csv.DictReader(io.StringIO(text))
+    rows = []
+    for r in reader:
+        if not r.get("Team ID") or not r["Team ID"].isdigit():
+            continue
+        rows.append(
+            {
+                "team_id": int(r["Team ID"]),
+                "team_name": r["Team Name"],
+                "ottoneu_player_id": int(r["Player ID"]) if r.get("Player ID", "").isdigit() else None,
+                "player_name": r["Player Name"],
+                "pro_team": r.get("Pro Team") or None,
+                "positions": r.get("Position(s)") or None,
+                "salary": _money(r.get("Salary", "")),
+            }
+        )
+    return rows
+
+
+def parse_league_ids_from_player_card(html: str, exclude: int | None = None) -> set[int]:
+    """League IDs linked from a player card (trades in other leagues)."""
+    ids = {int(m) for m in _FOOTBALL_LEAGUE_RE.findall(html)}
+    if exclude is not None:
+        ids.discard(exclude)
+    return ids

--- a/scripts/league_explorer/store.py
+++ b/scripts/league_explorer/store.py
@@ -1,0 +1,205 @@
+"""SQLite storage for the league explorer.
+
+Local single-file DB (data/league_explorer/league_explorer.db, gitignored) —
+deliberately separate from the shared Supabase project. Roster and finances
+rows are dated snapshots so salary evolution accrues across runs; settings,
+teams, trophies, and standings are idempotent upserts.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+DEFAULT_DB_PATH = Path("data/league_explorer/league_explorer.db")
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS leagues (
+    league_id        INTEGER PRIMARY KEY,
+    name             TEXT,
+    established      TEXT,
+    established_year INTEGER,
+    tier             TEXT,
+    is_private       INTEGER,
+    num_teams        INTEGER,
+    points_system    TEXT,
+    roster_settings  TEXT,
+    playoff_settings TEXT,
+    last_scraped_at  TEXT
+);
+
+CREATE TABLE IF NOT EXISTS teams (
+    league_id INTEGER NOT NULL,
+    team_id   INTEGER NOT NULL,
+    name      TEXT,
+    owner     TEXT,
+    PRIMARY KEY (league_id, team_id)
+);
+
+CREATE TABLE IF NOT EXISTS trophies (
+    league_id INTEGER NOT NULL,
+    team_id   INTEGER NOT NULL,
+    season    INTEGER NOT NULL,
+    place     TEXT NOT NULL,   -- champion | runner_up | third_place
+    PRIMARY KEY (league_id, team_id, season, place)
+);
+
+CREATE TABLE IF NOT EXISTS standings (
+    league_id      INTEGER NOT NULL,
+    season         INTEGER NOT NULL,
+    team_id        INTEGER,
+    team_name      TEXT NOT NULL,
+    division       TEXT,
+    wins           INTEGER,
+    losses         INTEGER,
+    ties           INTEGER,
+    points_for     REAL,
+    points_against REAL,
+    PRIMARY KEY (league_id, season, team_name)
+);
+
+CREATE TABLE IF NOT EXISTS roster_slots (
+    snapshot_date     TEXT NOT NULL,
+    league_id         INTEGER NOT NULL,
+    team_id           INTEGER NOT NULL,
+    team_name         TEXT,
+    ottoneu_player_id INTEGER,
+    player_name       TEXT,
+    pro_team          TEXT,
+    positions         TEXT,
+    salary            INTEGER,
+    PRIMARY KEY (snapshot_date, league_id, team_id, ottoneu_player_id)
+);
+
+CREATE TABLE IF NOT EXISTS finances (
+    snapshot_date  TEXT NOT NULL,
+    league_id      INTEGER NOT NULL,
+    team_name      TEXT NOT NULL,
+    players        INTEGER,
+    spots          INTEGER,
+    salaries       INTEGER,
+    cap_penalties  INTEGER,
+    incoming_loans INTEGER,
+    outgoing_loans INTEGER,
+    free_cap_space INTEGER,
+    PRIMARY KEY (snapshot_date, league_id, team_name)
+);
+
+CREATE TABLE IF NOT EXISTS discovered_leagues (
+    league_id     INTEGER PRIMARY KEY,
+    source        TEXT,
+    discovered_at TEXT
+);
+"""
+
+
+def connect(db_path: Path | str = DEFAULT_DB_PATH) -> sqlite3.Connection:
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA)
+    return conn
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def upsert_league(conn: sqlite3.Connection, settings: dict) -> None:
+    conn.execute(
+        """INSERT INTO leagues (league_id, name, established, established_year, tier,
+                                is_private, num_teams, points_system, roster_settings,
+                                playoff_settings, last_scraped_at)
+           VALUES (:league_id, :name, :established, :established_year, :tier,
+                   :is_private, :num_teams, :points_system, :roster_settings,
+                   :playoff_settings, :last_scraped_at)
+           ON CONFLICT(league_id) DO UPDATE SET
+               name=excluded.name, established=excluded.established,
+               established_year=excluded.established_year, tier=excluded.tier,
+               is_private=excluded.is_private, num_teams=excluded.num_teams,
+               points_system=excluded.points_system,
+               roster_settings=excluded.roster_settings,
+               playoff_settings=excluded.playoff_settings,
+               last_scraped_at=excluded.last_scraped_at""",
+        {**settings, "is_private": int(settings.get("is_private") or 0),
+         "last_scraped_at": _now()},
+    )
+
+
+def upsert_team(conn: sqlite3.Connection, league_id: int, team_id: int,
+                name: str | None, owner: str | None) -> None:
+    conn.execute(
+        """INSERT INTO teams (league_id, team_id, name, owner)
+           VALUES (?, ?, ?, ?)
+           ON CONFLICT(league_id, team_id) DO UPDATE SET
+               name=COALESCE(excluded.name, name),
+               owner=COALESCE(excluded.owner, owner)""",
+        (league_id, team_id, name, owner),
+    )
+
+
+def replace_trophies(conn: sqlite3.Connection, league_id: int, team_id: int,
+                     trophies: list[dict]) -> None:
+    conn.execute("DELETE FROM trophies WHERE league_id=? AND team_id=?",
+                 (league_id, team_id))
+    conn.executemany(
+        "INSERT OR IGNORE INTO trophies (league_id, team_id, season, place) VALUES (?, ?, ?, ?)",
+        [(league_id, team_id, t["season"], t["place"]) for t in trophies],
+    )
+
+
+def replace_standings(conn: sqlite3.Connection, league_id: int, season: int,
+                      rows: list[dict]) -> None:
+    conn.execute("DELETE FROM standings WHERE league_id=? AND season=?",
+                 (league_id, season))
+    conn.executemany(
+        """INSERT OR REPLACE INTO standings
+           (league_id, season, team_id, team_name, division, wins, losses, ties,
+            points_for, points_against)
+           VALUES (:league_id, :season, :team_id, :team_name, :division, :wins,
+                   :losses, :ties, :points_for, :points_against)""",
+        [{**r, "league_id": league_id, "season": season} for r in rows],
+    )
+
+
+def snapshot_rosters(conn: sqlite3.Connection, league_id: int, rows: list[dict],
+                     snapshot_date: str | None = None) -> None:
+    day = snapshot_date or date.today().isoformat()
+    conn.executemany(
+        """INSERT OR REPLACE INTO roster_slots
+           (snapshot_date, league_id, team_id, team_name, ottoneu_player_id,
+            player_name, pro_team, positions, salary)
+           VALUES (:snapshot_date, :league_id, :team_id, :team_name,
+                   :ottoneu_player_id, :player_name, :pro_team, :positions,
+                   :salary)""",
+        [{**r, "snapshot_date": day, "league_id": league_id} for r in rows],
+    )
+
+
+def snapshot_finances(conn: sqlite3.Connection, league_id: int, rows: list[dict],
+                      snapshot_date: str | None = None) -> None:
+    day = snapshot_date or date.today().isoformat()
+    conn.executemany(
+        """INSERT OR REPLACE INTO finances
+           (snapshot_date, league_id, team_name, players, spots, salaries,
+            cap_penalties, incoming_loans, outgoing_loans, free_cap_space)
+           VALUES (:snapshot_date, :league_id, :team_name, :players, :spots,
+                   :salaries, :cap_penalties, :incoming_loans, :outgoing_loans,
+                   :free_cap_space)""",
+        [{**r, "snapshot_date": day, "league_id": league_id} for r in rows],
+    )
+
+
+def record_discovered(conn: sqlite3.Connection, league_id: int, source: str) -> None:
+    conn.execute(
+        """INSERT INTO discovered_leagues (league_id, source, discovered_at)
+           VALUES (?, ?, ?) ON CONFLICT(league_id) DO NOTHING""",
+        (league_id, source, _now()),
+    )
+
+
+def discovered_league_ids(conn: sqlite3.Connection) -> list[int]:
+    return [r["league_id"] for r in
+            conn.execute("SELECT league_id FROM discovered_leagues ORDER BY league_id")]

--- a/scripts/tests/test_league_explorer.py
+++ b/scripts/tests/test_league_explorer.py
@@ -1,0 +1,271 @@
+"""Tests for the league explorer (scripts/league_explorer/).
+
+Parser fixtures are compact excerpts of the real page markup (verified live
+July 2026); store tests run against a temp SQLite file; fetcher tests use a
+fake requests session (no network).
+"""
+
+import time
+
+import pytest
+
+from scripts.league_explorer import parsers, store
+from scripts.league_explorer.fetcher import Fetcher
+
+SETTINGS_HTML = """
+<html><head>
+<title>Ottoneu Fantasy Football - St Louis Metropolitan Football - Settings</title>
+</head><body><table>
+<tr><th>Setting</th><th></th></tr>
+<tr><td>ID</td><td>33</td></tr>
+<tr><td>Established</td><td>August 12, 2015</td></tr>
+<tr><td>Tier</td><td>$100 Tier</td></tr>
+<tr><td>Private League?</td><td>No</td></tr>
+<tr><td>Number of Teams</td><td>12</td></tr>
+<tr><td>Points System</td><td>0.5 PPR</td></tr>
+<tr><td>Roster Settings</td><td>Two Flex</td></tr>
+<tr><td>Playoff Settings</td><td>Six playoff teams</td></tr>
+</table></body></html>
+"""
+
+STANDINGS_HTML = """
+<html><body><table>
+<tr><th>Team</th><th>Record (W-L-T)</th><th>Points For</th><th>Points Against</th></tr>
+<tr><td>Csonka</td><td>Csonka</td><td>Csonka</td><td>Csonka</td></tr>
+<tr><td><a href="/football/33/team/134">JTP</a></td><td>10-4-0</td>
+    <td>1569.66</td><td>1337.42</td></tr>
+<tr><td><a href="/football/33/team/216">Da Dolphins</a></td><td>6-8-0</td>
+    <td>1246.64</td><td>1277.96</td></tr>
+<tr><td>Nagurski</td><td>Nagurski</td><td>Nagurski</td><td>Nagurski</td></tr>
+<tr><td><a href="/football/33/team/157">Juggernaut</a></td><td>9-5-0</td>
+    <td>1672.78</td><td>1398.16</td></tr>
+</table></body></html>
+"""
+
+TEAM_HTML = """
+<html><head>
+<title>Ottoneu Fantasy Football - St Louis Metropolitan Football - Team</title>
+</head><body>
+<h1 class="header-headline ottoneu-logo">ottoneu Football Logo</h1>
+<h1>JTP</h1>
+<h3>Manager</h3><h4><a href="/user/jpanaro">jpanaro</a></h4>
+<span class="trophy-case">
+  <i class="fa fa-trophy third-place" title="2017 Third Place"></i>
+  <i class="fa fa-trophy runner-up" title="2021 Runner-Up"></i>
+  <i class="fa fa-trophy champion" title="2025 Champion"></i>
+  <i class="fa fa-trophy" title="not a trophy"></i>
+</span>
+</body></html>
+"""
+
+FINANCES_HTML = """
+<html><body><table>
+<tr><th>Team</th><th>Players</th><th>Spots</th><th>Salaries</th>
+    <th>Cap Penalties</th><th>Incoming Loans</th><th>Outgoing Loans</th>
+    <th>Free Cap Space</th></tr>
+<tr><td>JTP</td><td>22</td><td>20</td><td>$497</td><td>$0</td>
+    <td>$0</td><td>$0</td><td>$-97</td></tr>
+<tr><td>Da Dolphins</td><td>15</td><td>20</td><td>$1,185</td><td>$0</td>
+    <td>$0</td><td>$0</td><td>$215</td></tr>
+</table></body></html>
+"""
+
+ROSTERS_CSV = '''"Team ID","Team Name","Player ID","Pro Player","Player Name","Pro Team",Position(s),Salary
+134,JTP,8970,true,"Justin Jefferson",MIN,WR,$100
+134,JTP,13095,true,"Drake Maye",NE,QB,$35
+133,"Gently's Agency",12653,true,"Jake Bates",DET,K,$6
+'''
+
+PLAYER_CARD_HTML = """
+<html><body>
+<a href="/football/309/standings">Standings</a>
+<a href="https://ottoneu.fangraphs.com/football/33/team/134">JTP</a>
+<a href="https://ottoneu.fangraphs.com/football/33/view_trade/39466">trade</a>
+<a href="https://ottoneu.fangraphs.com/football/205/team/2108">other</a>
+<a href="https://www.fangraphs.com/policy.aspx">policy</a>
+</body></html>
+"""
+
+
+class TestParsers:
+    def test_parse_league_name(self):
+        assert parsers.parse_league_name(SETTINGS_HTML) == "St Louis Metropolitan Football"
+
+    def test_parse_league_name_handles_hyphenated_names(self):
+        html = "<title>Ottoneu Fantasy Football - The A - Team League - Settings</title>"
+        assert parsers.parse_league_name(html) == "The A - Team League"
+
+    def test_parse_settings(self):
+        s = parsers.parse_settings(SETTINGS_HTML)
+        assert s["league_id"] == 33
+        assert s["name"] == "St Louis Metropolitan Football"
+        assert s["established_year"] == 2015
+        assert s["tier"] == "$100 Tier"
+        assert s["is_private"] is False
+        assert s["num_teams"] == 12
+        assert s["points_system"] == "0.5 PPR"
+        assert s["roster_settings"] == "Two Flex"
+        assert s["playoff_settings"] == "Six playoff teams"
+
+    def test_parse_settings_missing_table(self):
+        s = parsers.parse_settings("<html><body>login required</body></html>")
+        assert s["league_id"] is None
+
+    def test_parse_standings_divisions_and_records(self):
+        rows = parsers.parse_standings(STANDINGS_HTML)
+        assert len(rows) == 3
+        jtp = rows[0]
+        assert jtp["team_id"] == 134
+        assert jtp["team_name"] == "JTP"
+        assert jtp["division"] == "Csonka"
+        assert (jtp["wins"], jtp["losses"], jtp["ties"]) == (10, 4, 0)
+        assert jtp["points_for"] == pytest.approx(1569.66)
+        assert rows[2]["division"] == "Nagurski"
+
+    def test_parse_team_page(self):
+        team = parsers.parse_team_page(TEAM_HTML)
+        assert team["name"] == "JTP"  # skips the ottoneu-logo h1
+        assert team["owner"] == "jpanaro"
+        assert {"season": 2025, "place": "champion"} in team["trophies"]
+        assert {"season": 2021, "place": "runner_up"} in team["trophies"]
+        assert {"season": 2017, "place": "third_place"} in team["trophies"]
+        assert len(team["trophies"]) == 3  # malformed title ignored
+
+    def test_parse_finances(self):
+        rows = parsers.parse_finances(FINANCES_HTML)
+        assert len(rows) == 2
+        assert rows[0]["team_name"] == "JTP"
+        assert rows[0]["salaries"] == 497
+        assert rows[0]["free_cap_space"] == -97
+        assert rows[1]["salaries"] == 1185  # comma stripped
+
+    def test_parse_rosters_csv(self):
+        rows = parsers.parse_rosters_csv(ROSTERS_CSV)
+        assert len(rows) == 3
+        jj = rows[0]
+        assert jj["team_id"] == 134
+        assert jj["ottoneu_player_id"] == 8970
+        assert jj["player_name"] == "Justin Jefferson"
+        assert jj["positions"] == "WR"
+        assert jj["salary"] == 100
+        assert rows[2]["team_name"] == "Gently's Agency"
+
+    def test_parse_league_ids_from_player_card(self):
+        seed = 309
+        ids = parsers.parse_league_ids_from_player_card(PLAYER_CARD_HTML, exclude=seed)
+        assert ids == {33, 205}
+
+
+class TestStore:
+    def _settings(self, league_id=33):
+        return {
+            "league_id": league_id,
+            "name": "Test League",
+            "established": "August 12, 2015",
+            "established_year": 2015,
+            "tier": "$100 Tier",
+            "is_private": False,
+            "num_teams": 12,
+            "points_system": "0.5 PPR",
+            "roster_settings": "Two Flex",
+            "playoff_settings": "Six playoff teams",
+        }
+
+    def test_upsert_league_idempotent(self, tmp_path):
+        conn = store.connect(tmp_path / "t.db")
+        store.upsert_league(conn, self._settings())
+        store.upsert_league(conn, {**self._settings(), "name": "Renamed"})
+        rows = conn.execute("SELECT name FROM leagues").fetchall()
+        assert len(rows) == 1
+        assert rows[0]["name"] == "Renamed"
+
+    def test_trophies_replaced_not_duplicated(self, tmp_path):
+        conn = store.connect(tmp_path / "t.db")
+        trophies = [{"season": 2025, "place": "champion"}]
+        store.replace_trophies(conn, 33, 134, trophies)
+        store.replace_trophies(conn, 33, 134, trophies)
+        assert conn.execute("SELECT COUNT(*) c FROM trophies").fetchone()["c"] == 1
+
+    def test_standings_replaced_per_season(self, tmp_path):
+        conn = store.connect(tmp_path / "t.db")
+        row = {"team_id": 134, "team_name": "JTP", "division": "Csonka",
+               "wins": 10, "losses": 4, "ties": 0,
+               "points_for": 1569.66, "points_against": 1337.42}
+        store.replace_standings(conn, 33, 2025, [row])
+        store.replace_standings(conn, 33, 2025, [{**row, "wins": 11}])
+        rows = conn.execute("SELECT * FROM standings").fetchall()
+        assert len(rows) == 1
+        assert rows[0]["wins"] == 11
+
+    def test_roster_snapshots_accumulate_by_date(self, tmp_path):
+        conn = store.connect(tmp_path / "t.db")
+        slot = {"team_id": 134, "team_name": "JTP", "ottoneu_player_id": 8970,
+                "player_name": "Justin Jefferson", "pro_team": "MIN",
+                "positions": "WR", "salary": 100}
+        store.snapshot_rosters(conn, 33, [slot], snapshot_date="2026-07-01")
+        store.snapshot_rosters(conn, 33, [{**slot, "salary": 110}],
+                               snapshot_date="2026-08-01")
+        rows = conn.execute(
+            "SELECT salary FROM roster_slots ORDER BY snapshot_date").fetchall()
+        assert [r["salary"] for r in rows] == [100, 110]
+
+    def test_discovered_leagues_dedupe(self, tmp_path):
+        conn = store.connect(tmp_path / "t.db")
+        store.record_discovered(conn, 33, "player_card:1")
+        store.record_discovered(conn, 33, "player_card:2")
+        store.record_discovered(conn, 205, "player_card:1")
+        assert store.discovered_league_ids(conn) == [33, 205]
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, text="page"):
+        self.status_code = status_code
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+class _FakeSession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.headers = {}
+        self.calls = 0
+
+    def get(self, url, timeout=None):
+        self.calls += 1
+        return self.responses.pop(0)
+
+
+class TestFetcher:
+    def test_caches_successful_fetches(self, tmp_path):
+        f = Fetcher(cache_dir=tmp_path, delay_seconds=0)
+        f.session = _FakeSession([_FakeResponse(text="hello")])
+        assert f.get("/football/33/settings", max_age_hours=12) == "hello"
+        # Second call is served from cache — no new network call.
+        assert f.get("/football/33/settings", max_age_hours=12) == "hello"
+        assert f.session.calls == 1
+        assert f.cache_hits == 1
+
+    def test_404_returns_none_and_is_not_cached(self, tmp_path):
+        f = Fetcher(cache_dir=tmp_path, delay_seconds=0)
+        f.session = _FakeSession([_FakeResponse(status_code=404)])
+        assert f.get("/football/33/standings/2010") is None
+        assert not list(tmp_path.iterdir())
+
+    def test_refresh_bypasses_mutable_cache_but_not_immutable(self, tmp_path):
+        f = Fetcher(cache_dir=tmp_path, delay_seconds=0, refresh=True)
+        f.session = _FakeSession([_FakeResponse(text="v1"), _FakeResponse(text="v2")])
+        assert f.get("/a", max_age_hours=12) == "v1"
+        assert f.get("/a", max_age_hours=12) == "v2"      # refresh refetches
+        assert f.get("/a", max_age_hours=None) == "v2"    # immutable: cache trusted
+
+    def test_stale_cache_refetched(self, tmp_path):
+        f = Fetcher(cache_dir=tmp_path, delay_seconds=0)
+        f.session = _FakeSession([_FakeResponse(text="new")])
+        cache_file = f._cache_path("/a")
+        cache_file.write_text("old")
+        two_days_ago = time.time() - 48 * 3600
+        import os
+        os.utime(cache_file, (two_days_ago, two_days_ago))
+        assert f.get("/a", max_age_hours=12) == "new"

--- a/scripts/tests/test_league_explorer.py
+++ b/scripts/tests/test_league_explorer.py
@@ -6,10 +6,11 @@ fake requests session (no network).
 """
 
 import time
+from datetime import date
 
 import pytest
 
-from scripts.league_explorer import parsers, store
+from scripts.league_explorer import cli, parsers, store
 from scripts.league_explorer.fetcher import Fetcher
 
 SETTINGS_HTML = """
@@ -232,7 +233,7 @@ class _FakeSession:
         self.headers = {}
         self.calls = 0
 
-    def get(self, url, timeout=None):
+    def get(self, url, timeout=None, allow_redirects=True):
         self.calls += 1
         return self.responses.pop(0)
 
@@ -253,6 +254,13 @@ class TestFetcher:
         assert f.get("/football/33/standings/2010") is None
         assert not list(tmp_path.iterdir())
 
+    def test_redirect_returns_none_and_is_not_cached(self, tmp_path):
+        # Dead league IDs 307-redirect to /football/?invalidLeague=1.
+        f = Fetcher(cache_dir=tmp_path, delay_seconds=0)
+        f.session = _FakeSession([_FakeResponse(status_code=307)])
+        assert f.get("/football/999/settings") is None
+        assert not list(tmp_path.iterdir())
+
     def test_refresh_bypasses_mutable_cache_but_not_immutable(self, tmp_path):
         f = Fetcher(cache_dir=tmp_path, delay_seconds=0, refresh=True)
         f.session = _FakeSession([_FakeResponse(text="v1"), _FakeResponse(text="v2")])
@@ -269,3 +277,48 @@ class TestFetcher:
         import os
         os.utime(cache_file, (two_days_ago, two_days_ago))
         assert f.get("/a", max_age_hours=12) == "new"
+
+
+class _FakeFetcher:
+    """Maps path substrings to canned pages; None means unavailable."""
+
+    def __init__(self, pages: dict):
+        self.pages = pages
+
+    def get(self, path, max_age_hours=None):
+        for fragment, page in self.pages.items():
+            if fragment in path:
+                return page
+        return None
+
+
+class TestScan:
+    def test_latest_completed_season(self):
+        assert cli.latest_completed_season(date(2026, 7, 3)) == 2025
+        assert cli.latest_completed_season(date(2026, 1, 15)) == 2024
+        assert cli.latest_completed_season(date(2026, 2, 1)) == 2025
+
+    def test_scan_league_dead_id(self, tmp_path):
+        conn = store.connect(tmp_path / "t.db")
+        assert cli._scan_league(_FakeFetcher({}), conn, 999) is None
+        assert conn.execute("SELECT COUNT(*) c FROM leagues").fetchone()["c"] == 0
+
+    def test_scan_league_live_and_active(self, tmp_path):
+        conn = store.connect(tmp_path / "t.db")
+        season = cli.latest_completed_season()
+        fetcher = _FakeFetcher({
+            "/settings": SETTINGS_HTML,
+            "/csv/rosters": ROSTERS_CSV,
+            f"/standings/{season}": STANDINGS_HTML,
+        })
+        status = cli._scan_league(fetcher, conn, 33)
+        assert status is not None and status.startswith("live")
+        assert conn.execute("SELECT COUNT(*) c FROM leagues").fetchone()["c"] == 1
+        assert cli.active_league_ids(conn) == [33]
+
+    def test_scan_league_live_but_inactive(self, tmp_path):
+        # Settings exist but no rosters and no latest-season standings.
+        conn = store.connect(tmp_path / "t.db")
+        status = cli._scan_league(_FakeFetcher({"/settings": SETTINGS_HTML}), conn, 33)
+        assert status is not None and "did not play" in status
+        assert cli.active_league_ids(conn) == []


### PR DESCRIPTION
## What

New `scripts/league_explorer/` package + `just league-explorer` recipe: a scraper/CLI for getting the lay of the land across other Ottoneu football leagues — formats, salaries, rosters, standings history, and who wins — stored in a local SQLite DB (`data/league_explorer/`, gitignored) that AI agents and scripts can query directly. Entirely separate from the shared Supabase project.

## Subcommands

- `scan` — enumerates the **entire** league-ID space (IDs are small sequential ints; dead IDs 307-redirect to `?invalidLeague=1`), auto-stopping after 120 consecutive dead IDs. Per live league it stores settings + an activity probe (rosters CSV snapshot + latest completed season's standings). "Active" = played the latest completed season and still has rostered players.
- `discover` — walks our league's player cards ("trades in other leagues" links) to find connected league IDs; 15 cards already surface ~39 leagues
- `scrape --active | --discovered | --league-ids 33,74` — per league (~25 requests @ 1 req/s): settings (points system, Superflex vs Two Flex, tier), standings for every season since founding, team trophy cases (champion/runner-up/third by season), finances, and the `/csv/rosters` export (all salaries)
- `report` — canned cross-league summaries: active-league count, league overview, format mix, champions by season, and reigning-champion vs everyone salary allocation by position
- `query "SQL" [--csv]` — ad-hoc SQL for agents/scripts

## Design notes

- Plain `requests` (pages are fully server-rendered — no Playwright needed), descriptive User-Agent, 1 req/s throttle, retries, and an on-disk page cache; completed-season standings are cached forever so re-parses are free. The fetcher never follows redirects — a redirect always means "no public page here" (dead ID or login gate). robots.txt only restricts AI-training crawlers; this is a personal research tool over public pages.
- Standings + trophies are truly historical; rosters/finances only exist as *current* state upstream, so they're stored as dated snapshots — rerunning scrape over time builds the salary-evolution series. Player-card transaction logs are the documented next lever for deeper per-player salary history.
- Verified live end-to-end on leagues 2, 11, 14, 33 (e.g. league 33: 207 roster slots, 12 teams, 11 seasons of standings) plus a full ID-space scan.

## Testing

- 23 tests (`scripts/tests/test_league_explorer.py`): parsers on fixture excerpts of real markup, SQLite store idempotency/snapshot semantics, fetcher cache/404/redirect/refresh behavior with a fake session, and scan/active-league logic with a fake fetcher (no network)
- `just preflight` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)