### PR TITLE
docs: daily harness audit 2026-07-04 + 2026-07-20

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Comprehensive database and analytics platform for Ottoneu Fantasy Football Leagu
 - **Ottoneu rules:** See [docs/references/ottoneu-rules.md](docs/references/ottoneu-rules.md) for scoring, roster, salary cap, and arbitration rules
 - **Ottoneu strategy:** See [docs/references/ottoneu-strategy.md](docs/references/ottoneu-strategy.md) for format economics (surplus value, raise treadmill, Superflex QB premium, arbitration tax) and the reasoning checklist used by the `/ottoneu-roster-question` skill. Use the `/ottoneu-roster-question` skill (which loads this + live data via `just roster-context`) to answer advanced keeper/trade/auction/arbitration questions.
 - **Environment:** See [docs/references/environment-variables.md](docs/references/environment-variables.md) for `.env` setup
+- **League Explorer:** See [docs/references/league-explorer.md](docs/references/league-explorer.md) for the cross-league survey tool (`just league-explorer`) — scrapes other public Ottoneu leagues (settings, standings history, champions, roster/salary snapshots) into a local SQLite DB at `data/league_explorer/`, separate from Supabase
 - **Autonomous operation:** See [docs/references/autonomous-operation.md](docs/references/autonomous-operation.md) for the permission-friction strategy — allowlist design, prompt-rate metrics (`just permission-report`), and the `.devcontainer/` for safely running `claude --dangerously-skip-permissions`
 - **Season cycle:** See [docs/exec-plans/season-cycle.md](docs/exec-plans/season-cycle.md) — the site rolls between Ottoneu seasons from the `league_calendar` table; the current season is resolved at runtime via `scripts/season.py` and `web/lib/season.ts`, not from static config
 - **Projection Accuracy Plan:** See [docs/exec-plans/projection-accuracy-improvement.md](docs/exec-plans/projection-accuracy-improvement.md) for the 4-phase accuracy improvement roadmap (Issues #271-#285)
@@ -65,6 +66,7 @@ docs/
 │   ├── [experiment-log.md](docs/generated/experiment-log.md)              # History of all model iteration attempts
 │   ├── [player-diagnostics.md](docs/generated/player-diagnostics.md)          # Per-player backtest diagnostics
 │   ├── [projection-accuracy.md](docs/generated/projection-accuracy.md)         # Projection model accuracy report (in-sample; see audit caveat)
+│   ├── [projection-intervals.md](docs/generated/projection-intervals.md)        # Empirical prediction-interval bands — held-out coverage + fitted offsets — `just interval-calibration`
 │   ├── [projection-holdout-eval.md](docs/generated/projection-holdout-eval.md)     # Held-out (leakage-free) model re-ranking — `just holdout-eval` (#572); naïve baselines (#575)
 │   ├── [projection-holdout-eval-matched.md](docs/generated/projection-holdout-eval-matched.md) # Held-out re-ranking on the common player set — apples-to-apples FantasyPros — `just holdout-eval --matched` (#575)
 │   ├── [projection-holdout-eval-rolling.md](docs/generated/projection-holdout-eval-rolling.md) # Held-out re-ranking, rolling-origin protocol — `just holdout-eval --protocol rolling` (#594)
@@ -75,6 +77,7 @@ docs/
 ├── references/
 │   ├── [autonomous-operation.md](docs/references/autonomous-operation.md)        # Permission-friction strategy: allowlist, prompt metrics, devcontainer
 │   ├── environment-variables.md       # .env and .env.local variable reference
+│   ├── [league-explorer.md](docs/references/league-explorer.md)             # Cross-league survey: other Ottoneu leagues → local SQLite (just league-explorer)
 │   ├── ottoneu-rules.md               # Scoring, roster, salary cap, arbitration rules
 │   └── ottoneu-strategy.md            # Format economics + AI reasoning checklist for roster construction
 └── superpowers/

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -1,6 +1,6 @@
 # Database Schema
 
-Twenty-four tables owned by this project, all with UUID primary keys.
+Twenty-five tables owned by this project, all with UUID primary keys.
 
 ## Shared Database — Hands Off `fp_*`
 


### PR DESCRIPTION
## Summary

Rolling docs audit — this PR was opened after the 2026-07-04 window and picked up an additional drift item from #681 (merged 2026-07-19) on the 2026-07-20 sweep. Rebased onto latest `main`.

## Changes

- **AGENTS.md — sync with CLAUDE.md after #678 (League Explorer):** the feature PR added a **League Explorer** bullet to CLAUDE.md's Quick Reference and a `league-explorer.md` entry to its Documentation Map (references), but neither propagated into AGENTS.md. Both added.
- **AGENTS.md — sync with CLAUDE.md after #681 (prediction intervals):** #681 added the `projection-intervals.md` entry to CLAUDE.md's Documentation Map (generated section) but not to AGENTS.md. Added, alongside `projection-accuracy.md`, to mirror CLAUDE.md's ordering.
- **`docs/generated/db-schema.md` — fix stale top-line count:** the doc lists **25** own-tables in the table (through `red_zone_usage` / `ngs_passing`), but the header still reads *"Twenty-four tables owned by this project."* Updated to *"Twenty-five."* Root cause: #672 (`red_zone_usage`, migration 032) added the row but didn't bump the count 22→23; #677 (`ngs_passing`, migration 033) then bumped 23→24 for its own row, leaving the count one behind. Audit #670 read the header as authoritative and didn't recount. #681's migration 034 is columns-only on existing tables, so 25 is still correct.

## Commits reviewed

### 2026-07-04 window (since audit #670)

| SHA | Title | Doc impact |
|-----|-------|------------|
| d201bcf | docs: daily harness audit 2026-06-15 + 2026-06-16 (#670) | left stale db-schema.md header count — fixed here |
| aad50cc | docs: offseason cuts carry no lasting cap penalty (#679) | self-contained (`ottoneu-rules.md` + `ottoneu-strategy.md`) — no follow-up |
| 1a3ab79 | feat: league explorer — cross-league survey → local SQLite (#678) | CLAUDE.md, Justfile, `docs/COMMANDS.md`, new `docs/references/league-explorer.md` updated in-PR; AGENTS.md missed — fixed here |

### 2026-07-20 window (since 2026-07-04)

| SHA | Title | Doc impact |
|-----|-------|------------|
| e840f1d | feat(projections): empirical prediction-interval bands (uncertainty layer) (#681) | CLAUDE.md, `docs/COMMANDS.md`, `docs/generated/db-schema.md`, new `docs/generated/projection-intervals.md`, migration 034 (columns-only) all updated in-PR; AGENTS.md doc map missed the new `projection-intervals.md` entry — fixed here |

## Other things checked, no action needed

- Latest migration is `034_add_projection_intervals.sql`; it adds columns to `player_projections` + `model_projections` (not a new table), so the "Twenty-five" count remains correct after fixing.
- `.claude/commands/*.md` — 14 skills, all match the Skills line in CLAUDE.md / AGENTS.md.
- `docs/references/`, `docs/exec-plans/`, `docs/generated/` filesystem contents match the Documentation Maps in both root docs.
- `docs/COMMANDS.md` already documents `just interval-calibration` (added in #681) and `just league-explorer` (added in #678).
- `db-schema.md` already documents the new `projected_ppg_low`/`projected_ppg_high` columns on `player_projections` and `model_projections` (from #681).

## Test Plan

- [x] AGENTS.md and CLAUDE.md now match on League Explorer entries (Quick Reference + Documentation Map references section).
- [x] AGENTS.md and CLAUDE.md now match on `projection-intervals.md` entry in the Documentation Map generated section.
- [x] `db-schema.md` header count matches the actual table-row count in the file.
- [ ] `just check-arch` — will run in CI.
- [ ] `just preflight` — will run in CI.

## Items flagged for human follow-up

None this run.
