### PR TITLE
feat(scraper): refresh rosters weekly in the offseason + resolve scra…

### DIFF
--- a/.claude/skills/scraper-logic/SKILL.md
+++ b/.claude/skills/scraper-logic/SKILL.md
@@ -34,5 +34,21 @@ The scraping heavily relies on Playwright for browser automation and Supabase fo
     - **Processing**: This tracks historical salary movement into the `transactions` table.
 
 ## Automated Runs
-The scraping pipeline is commonly set to run daily at 6 AM using cron or GitHub Actions. 
-These scheduled runs will trigger the batch enqueue followed by the worker loop.
+The scraping pipeline runs on GitHub Actions (`.github/workflows/scrape-players.yml`),
+triggering the batch enqueue followed by the worker loop. The schedule is season-aware:
+
+- **In-season (Sep–Jan):** daily at 06:00 UTC.
+- **Offseason (Feb–Aug):** weekly on Mondays at 06:00 UTC — rosters still churn
+  (keeper cuts, arbitration results, trades), so `league_prices` needs a periodic
+  refresh even out of season, just less often than in-season.
+- **`workflow_dispatch`:** always runs, bypassing the season gate (use this for an
+  on-demand refresh).
+
+The workflow defines two cron entries and a gate step routes each trigger so exactly
+one fires per day. The scrape season resolves at runtime from `stats_season()`
+(`scripts/season.py`) — it is not hardcoded.
+
+**Environment note:** Ottoneu sits behind a Cloudflare anti-bot challenge. GitHub
+Actions runners pass it, but a headless scrape from a datacenter/sandbox IP is served
+a 403 "Just a moment…" interstitial and will time out waiting for page selectors. Run
+scrapes via the workflow (or an allow-listed IP), not from an arbitrary sandbox.

--- a/.github/workflows/scrape-players.yml
+++ b/.github/workflows/scrape-players.yml
@@ -4,9 +4,15 @@ on:
   # Manual trigger
   workflow_dispatch:
 
-  # Daily at 6:00 AM UTC (10 PM PT previous day)
+  # Two cadences, routed by the season gate below so each fires at most once/day:
+  #   - Daily at 6:00 AM UTC (10 PM PT previous day) — used in-season (Sep–Jan).
+  #   - Weekly on Mondays at 6:00 AM UTC — used in the offseason (Feb–Aug) to
+  #     catch roster churn (keeper cuts, arbitration results, trades). Rosters
+  #     change through the offseason, but far less often than in-season, so a
+  #     weekly refresh keeps `league_prices` current without daily scraping.
   schedule:
     - cron: "0 6 * * *"
+    - cron: "0 6 * * 1"
 
 permissions:
   contents: read
@@ -16,34 +22,49 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check if in fantasy football season
+      - name: Decide whether to run for this trigger
         id: season_gate
+        env:
+          SCHEDULE: ${{ github.event.schedule }}
         run: |
           MONTH=$(date +%-m)
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "Manual trigger — skipping season check."
-            echo "in_season=true" >> "$GITHUB_OUTPUT"
+            echo "Manual trigger — always run."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
           elif [[ $MONTH -ge 9 || $MONTH -le 1 ]]; then
-            echo "Month $MONTH is in season (Sep–Jan). Proceeding."
-            echo "in_season=true" >> "$GITHUB_OUTPUT"
+            # In-season: the daily cron drives it. Ignore the weekly cron so
+            # Mondays don't run twice.
+            if [[ "$SCHEDULE" == "0 6 * * *" ]]; then
+              echo "In season (month $MONTH), daily cron — running."
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "In season (month $MONTH), weekly cron — daily already covers it, skipping."
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+            fi
           else
-            echo "Month $MONTH is out of season. Skipping."
-            echo "in_season=false" >> "$GITHUB_OUTPUT"
+            # Offseason: only the weekly Monday cron runs; the daily cron no-ops.
+            if [[ "$SCHEDULE" == "0 6 * * 1" ]]; then
+              echo "Offseason (month $MONTH), weekly cron — running roster refresh."
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "Offseason (month $MONTH), daily cron — deferring to weekly cadence, skipping."
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Checkout
-        if: steps.season_gate.outputs.in_season == 'true'
+        if: steps.season_gate.outputs.should_run == 'true'
         uses: actions/checkout@v4
 
       - name: Setup Python
-        if: steps.season_gate.outputs.in_season == 'true'
+        if: steps.season_gate.outputs.should_run == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: pip
 
       - name: Install dependencies
-        if: steps.season_gate.outputs.in_season == 'true'
+        if: steps.season_gate.outputs.should_run == 'true'
         run: |
           pip install --upgrade pip
           pip install --only-binary pandas,numpy playwright supabase python-dotenv nfl_data_py pandas numpy
@@ -51,15 +72,15 @@ jobs:
           pip install -e . --no-deps
 
       - name: Install Playwright browsers
-        if: steps.season_gate.outputs.in_season == 'true'
+        if: steps.season_gate.outputs.should_run == 'true'
         run: playwright install --with-deps chromium
 
       - name: Create .env
-        if: steps.season_gate.outputs.in_season == 'true'
+        if: steps.season_gate.outputs.should_run == 'true'
         run: |
           echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" > .env
           echo "SUPABASE_KEY=${{ secrets.SUPABASE_SECRET_KEY }}" >> .env
 
       - name: Run scraper
