### PR TITLE
docs: offseason cuts carry no lasting cap penalty

### DIFF
--- a/docs/references/ottoneu-rules.md
+++ b/docs/references/ottoneu-rules.md
@@ -31,6 +31,7 @@ IR/PUP/NFI players don't count against roster limits but do count against salary
 - **Auctions:** 24-hour blind Vickrey-style (winner pays second-highest bid + $1). Minimum bid is the player's current cap penalty or $1.
 - **Waivers:** Cut players can be claimed within 24 hours at their full previous salary.
 - **Cutting:** Incurs a cap penalty of half the player's salary (rounded up). Player cannot be reacquired by the same team for 30 days.
+- **Offseason cut exception (verified in-league, July 2026):** cuts made between the end of the season and the keeper deadline carry **no lasting cap penalty**. The Ottoneu transaction log still displays a half-salary figure on every cut (e.g. `Josh Allen | cut | $61` after his salary reached $121), but the finances page shows $0 cap penalties for teams that made large April cuts. This is why unkeepable stars are cut en masse each offseason (typically right after arbitration finalizes salaries on April 1) and re-enter the annual auction draft pool at reset prices.
 
 ## Salary Increases & Arbitration
 

--- a/docs/references/ottoneu-strategy.md
+++ b/docs/references/ottoneu-strategy.md
@@ -147,6 +147,13 @@ analyzing real allocations.
 - **Cutting costs half-salary (rounded up) as a cap penalty**, plus a 30-day re-acquisition block.
   So a player's *true* carrying cost includes his eventual cut penalty. Cutting a $40 bust still
   burns $20 of cap — sometimes the least-bad move, but never free.
+- **Exception: offseason cuts are penalty-free** (verified on the finances page, July 2026 — see
+  [ottoneu-rules.md](ottoneu-rules.md)). Between season end and the keeper deadline, cutting carries
+  no lasting cap hit, so the in-season carrying-cost logic above does not apply to keeper decisions:
+  a non-keep frees the full salary. This drives the annual offseason cut wave — unkeepable stars
+  (post-raise, post-arbitration) hit the auction pool at reset prices, and league-wide auction
+  purchasing power (= $4,800 minus kept salaries, concentrated in a few teams) sets what they
+  clear at, not their prior salaries.
 - **IR/PUP/NFI** don't count against the 20-spot limit but **do** count against the $400 cap.
   Stashing an injured high-upside player is cheap in roster-spot terms, costly in cap terms.
 


### PR DESCRIPTION
Verified in-league (July 2026): the transaction log displays a half-salary figure on every cut, but the finances page shows $0 cap penalties for teams that cut $100+ stars in April. Record the offseason exception in the rules reference and the strategy primer so keeper-deadline reasoning treats non-keeps as freeing the full salary.

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes made -->

-

## Test Plan

<!-- How were these changes verified? -->

- [ ] Python tests pass (`just test-python`)
- [ ] Web tests pass (`just test-web`)
- [ ] ESLint clean (`just lint`)
- [ ] TypeScript compiles (`just typecheck`)
- [ ] Production build succeeds (`just build`)
