### PR TITLE
fix(roster-context): paginate league_prices + players reads

### DIFF
--- a/scripts/roster_context_pack.py
+++ b/scripts/roster_context_pack.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import argparse
 from collections import defaultdict
 
-from scripts.config import get_supabase_client
+from scripts.config import fetch_all_rows, get_supabase_client
 
 CAP_PER_TEAM = 400
 NUM_TEAMS = 12
@@ -29,18 +29,24 @@ NUM_TEAMS = 12
 def fetch_rows(season: int):
     client = get_supabase_client()
 
+    # NOTE: all three reads must paginate. `players` and `league_prices` each
+    # exceed the PostgREST 1000-row cap (the scraper now writes ~900 free-agent
+    # rows into league_prices), so a bare .execute() silently truncates to the
+    # first 1000 rows — dropping rostered players and understating every team's
+    # committed salary. See CLAUDE.md "Supabase pagination".
     players = {
         p["id"]: p
-        for p in client.table("players").select("id,name,position").execute().data
+        for p in fetch_all_rows(client, "players", "id,name,position")
     }
-    prices = client.table("league_prices").select("player_id,price,team_name").execute().data
+    prices = fetch_all_rows(client, "league_prices", "player_id,price,team_name")
     projections = {
         p["player_id"]: p["projected_ppg"]
-        for p in client.table("player_projections")
-        .select("player_id,projected_ppg,season")
-        .eq("season", season)
-        .execute()
-        .data
+        for p in fetch_all_rows(
+            client,
+            "player_projections",
+            "player_id,projected_ppg,season",
+            filters=[("eq", "season", season)],
+        )
     }
 
     rows = []


### PR DESCRIPTION
## Problem

`just roster-context` was silently returning **partial rosters for every team** — one team showed 6 players instead of 14, committed salary was understated, and cap space overstated. Reasoning off this snapshot produced a completely wrong league picture.

## Cause

`scripts/roster_context_pack.py` read both `players` and `league_prices` with a bare `.execute()`, which PostgREST caps at **1000 rows**. The scraper now writes **~876 free-agent rows** into `league_prices`, pushing the table well past that cap, so the non-paginated read truncated to the first 1000 rows and dropped most rostered players (those whose IDs fell outside the truncated `players` map were silently skipped by the `if not pl: continue` guard).

This is the exact failure class documented in CLAUDE.md → "Supabase pagination".

## Fix

Route all three reads (`players`, `league_prices`, `player_projections`) through `fetch_all_rows` from `scripts.config`, which pages past the 1000-row limit. Verified locally — the snapshot now returns complete rosters and correct per-team committed/cap figures.

## Follow-up (not in this PR)

`league_prices` is **not** in the `LARGE_TABLES` list that `TestSupabasePagination` scans, which is why this wasn't caught mechanically. It only recently crossed 1000 rows (once the scraper began writing FAs). Adding it to `LARGE_TABLES` (both `scripts/tests/test_architecture.py` and `web/__tests__/lib/architecture.test.ts`) would catch this class automatically — but it would also flag several other non-paginated `league_prices` readers in `web/lib/` and `scripts/`, so it's better done as a dedicated audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)