-        if: steps.season_gate.outputs.in_season == 'true'
+        if: steps.season_gate.outputs.should_run == 'true'
         run: python scripts/ottoneu_scraper.py

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -172,7 +172,7 @@ equivalent self-hosted setup would look like.
 
 | Workflow | Trigger | What it runs |
 |----------|---------|--------------|
-| `scrape-players.yml` | Daily 06:00 UTC (gated to Sep–Jan) + `workflow_dispatch` | `scripts/ottoneu_scraper.py` — full roster + player-card scrape (uses `SUPABASE_URL` / `SUPABASE_SECRET_KEY`) |
+| `scrape-players.yml` | Daily 06:00 UTC in-season (Sep–Jan) **+ weekly Mon 06:00 UTC in the offseason (Feb–Aug)** + `workflow_dispatch` | `scripts/ottoneu_scraper.py` — full roster + player-card scrape (uses `SUPABASE_URL` / `SUPABASE_SECRET_KEY`). Two cron entries routed by the season gate so each fires at most once/day; the weekly offseason cadence keeps `league_prices` current through keeper cuts / arbitration / trades (#555-style churn). Scrape season resolves from `stats_season()`, not a hardcoded year. |
 | `scrape-arbitration-progress.yml` | Every 6h (gated to Jan–Mar + Apr 1) + `workflow_dispatch` | `scripts/scrape_arbitration_progress.py` — pulls per-team allocation status via FanGraphs login (`FANGRAPHS_USERNAME` / `FANGRAPHS_PASSWORD`) |
 | `scrape-draft-sharks.yml` | Mondays 08:00 UTC + `workflow_dispatch` | `scripts/scrape_draft_sharks.py` — Draft Sharks Half-PPR Superflex auction values (no in-season gate; ×2 for the $400 cap) |
 | `scrape-league-calendar.yml` | Mondays 12:00 UTC + `workflow_dispatch` | `scripts/scrape_league_calendar.py` — refreshes `league_calendar`, the source of truth for the season-cycle resolver. Requires FanGraphs login. |
@@ -189,8 +189,11 @@ All scheduled scraping workflows that hit Supabase use the **service key**
 ### Equivalent local cron (reference only)
 
 ```bash
-# Daily at 6 AM: enqueue batch and run worker
-0 6 * * * cd /path/to/ottoneu_db && source venv/bin/activate && python scripts/enqueue.py batch && python scripts/worker.py
+# Daily at 6 AM in-season (Sep–Jan), weekly Mondays in the offseason (Feb–Aug):
+# enqueue batch and run worker. (In GitHub Actions this is one workflow with two
+# cron entries + a season gate; a local crontab needs the two lines below.)
+0 6 * 9-12,1 * cd /path/to/ottoneu_db && source venv/bin/activate && python scripts/enqueue.py batch && python scripts/worker.py
+0 6 * 2-8 1   cd /path/to/ottoneu_db && source venv/bin/activate && python scripts/enqueue.py batch && python scripts/worker.py
 
 # Every 6 hours (Jan-Mar): scrape arbitration progress
 0 */6 * 1-3 * cd /path/to/ottoneu_db && source venv/bin/activate && python scripts/scrape_arbitration_progress.py

--- a/scripts/ottoneu_scraper.py
+++ b/scripts/ottoneu_scraper.py
@@ -17,11 +17,14 @@ from dotenv import load_dotenv
 from scripts.tasks import PULL_NFL_STATS, SCRAPE_ROSTER
 from scripts.worker import ScraperWorker
 from scripts.config import LEAGUE_ID, POSITIONS, get_supabase_client
+from scripts.season import stats_season
 
 load_dotenv()
 
 
-def enqueue_batch(season=2025):
+def enqueue_batch(season=None):
+    if season is None:
+        season = stats_season()
     """Create a full batch of scraper jobs and return the batch ID."""
     supabase = get_supabase_client()
     batch_id = str(uuid.uuid4())
@@ -58,7 +61,7 @@ def enqueue_batch(season=2025):
     return batch_id
 
 
-async def scrape_ottoneu_data(target_season=2025):
+async def scrape_ottoneu_data(target_season=None):
     """Enqueue a full batch and run the worker to completion."""
     batch_id = enqueue_batch(target_season)
     if not batch_id:


### PR DESCRIPTION
…pe season dynamically

Rosters keep churning through the offseason (keeper cuts, arbitration results, trades), but scrape-players.yml was gated off Feb–Aug, so league_prices went stale for months (last refresh 2026-06-01). Add a weekly Monday cron for the offseason alongside the daily in-season cron; a season-gate step routes each trigger so exactly one fires per day (daily Sep–Jan, weekly Feb–Aug, workflow_dispatch always). This keeps current rosters/salaries/ownership fresh year-round.

Also fix ottoneu_scraper.py hardcoding season=2025 — resolve it from stats_season() (scripts/season.py) so player_stats land under the correct NFL season as the calendar rolls forward.

Docs: update the scrape-players cadence in docs/COMMANDS.md and the Automated Runs section of the scraper-logic skill (incl. a note that Ottoneu's Cloudflare challenge blocks sandbox/datacenter-IP scrapes — run via the workflow).

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes made -->

-

## Test Plan

<!-- How were these changes verified? -->

- [ ] Python tests pass (`just test-python`)
- [ ] Web tests pass (`just test-web`)
- [ ] ESLint clean (`just lint`)
- [ ] TypeScript compiles (`just typecheck`)
- [ ] Production build succeeds (`just build`)
