### PR TITLE
fix(scraper): authenticate Ottoneu scrape to clear Cloudflare challenge

### DIFF
--- a/.claude/skills/scraper-logic/SKILL.md
+++ b/.claude/skills/scraper-logic/SKILL.md
@@ -68,6 +68,17 @@ scrape — cuts/adds/trades stop appearing on the site even though `pull_nfl_sta
 3. `scripts/worker.py` loads it into the browser context automatically when
    present, clearing the challenge. It falls back to anonymous browsing when absent.
 
+If the login window loops on the Cloudflare "verify you're human" (Turnstile)
+check — you click it and it re-appears — that is Cloudflare refusing to issue a
+clearance token to an automation-flagged browser (`navigator.webdriver`, the
+`--enable-automation` switch). `ottoneu_login.py` launches with those signals
+dropped (`--disable-blink-features=AutomationControlled`, `ignore_default_args=
+["--enable-automation"]`, and a `navigator.webdriver` mask) so the human can pass
+their own login; it never solves the challenge programmatically. The login and
+worker share `SCRAPER_USER_AGENT` because Cloudflare binds the clearance cookie to
+the UA — a mismatch would invalidate the saved session. If it still loops, fall
+back to the official Ottoneu CSV roster export (planned follow-up).
+
 The roster scrape raises an explicit `Cloudflare challenge` error (instead of a bare
 selector timeout) when it detects the `Just a moment…` title, so the failure is
 actionable. `OTTONEU_HEADLESS=0` runs a visible browser for debugging.

--- a/.claude/skills/scraper-logic/SKILL.md
+++ b/.claude/skills/scraper-logic/SKILL.md
@@ -48,7 +48,30 @@ The workflow defines two cron entries and a gate step routes each trigger so exa
 one fires per day. The scrape season resolves at runtime from `stats_season()`
 (`scripts/season.py`) — it is not hardcoded.
 
-**Environment note:** Ottoneu sits behind a Cloudflare anti-bot challenge. GitHub
-Actions runners pass it, but a headless scrape from a datacenter/sandbox IP is served
-a 403 "Just a moment…" interstitial and will time out waiting for page selectors. Run
-scrapes via the workflow (or an allow-listed IP), not from an arbitrary sandbox.
+## Authentication / Cloudflare
+
+Ottoneu sits behind a Cloudflare anti-bot challenge. A headless, anonymous scrape
+from a datacenter IP (GitHub Actions runners **included** — they no longer reliably
+pass) is served a 403 `Just a moment…` interstitial, so every `scrape_roster` job
+times out waiting for `a.top_players` and is marked `failed`. When that happens no
+roster row is written and `league_prices` silently freezes at the last successful
+scrape — cuts/adds/trades stop appearing on the site even though `pull_nfl_stats`
+(which never touches Ottoneu) keeps succeeding.
+
+**Mitigation — reuse a real logged-in session:**
+
+1. From a local machine (a residential IP), run `just ottoneu-login`. A visible
+   browser opens; sign in and clear any Cloudflare check, then press Enter.
+2. That saves a Playwright `storage_state` (cookies **and** localStorage — Ottoneu
+   keeps its session in localStorage) to `ottoneu_state.json` (gitignored;
+   path overridable via `OTTONEU_STORAGE_STATE`).
+3. `scripts/worker.py` loads it into the browser context automatically when
+   present, clearing the challenge. It falls back to anonymous browsing when absent.
+
+The roster scrape raises an explicit `Cloudflare challenge` error (instead of a bare
+selector timeout) when it detects the `Just a moment…` title, so the failure is
+actionable. `OTTONEU_HEADLESS=0` runs a visible browser for debugging.
+
+Diagnosing a "missing cut/roster change" report: check `scraper_jobs` for recent
+`failed` `scrape_roster` rows and read their `last_error`; a `league_prices` row
+whose `updated_at` predates the reported change confirms the freeze.

--- a/.claude/skills/scraper-logic/SKILL.md
+++ b/.claude/skills/scraper-logic/SKILL.md
@@ -76,8 +76,14 @@ dropped (`--disable-blink-features=AutomationControlled`, `ignore_default_args=
 ["--enable-automation"]`, and a `navigator.webdriver` mask) so the human can pass
 their own login; it never solves the challenge programmatically. The login and
 worker share `SCRAPER_USER_AGENT` because Cloudflare binds the clearance cookie to
-the UA — a mismatch would invalidate the saved session. If it still loops, fall
-back to the official Ottoneu CSV roster export (planned follow-up).
+the UA — a mismatch would invalidate the saved session.
+
+Note: the official Ottoneu **CSV roster export is not a replacement** for this
+scrape. It lists only current rostered players + salaries — no free agents (the
+scrape captures the whole FA universe with `team_name="FA"`) and no transaction
+history (from `scrape_player_card`). At most it could feed a roster-diff
+reconciliation to catch cuts/adds if the authenticated scrape is ever blocked; it
+cannot stand in for the search-page scrape.
 
 The roster scrape raises an explicit `Cloudflare challenge` error (instead of a bare
 selector timeout) when it detects the `Just a moment…` title, so the failure is

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ build/
 # Allow specific example files if needed
 !**/.env.example
 
+# Authenticated Ottoneu session (Playwright storage_state) — holds a live login;
+# captured by `just ottoneu-login`. Never commit it.
+ottoneu_state.json
+
 # Python editable-install build metadata
 *.egg-info/
 

--- a/Justfile
+++ b/Justfile
@@ -85,6 +85,10 @@ test-web-file file:
 scrape:
     {{python}} scripts/ottoneu_scraper.py
 
+# Capture an authenticated Ottoneu session (clears the Cloudflare challenge). Run locally; a browser opens for you to log in.
+ottoneu-login:
+    {{python}} scripts/ottoneu_login.py
+
 # Update player projections (VORP/surplus/arbitration now computed in the web UI)
 analyze:
     {{python}} scripts/update_projections.py

--- a/docs/references/environment-variables.md
+++ b/docs/references/environment-variables.md
@@ -9,6 +9,8 @@
 | `FANGRAPHS_USERNAME` | FanGraphs login username (for arbitration progress scraper) |
 | `FANGRAPHS_PASSWORD` | FanGraphs login password (for arbitration progress scraper) |
 | `OTTONEU_HOLDOUT_CACHE` | **Optional.** Absolute path to the holdout-eval cache dir (GH #629). Default: the main checkout's `.cache/holdout`, resolved via `git rev-parse --git-common-dir` so all worktrees share one cache. Set to override the location. |
+| `OTTONEU_STORAGE_STATE` | **Optional.** Path to the Playwright `storage_state` JSON (cookies + localStorage) for an authenticated Ottoneu session. Default: `ottoneu_state.json` at the repo root (gitignored). Capture it with `just ottoneu-login`; the scraper worker loads it to clear the Cloudflare bot challenge on the search page. Absent → the worker browses anonymously (fine until Cloudflare challenges it). |
+| `OTTONEU_HEADLESS` | **Optional.** Set to `0` to run the scraper's Chromium in a visible (non-headless) window — useful for debugging the Cloudflare challenge locally. Default headless. |
 
 ## `web/.env.local` (for Next.js)
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -66,6 +66,16 @@ OTTONEU_STORAGE_STATE_PATH = Path(
     os.getenv("OTTONEU_STORAGE_STATE", str(CONFIG_PATH.parent / "ottoneu_state.json"))
 )
 
+# User-Agent presented by every scraper browser context. Kept in one place so the
+# session captured by `just ottoneu-login` and the headless scrape send an
+# identical UA — Cloudflare binds its clearance cookie to the UA, so a mismatch
+# between the login browser and the worker would invalidate the saved session.
+SCRAPER_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/120.0.0.0 Safari/537.36"
+)
+
 
 def get_supabase_client() -> Client:
     """Return a configured Supabase client.

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -57,6 +57,16 @@ NFL_TEAM_CODES = set(_config["NFL_TEAM_CODES"])
 # --- END GENERATED CONFIG ---
 
 
+# Path to the Playwright storage_state file holding an authenticated Ottoneu
+# session (cookies + localStorage). Produced by `just ottoneu-login` and loaded
+# by the scraper worker to clear the Cloudflare bot challenge on the search page.
+# Override the location with OTTONEU_STORAGE_STATE; the default lives at the repo
+# root and is gitignored so the session secret is never committed.
+OTTONEU_STORAGE_STATE_PATH = Path(
+    os.getenv("OTTONEU_STORAGE_STATE", str(CONFIG_PATH.parent / "ottoneu_state.json"))
+)
+
+
 def get_supabase_client() -> Client:
     """Return a configured Supabase client.
 

--- a/scripts/ottoneu_login.py
+++ b/scripts/ottoneu_login.py
@@ -23,20 +23,28 @@ import asyncio
 
 from playwright.async_api import async_playwright
 
-from scripts.config import LEAGUE_ID, OTTONEU_STORAGE_STATE_PATH
+from scripts.config import LEAGUE_ID, OTTONEU_STORAGE_STATE_PATH, SCRAPER_USER_AGENT
 
 SEARCH_URL = f"https://ottoneu.fangraphs.com/football/{LEAGUE_ID}/search"
 
 
 async def main() -> None:
     async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=False)
-        context = await browser.new_context(
-            user_agent=(
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) "
-                "Chrome/120.0.0.0 Safari/537.36"
-            )
+        # Cloudflare's Turnstile challenge refuses to issue a clearance token to a
+        # browser flagged as automated (navigator.webdriver, the --enable-automation
+        # switch and its "controlled by automated software" banner) — the challenge
+        # then loops even when a human clicks it. Drop those signals so the human
+        # in front of this window can pass their own login. We do NOT solve the
+        # challenge programmatically and this is scoped to the interactive login;
+        # the headless scrape relies only on the resulting session cookie.
+        browser = await p.chromium.launch(
+            headless=False,
+            args=["--disable-blink-features=AutomationControlled"],
+            ignore_default_args=["--enable-automation"],
+        )
+        context = await browser.new_context(user_agent=SCRAPER_USER_AGENT)
+        await context.add_init_script(
+            "Object.defineProperty(navigator, 'webdriver', {get: () => undefined});"
         )
         page = await context.new_page()
         await page.goto(SEARCH_URL, timeout=60000)

--- a/scripts/ottoneu_login.py
+++ b/scripts/ottoneu_login.py
@@ -1,0 +1,75 @@
+"""Interactive helper: capture an authenticated Ottoneu session for the scraper.
+
+Ottoneu's search page now sits behind a Cloudflare bot challenge that a headless,
+datacenter-IP browser cannot clear, so anonymous scrapes fail with a
+``Just a moment...`` interstitial and every ``scrape_roster`` job times out. This
+script opens a *visible* browser on your own machine so you can sign in (and clear
+any Cloudflare check) by hand, then saves the resulting Playwright storage_state
+— cookies *and* localStorage — to disk. The scraper worker loads that file to
+reuse your logged-in session.
+
+Run it from your local machine (a residential IP), not CI:
+
+    just ottoneu-login
+
+Re-run whenever the session expires and the scrape starts hitting the challenge
+again. The saved file (``OTTONEU_STORAGE_STATE_PATH``) is gitignored — it holds a
+live login, so never commit it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from playwright.async_api import async_playwright
+
+from scripts.config import LEAGUE_ID, OTTONEU_STORAGE_STATE_PATH
+
+SEARCH_URL = f"https://ottoneu.fangraphs.com/football/{LEAGUE_ID}/search"
+
+
+async def main() -> None:
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=False)
+        context = await browser.new_context(
+            user_agent=(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/120.0.0.0 Safari/537.36"
+            )
+        )
+        page = await context.new_page()
+        await page.goto(SEARCH_URL, timeout=60000)
+
+        print("\n" + "=" * 70)
+        print("A browser window has opened.")
+        print("  1. Sign in to Ottoneu / FanGraphs in that window.")
+        print("  2. Wait until the league search page and its player table are")
+        print("     visible (the Cloudflare 'Just a moment...' page is gone).")
+        print("  3. Return here and press Enter to save the session.")
+        print("=" * 70)
+        input("\nPress Enter once you are logged in and the search page has loaded... ")
+
+        # Re-visit the search page so its origin's localStorage is captured, and
+        # confirm the authenticated table is actually reachable before saving.
+        await page.goto(SEARCH_URL, timeout=60000)
+        try:
+            await page.wait_for_selector("a.top_players", timeout=15000)
+            print("Search page loaded successfully (a.top_players found).")
+        except Exception:
+            print(
+                "WARNING: could not confirm the search page loaded "
+                "(a.top_players not found). Saving the session anyway — if the "
+                "scrape still fails, re-run this and make sure the player table "
+                "is visible before pressing Enter."
+            )
+
+        await context.storage_state(path=str(OTTONEU_STORAGE_STATE_PATH))
+        print(f"\nSaved authenticated session to {OTTONEU_STORAGE_STATE_PATH}")
+        print("The scraper will now pick it up automatically. Run `just scrape`.")
+
+        await browser.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/tasks/scrape_roster.py
+++ b/scripts/tasks/scrape_roster.py
@@ -129,7 +129,19 @@ async def run(params: dict, context, supabase, nfl_stats: pd.DataFrame) -> TaskR
     try:
         print(f"\n--- Scraping Position: {position} ({level_label}) ---")
         await page.goto(search_url, timeout=60000)
-        await page.wait_for_selector("a.top_players", timeout=30000)
+        try:
+            await page.wait_for_selector("a.top_players", timeout=30000)
+        except Exception:
+            # Distinguish a Cloudflare bot challenge from an ordinary timeout so
+            # the failure is actionable instead of a generic selector error.
+            title = (await page.title()) or ""
+            if "just a moment" in title.lower() or "attention required" in title.lower():
+                raise RuntimeError(
+                    "Ottoneu search page is behind a Cloudflare challenge "
+                    f"(page title: {title!r}). Capture an authenticated session "
+                    "with `just ottoneu-login` and re-run from a residential IP."
+                )
+            raise
 
         # Use form submission for all levels to get ALL players, not just
         # "top players" from the quick-filter links (which miss low-profile players)

--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -22,7 +22,7 @@ from scripts.tasks import (
     TaskResult,
 )
 from scripts.tasks import pull_nfl_stats, pull_player_stats, scrape_roster, scrape_player_card
-from scripts.config import get_supabase_client, OTTONEU_STORAGE_STATE_PATH
+from scripts.config import get_supabase_client, OTTONEU_STORAGE_STATE_PATH, SCRAPER_USER_AGENT
 
 
 
@@ -231,13 +231,7 @@ class ScraperWorker:
         self.playwright = await async_playwright().start()
         self.browser = await self.playwright.chromium.launch(headless=headless)
 
-        context_kwargs = {
-            "user_agent": (
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) "
-                "Chrome/120.0.0.0 Safari/537.36"
-            )
-        }
+        context_kwargs = {"user_agent": SCRAPER_USER_AGENT}
         # Reuse an authenticated Ottoneu session (cookies + localStorage) if one
         # has been captured via `just ottoneu-login`. This clears the Cloudflare
         # bot challenge that blocks anonymous, headless, datacenter-IP scrapes of

--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
 import time
 import uuid
 
@@ -21,7 +22,7 @@ from scripts.tasks import (
     TaskResult,
 )
 from scripts.tasks import pull_nfl_stats, pull_player_stats, scrape_roster, scrape_player_card
-from scripts.config import get_supabase_client
+from scripts.config import get_supabase_client, OTTONEU_STORAGE_STATE_PATH
 
 
 
@@ -224,15 +225,33 @@ class ScraperWorker:
             return
 
         print("Launching browser...")
+        # OTTONEU_HEADLESS=0 runs a visible browser — useful when debugging the
+        # Cloudflare challenge locally.
+        headless = os.getenv("OTTONEU_HEADLESS", "1") != "0"
         self.playwright = await async_playwright().start()
-        self.browser = await self.playwright.chromium.launch(headless=True)
-        self.browser_context = await self.browser.new_context(
-            user_agent=(
+        self.browser = await self.playwright.chromium.launch(headless=headless)
+
+        context_kwargs = {
+            "user_agent": (
                 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
                 "AppleWebKit/537.36 (KHTML, like Gecko) "
                 "Chrome/120.0.0.0 Safari/537.36"
             )
-        )
+        }
+        # Reuse an authenticated Ottoneu session (cookies + localStorage) if one
+        # has been captured via `just ottoneu-login`. This clears the Cloudflare
+        # bot challenge that blocks anonymous, headless, datacenter-IP scrapes of
+        # the search page. Falls back to anonymous browsing when absent.
+        if OTTONEU_STORAGE_STATE_PATH.exists():
+            print(f"Loading authenticated Ottoneu session from {OTTONEU_STORAGE_STATE_PATH}")
+            context_kwargs["storage_state"] = str(OTTONEU_STORAGE_STATE_PATH)
+        else:
+            print(
+                "No Ottoneu storage_state found — browsing anonymously. "
+                "If the roster scrape hits the Cloudflare 'Just a moment...' "
+                "challenge, capture a session with `just ottoneu-login`."
+            )
+        self.browser_context = await self.browser.new_context(**context_kwargs)
 
     async def _close_browser(self):
         """Shut down the browser if it was started."""


### PR DESCRIPTION
## Problem

The daily crawler stopped reflecting roster changes — e.g. Tyjae Spears was cut from The Witchcraft last weekend but the site still shows him rostered. Root cause is **not** the cut logic or the web app: **every `scrape_roster` job is failing**, so `league_prices` has been frozen since the last successful scrape (2026-01-16). His `league_prices` row still reads `team_name = "The Witchcraft"`, `updated_at = 2026-01-16`.

The Ottoneu search page now sits behind a **Cloudflare bot challenge**. A headless, anonymous, datacenter-IP browser (GitHub Actions runners included — they no longer reliably pass) is served a `403 / Just a moment...` interstitial. `page.goto()` renders that page without raising, so the scrape only fails at the *next* step — `wait_for_selector("a.top_players")` times out — logging a cryptic selector timeout with no HTTP status. `pull_nfl_stats` (no Ottoneu) keeps succeeding, which is why the freeze was silent.

Diagnosis detail: the logs show only the selector timeout; the `403 / Just a moment...` was confirmed by an independent `curl` to the search page with the scraper's user-agent.

## Fix

Reuse a real logged-in session (above-board: your own account, your own IP, low volume — no CAPTCHA solvers or proxies):

- **`scripts/ottoneu_login.py` + `just ottoneu-login`** — opens a visible browser to log in by hand and clear Cloudflare, then saves a Playwright `storage_state` (cookies **and** localStorage, since Ottoneu keeps its session in localStorage) to `ottoneu_state.json` (gitignored; path via `OTTONEU_STORAGE_STATE`).
- **Cloudflare Turnstile loop fix** — the interactive login was looping on "verify you're human" because Cloudflare won't issue a clearance token to an automation-flagged browser. The login launch drops those signals (`--disable-blink-features=AutomationControlled`, `ignore_default_args=["--enable-automation"]`, `navigator.webdriver` mask) so the human can pass their *own* login. It never solves the challenge programmatically, and this is scoped to the interactive login only — the headless scrape relies solely on the resulting session cookie.
- **`worker.py`** — loads that `storage_state` into the browser context when present; anonymous fallback otherwise. Adds `OTTONEU_HEADLESS=0` toggle for local debugging.
- **`scrape_roster.py`** — detects the `Just a moment...` title and raises an explicit `Cloudflare challenge` error instead of a bare selector timeout, so future failures are self-explanatory.
- Shared `config.SCRAPER_USER_AGENT` for login + worker — Cloudflare binds the clearance cookie to the UA, so both must present an identical UA or the saved session is rejected.
- Docs: scraper-logic skill (corrected the stale "GitHub Actions runners pass it" note + a diagnosis playbook + Turnstile-loop troubleshooting) and environment-variables reference.

## How to use

Run locally from a residential IP:
```
just ottoneu-login   # log in when the browser opens
just scrape          # now uses the saved session
```
If cron runs on GitHub Actions, the captured `storage_state` will need to be provided to CI (e.g. as a secret) as a follow-up — noted but out of scope here.

## On the CSV roster export

Earlier framed as an alternative — **corrected: it is not a replacement** for this scrape. The CSV lists only current rostered players + salaries; it has **no free agents** (the search scrape captures the whole FA universe as `team_name="FA"`) and **no transaction history** (from `scrape_player_card`). At most it could feed a roster-diff reconciliation to catch cuts/adds if the authenticated scrape is ever blocked — it cannot stand in for the search-page scrape. So the authenticated scrape in this PR is the actual fix, not a stopgap.

## Testing

`just preflight` green — Python 1834 passed, web 342 passed, lint + typecheck + doc checks all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)